### PR TITLE
feat(codec): Add lz4 support

### DIFF
--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -15,7 +15,7 @@ pin-project = "1.0"
 prost = "0.14"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = "0.1"
-tonic = {path = "../../tonic", features = ["gzip", "deflate", "zstd"]}
+tonic = {path = "../../tonic", features = ["gzip", "deflate", "zstd", "lz4"]}
 tower = "0.5"
 tower-http = {version = "0.6", features = ["map-response-body", "map-request-body"]}
 

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -7,6 +7,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -36,6 +37,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -89,6 +91,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);

--- a/tests/compression/src/client_stream.rs
+++ b/tests/compression/src/client_stream.rs
@@ -7,6 +7,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -33,6 +34,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -80,6 +82,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -131,6 +134,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -161,6 +165,7 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
@@ -174,6 +179,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -215,6 +221,7 @@ async fn compressing_response_from_client_stream(encoding: CompressionEncoding) 
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);

--- a/tests/compression/src/compressing_request.rs
+++ b/tests/compression/src/compressing_request.rs
@@ -7,6 +7,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -33,6 +34,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -84,6 +86,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -93,12 +96,13 @@ async fn client_enabled_server_enabled_multi_encoding(encoding: CompressionEncod
     let svc = test_server::TestServer::new(Svc::default())
         .accept_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Deflate);
+        .accept_compressed(CompressionEncoding::Deflate)
+        .accept_compressed(CompressionEncoding::Lz4);
 
     let request_bytes_counter = Arc::new(AtomicUsize::new(0));
 
     fn assert_right_encoding<B>(req: http::Request<B>) -> http::Request<B> {
-        let supported_encodings = ["gzip", "zstd", "deflate"];
+        let supported_encodings = ["gzip", "zstd", "deflate", "lz4"];
         let req_encoding = req.headers().get("grpc-encoding").unwrap();
         assert!(supported_encodings.iter().any(|e| e == req_encoding));
 
@@ -146,6 +150,7 @@ parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -177,6 +182,7 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
@@ -194,6 +200,7 @@ parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]

--- a/tests/compression/src/compressing_response.rs
+++ b/tests/compression/src/compressing_response.rs
@@ -6,6 +6,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -38,6 +39,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(
@@ -88,6 +90,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
 
@@ -104,6 +107,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -180,7 +184,8 @@ async fn client_enabled_server_disabled_multi_encoding() {
     let mut client = test_client::TestClient::new(mock_io_channel(client).await)
         .accept_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Deflate);
+        .accept_compressed(CompressionEncoding::Deflate)
+        .accept_compressed(CompressionEncoding::Lz4);
 
     let res = client.compress_output_unary(()).await.unwrap();
 
@@ -195,6 +200,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -266,6 +272,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -310,6 +317,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -353,6 +361,7 @@ async fn disabling_compression_on_single_response(encoding: CompressionEncoding)
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
@@ -366,6 +375,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -411,6 +421,7 @@ async fn disabling_compression_on_response_but_keeping_compression_on_stream(
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
@@ -437,6 +448,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -482,6 +494,7 @@ async fn disabling_compression_on_response_from_client_stream(encoding: Compress
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);

--- a/tests/compression/src/server_stream.rs
+++ b/tests/compression/src/server_stream.rs
@@ -7,6 +7,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -47,6 +48,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
@@ -72,6 +74,7 @@ util::parametrized_tests! {
     client_disabled_server_enabled,
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -124,6 +127,7 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]

--- a/tests/compression/src/util.rs
+++ b/tests/compression/src/util.rs
@@ -162,6 +162,7 @@ impl AssertRightEncoding {
             CompressionEncoding::Gzip => "gzip",
             CompressionEncoding::Zstd => "zstd",
             CompressionEncoding::Deflate => "deflate",
+            CompressionEncoding::Lz4 => "lz4",
             _ => panic!("unexpected encoding {:?}", self.encoding),
         };
         assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -24,6 +24,7 @@ codegen = ["dep:async-trait"]
 gzip = ["dep:flate2"]
 deflate = ["dep:flate2"]
 zstd = ["dep:zstd"]
+lz4 = ["dep:lz4_flex"]
 default = ["router", "transport", "codegen", "prost"]
 prost = ["dep:prost"]
 _tls-any = ["dep:tokio-rustls", "dep:tokio", "tokio?/rt", "tokio?/macros"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
@@ -91,6 +92,7 @@ webpki-roots = { version = "1", optional = true }
 # compression
 flate2 = {version = "1.0", optional = true}
 zstd = { version = "0.13.0", optional = true }
+lz4_flex = { version = "0.11.3", default-features = false, features = ["std", "frame"], optional = true }
 
 # channel
 hyper-timeout = {version = "0.5", optional = true}

--- a/tonic/src/lib.rs
+++ b/tonic/src/lib.rs
@@ -39,6 +39,9 @@
 //!   Not enabled by default.
 //! - `zstd`: Enables compressing requests, responses, and streams. Depends on [`zstd`].
 //!   Not enabled by default.
+//! - `lz4`: Enables LZ4 compression for requests, responses, and streams. Uses [`lz4_flex`]
+//!   with unsafe optimizations for maximum performance. Depends on [`lz4_flex`].
+//!   Not enabled by default.
 //!
 //! # Structure
 //!
@@ -86,6 +89,7 @@
 //! [`webpki-roots`]: https://docs.rs/webpki-roots
 //! [`flate2`]: https://docs.rs/flate2
 //! [`zstd`]: https://docs.rs/zstd
+//! [`lz4_flex`]: https://docs.rs/lz4_flex
 
 #![recursion_limit = "256"]
 #![doc(


### PR DESCRIPTION
## Motivation

Add support for LZ4 compression with lz4_flex. 

Closes #2312 

## Solution

- Added the `lz4_flex` crate as an optional dependency behind a new `lz4` feature flag.
- Updated header parsing, encoding negotiation, and metadata handling to recognize and advertise LZ4.
