### PR TITLE
add support for parsing X509 certs from DER

### DIFF
--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -28,7 +28,9 @@ impl Certificate {
     pub fn from_der(der: impl AsRef<[u8]>) -> Self {
         let der = der.as_ref();
         let pem = der2pem(der);
-        Self { pem: pem.into_bytes() }
+        Self {
+            pem: pem.into_bytes(),
+        }
     }
 
     /// Get a immutable reference to underlying certificate
@@ -70,7 +72,7 @@ impl Identity {
     }
 
     /// Parse a DER encoded certificate and private key.
-    /// 
+    ///
     /// The provided cert must contain exactly one DER encoded certificate.
     pub fn from_der(cert: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> Self {
         let cert = Certificate::from_der(cert);
@@ -85,4 +87,3 @@ fn der2pem(der: &[u8]) -> String {
     let pem = crate::util::base64::STANDARD_NO_PAD.encode(der);
     format!("{RFC7468_HEADER}\n{pem}\n{RFC7468_FOOTER}\n")
 }
-

--- a/tonic/src/transport/tls.rs
+++ b/tonic/src/transport/tls.rs
@@ -1,3 +1,5 @@
+use base64::Engine as _;
+
 /// Represents a X509 certificate.
 #[derive(Debug, Clone)]
 pub struct Certificate {
@@ -18,6 +20,15 @@ impl Certificate {
     pub fn from_pem(pem: impl AsRef<[u8]>) -> Self {
         let pem = pem.as_ref().into();
         Self { pem }
+    }
+
+    /// Parse a DER encoded X509 Certificate.
+    ///
+    /// The provided DER should include exactly one DER encoded certificate.
+    pub fn from_der(der: impl AsRef<[u8]>) -> Self {
+        let der = der.as_ref();
+        let pem = der2pem(der);
+        Self { pem: pem.into_bytes() }
     }
 
     /// Get a immutable reference to underlying certificate
@@ -57,4 +68,21 @@ impl Identity {
         let key = key.as_ref().into();
         Self { cert, key }
     }
+
+    /// Parse a DER encoded certificate and private key.
+    /// 
+    /// The provided cert must contain exactly one DER encoded certificate.
+    pub fn from_der(cert: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> Self {
+        let cert = Certificate::from_der(cert);
+        let key = key.as_ref().into();
+        Self { cert, key }
+    }
 }
+
+fn der2pem(der: &[u8]) -> String {
+    const RFC7468_HEADER: &str = "-----BEGIN CERTIFICATE-----";
+    const RFC7468_FOOTER: &str = "-----END CERTIFICATE-----";
+    let pem = crate::util::base64::STANDARD_NO_PAD.encode(der);
+    format!("{RFC7468_HEADER}\n{pem}\n{RFC7468_FOOTER}\n")
+}
+


### PR DESCRIPTION
tls: allow creation of Certificate and Identity from DER

Adds `Certificate::from_der` and `Identity::from_der` constructors to allow creation of Certificate and Identity from DER-encoded data.

Fixes: #2343
Fixes: #2344

## Motivation

PEM and DER are both very common encoding formats for X509 certificates.

## Solution

Convert DER certificates to PEM to prevent changes to the rest of the crate. The conversion is done following RFC 7468, which basically means converting the DER in base64 and adding the proper header and footer.
