### PR TITLE
tonic: add compression threshold for message encoding

### DIFF
--- a/tests/compression/src/server_stream.rs
+++ b/tests/compression/src/server_stream.rs
@@ -58,7 +58,8 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         .await
         .expect("stream empty")
         .expect("item was error");
-    assert!(response_bytes_counter.load(SeqCst) < UNCOMPRESSED_MIN_BODY_SIZE);
+    // The first message shouldn't get compressed because it's below the threshold
+    assert!(response_bytes_counter.load(SeqCst) > UNCOMPRESSED_MIN_BODY_SIZE - 100);
 
     stream
         .next()

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -293,6 +293,7 @@ pub(crate) fn compress(
 }
 
 /// Decompress `len` bytes from `compressed_buf` into `out_buf`.
+#[cfg(any(feature = "gzip", feature = "deflate", feature = "zstd"))]
 #[allow(unused_variables, unreachable_code)]
 pub(crate) fn decompress(
     settings: CompressionSettings,

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -213,10 +213,7 @@ impl StreamingInner {
                 self.decompress_buf.clear();
 
                 if let Err(err) = decompress(
-                    CompressionSettings {
-                        encoding,
-                        buffer_growth_interval: buffer_settings.buffer_size,
-                    },
+                    CompressionSettings::new(encoding, buffer_settings.buffer_size),
                     &mut self.buf,
                     &mut self.decompress_buf,
                     len,


### PR DESCRIPTION
### Add configurable compression thresholds for Tonic
This PR adds runtime-configurable compression thresholds to improve performance for large message compression scenarios.
**Changes:**
- Compression threshold: Messages smaller than `TONIC_COMPRESSION_THRESHOLD` (default 1024 bytes) are sent uncompressed
- Spawn-blocking threshold: Messages larger than `TONIC_SPAWN_BLOCKING_THRESHOLD` can be compressed on a blocking thread pool to avoid blocking the async runtime

**Configuration:**
Set via environment variables:
- TONIC_COMPRESSION_THRESHOLD=4096        # Skip compression for messages < 4KB
- TONIC_SPAWN_BLOCKING_THRESHOLD=65536    # Use blocking threads for messages >= 64KB

**Benefits:**
- Avoids unnecessary compression overhead for small messages
- Prevents large message compression from blocking async tasks
- Maintains backward compatibility (defaults preserve existing behavior)

**Implementation notes:**
- Added conditional compilation to support builds with/without tokio and compression features
- Compression task polling happens immediately after spawning for optimal waker registration
- Tests updated to verify threshold behavior
- Fixes performance issues with large gRPC message compression blocking the tokio runtime.