### PR TITLE
feat: add debug spans for decoding requests

### DIFF
--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -57,6 +57,7 @@ struct StreamingInner {
     decompress_buf: BytesMut,
     encoding: Option<CompressionEncoding>,
     max_message_size: Option<usize>,
+    span: tracing::Span,
 }
 
 impl<T> Unpin for Streaming<T> {}
@@ -65,10 +66,34 @@ impl<T> Unpin for Streaming<T> {}
 enum State {
     ReadHeader,
     ReadBody {
+        span: tracing::Span,
         compression: Option<CompressionEncoding>,
         len: usize,
     },
     Error(Option<Status>),
+}
+
+impl State {
+    fn read_body(compression: Option<CompressionEncoding>, len: usize) -> Self {
+        let span = tracing::debug_span!(
+            "read_body",
+            body.compression = compression.map(|c| c.as_str()).unwrap_or("none"),
+            body.bytes.compressed = compression.is_some().then_some(len),
+            body.bytes.uncompressed = compression.is_none().then_some(len),
+        );
+        Self::ReadBody {
+            span,
+            compression,
+            len,
+        }
+    }
+
+    fn span(&self) -> Option<&tracing::Span> {
+        match self {
+            Self::ReadBody { span, .. } => Some(span),
+            Self::ReadHeader | Self::Error(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -163,6 +188,7 @@ impl<T> Streaming<T> {
                 decompress_buf: BytesMut::new(),
                 encoding,
                 max_message_size,
+                span: tracing::debug_span!("streaming"),
             },
         }
     }
@@ -173,6 +199,7 @@ impl StreamingInner {
         &mut self,
         buffer_settings: BufferSettings,
     ) -> Result<Option<DecodeBuf<'_>>, Status> {
+        let _guard = self.span.enter();
         if let State::ReadHeader = self.state {
             if self.buf.remaining() < HEADER_SIZE {
                 return Ok(None);
@@ -222,13 +249,17 @@ impl StreamingInner {
 
             self.buf.reserve(len);
 
-            self.state = State::ReadBody {
-                compression: compression_encoding,
-                len,
-            }
+            self.state = State::read_body(compression_encoding, len);
         }
 
-        if let State::ReadBody { len, compression } = self.state {
+        if let State::ReadBody {
+            len,
+            span,
+            compression,
+        } = &self.state
+        {
+            let (len, compression) = (*len, *compression);
+            let _guard = span.enter();
             // if we haven't read enough of the message then return and keep
             // reading
             if self.buf.remaining() < len || self.buf.len() < len {
@@ -266,6 +297,7 @@ impl StreamingInner {
                     return Err(Status::internal(message));
                 }
                 let decompressed_len = self.decompress_buf.len();
+                span.record("body.bytes.uncompressed", decompressed_len);
                 DecodeBuf::new(&mut self.decompress_buf, decompressed_len)
             } else {
                 DecodeBuf::new(&mut self.buf, len)
@@ -279,6 +311,7 @@ impl StreamingInner {
 
     // Returns Some(()) if data was found or None if the loop in `poll_next` should break
     fn poll_frame(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<()>, Status>> {
+        let _guard = self.state.span().unwrap_or(&self.span).enter();
         let frame = match ready!(Pin::new(self.body.get_mut()).poll_frame(cx)) {
             Some(Ok(frame)) => frame,
             Some(Err(status)) => {
@@ -286,6 +319,7 @@ impl StreamingInner {
                     return Poll::Ready(Ok(None));
                 }
 
+                drop(_guard);
                 let _ = std::mem::replace(&mut self.state, State::Error(Some(status.clone())));
                 debug!("decoder inner stream error: {:?}", status);
                 return Poll::Ready(Err(status));


### PR DESCRIPTION
Closes: #1759

## Motivation

Adds optional debug spans into the decoder state. At the same time, it resolves a size regression in the `State` struct, which got much larger because of the inclusion of the `Status` in the error. The size change overall is from 16 bytes (v0.11.0) to 176 (master) to 56 (this PR).

## Solution

Adds tracing spans at the debug level for tracking decoding of streaming messages. This should have negligible overhead when debug spans are not enabled, and provide some more context when they are enabled.

Boxes the `Status` in the `Error` variant to avoid size bloat for the common case.

If desired, this functionality could be gated behind a feature, but I start off by avoiding the extra complexity of adding conditional compilation code.