### PR TITLE
chore(grpc): Apply workspace lint config to grpc crate

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -38,6 +38,9 @@ prost = "0.14"
 default = ["dns"]
 dns = ["dep:hickory-resolver"]
 
+[lints]
+workspace = true
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
     "tonic::*",


### PR DESCRIPTION
Applies workspace lint config to grpc crate.