### PR TITLE
tonic-web: proxy any kind of service

### DIFF
--- a/tests/web/Cargo.toml
+++ b/tests/web/Cargo.toml
@@ -18,6 +18,8 @@ tonic-prost = { path = "../../tonic-prost" }
 
 [dev-dependencies]
 tonic-web = { path = "../../tonic-web" }
+tower-layer = "0.3"
+tower-service = "0.3"
 
 [build-dependencies]
 tonic-prost-build = { path = "../../tonic-prost-build" }

--- a/tests/web/tests/grpc_web.rs
+++ b/tests/web/tests/grpc_web.rs
@@ -67,6 +67,29 @@ async fn binary_request() {
 }
 
 #[tokio::test]
+async fn binary_request_reverse_proxy() {
+    let server_url = spawn_reverse_proxy().await;
+    let client = Client::builder(TokioExecutor::new()).build_http();
+
+    let req = build_request(server_url, "grpc-web", "grpc-web");
+    let res = client.request(req).await.unwrap();
+    let content_type = res.headers().get(header::CONTENT_TYPE).unwrap().clone();
+    let content_type = content_type.to_str().unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(content_type, "application/grpc-web+proto");
+
+    let (message, trailers) = decode_body(res.into_body(), content_type).await;
+    let expected = Output {
+        id: 1,
+        desc: "one".to_owned(),
+    };
+
+    assert_eq!(message, expected);
+    assert_eq!(&trailers[..], b"grpc-status:0\r\n");
+}
+
+#[tokio::test]
 async fn text_request() {
     let server_url = spawn().await;
     let client = Client::builder(TokioExecutor::new()).build_http();
@@ -106,6 +129,77 @@ async fn spawn() -> String {
     }));
 
     url
+}
+
+/// Spawn two servers, one serving the gRPC API and another acting as a grpc-web proxy
+async fn spawn_reverse_proxy() -> String {
+    use hyper_util::client::legacy::Client;
+    use hyper_util::rt::TokioIo;
+    use tower_layer::Layer;
+    use tower_service::Service;
+
+    // Set up gRPC service
+    let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+    let listener = TcpListener::bind(addr).await.expect("listener");
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let listener_stream = TcpListenerStream::new(listener);
+
+    drop(tokio::spawn(async move {
+        Server::builder()
+            .add_service(TestServer::new(Svc))
+            .serve_with_incoming(listener_stream)
+            .await
+            .unwrap()
+    }));
+
+    // Set up proxy to the above service that applies tonic-web
+    let addr2 = SocketAddr::from(([127, 0, 0, 1], 0));
+    let http_client = Client::builder(TokioExecutor::new())
+        .http2_only(true)
+        .build_http();
+    let listener2 = TcpListener::bind(addr2).await.expect("listener");
+    let url2 = format!("http://{}", listener2.local_addr().unwrap());
+
+    let backend_url = url.clone();
+
+    drop(tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener2.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let client = http_client.clone();
+            let backend = backend_url.clone();
+
+            tokio::spawn(async move {
+                let svc = GrpcWebLayer::new().layer(client.clone());
+                let hyper_svc = hyper::service::service_fn(move |mut req: Request<Incoming>| {
+                    let mut svc = svc.clone();
+                    let backend = backend.clone();
+                    async move {
+                        // Rewrite URI to point to backend
+                        let path = req
+                            .uri()
+                            .path_and_query()
+                            .map(|pq| pq.as_str())
+                            .unwrap_or("/");
+                        let new_uri = format!("{backend}{path}").parse().unwrap();
+                        *req.uri_mut() = new_uri;
+
+                        let req = req.map(Body::new);
+                        svc.call(req).await
+                    }
+                });
+
+                if let Err(err) = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, hyper_svc)
+                    .await
+                {
+                    eprintln!("Error serving connection: {err:?}");
+                }
+            });
+        }
+    }));
+
+    url2
 }
 
 fn encode_body() -> Bytes {

--- a/tonic-web/src/call.rs
+++ b/tonic-web/src/call.rs
@@ -22,7 +22,6 @@
  *
  */
 
-use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
@@ -33,6 +32,8 @@ use http_body::{Body, Frame, SizeHint};
 use pin_project::pin_project;
 use tokio_stream::Stream;
 use tonic::Status;
+
+use crate::BoxError;
 
 use self::content_types::*;
 
@@ -182,11 +183,11 @@ impl<B> GrpcWebCall<B> {
     }
 }
 
-impl<B> GrpcWebCall<B>
+impl<B, D> GrpcWebCall<B>
 where
-    B: Body,
-    B::Data: Buf,
-    B::Error: fmt::Display,
+    B: Body<Data = D>,
+    B::Error: Into<BoxError> + Send,
+    D: Buf,
 {
     // Poll body for data, decoding (e.g. via Base64 if necessary) and returning frames
     // to the caller. If the caller is a client, it should look for trailers before
@@ -271,10 +272,11 @@ where
     }
 }
 
-impl<B> Body for GrpcWebCall<B>
+impl<B, D> Body for GrpcWebCall<B>
 where
-    B: Body,
-    B::Error: fmt::Display,
+    B: Body<Data = D>,
+    B::Error: Into<BoxError> + Send,
+    D: Buf,
 {
     type Data = Bytes;
     type Error = Status;
@@ -360,10 +362,11 @@ where
     }
 }
 
-impl<B> Stream for GrpcWebCall<B>
+impl<B, D> Stream for GrpcWebCall<B>
 where
-    B: Body,
-    B::Error: fmt::Display,
+    B: Body<Data = D>,
+    B::Error: Into<BoxError> + Send,
+    D: Buf,
 {
     type Item = Result<Frame<Bytes>, Status>;
 
@@ -396,7 +399,8 @@ impl Encoding {
     }
 }
 
-fn internal_error(e: impl std::fmt::Display) -> Status {
+fn internal_error(e: impl Into<BoxError> + Send) -> Status {
+    let e = e.into();
     Status::internal(format!("tonic-web: {e}"))
 }
 

--- a/tonic-web/src/layer.rs
+++ b/tonic-web/src/layer.rs
@@ -22,25 +22,52 @@
  *
  */
 
-use super::GrpcWebService;
+use std::error::Error;
+
+use super::{BoxError, GrpcWebService};
+use tonic::body::Body;
 
 use tower_layer::Layer;
+use tower_service::Service;
 
 /// Layer implementing the grpc-web protocol.
-#[derive(Debug, Default, Clone)]
-pub struct GrpcWebLayer {
-    _priv: (),
+#[derive(Debug)]
+pub struct GrpcWebLayer<ResBody = Body> {
+    _markers: std::marker::PhantomData<fn() -> ResBody>,
 }
 
-impl GrpcWebLayer {
-    /// Create a new grpc-web layer.
-    pub fn new() -> GrpcWebLayer {
-        Self::default()
+impl<ResBody> Clone for GrpcWebLayer<ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            _markers: std::marker::PhantomData,
+        }
     }
 }
 
-impl<S> Layer<S> for GrpcWebLayer {
-    type Service = GrpcWebService<S>;
+impl<ResBody> GrpcWebLayer<ResBody> {
+    /// Create a new grpc-web layer.
+    pub fn new() -> Self {
+        Self {
+            _markers: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<ResBody> Default for GrpcWebLayer<ResBody> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S, ResBody> Layer<S> for GrpcWebLayer<ResBody>
+where
+    S: Service<http::Request<Body>, Response = http::Response<ResBody>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError> + Send,
+    ResBody: http_body::Body<Data = bytes::Bytes> + Send + 'static,
+    ResBody::Error: Error + Send + Sync + 'static,
+{
+    type Service = GrpcWebService<S, ResBody>;
 
     fn layer(&self, inner: S) -> Self::Service {
         GrpcWebService::new(inner)

--- a/tonic-web/src/lib.rs
+++ b/tonic-web/src/lib.rs
@@ -104,7 +104,8 @@ mod client;
 mod layer;
 mod service;
 
-type BoxError = Box<dyn std::error::Error + Send + Sync>;
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 pub(crate) mod util {
     pub(crate) mod base64 {

--- a/tonic-web/src/service.rs
+++ b/tonic-web/src/service.rs
@@ -23,24 +23,39 @@
  */
 
 use core::fmt;
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
+use bytes::Buf;
 use http::{HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version, header};
+use http_body::Body as HttpBody;
 use pin_project::pin_project;
+use tonic::body::Body;
 use tonic::metadata::GRPC_CONTENT_TYPE;
-use tonic::{body::Body, server::NamedService};
+use tonic::server::NamedService;
 use tower_service::Service;
 use tracing::{debug, trace};
 
+use crate::BoxError;
 use crate::call::content_types::is_grpc_web;
 use crate::call::{Encoding, GrpcWebCall};
 
 /// Service implementing the grpc-web protocol.
-#[derive(Debug, Clone)]
-pub struct GrpcWebService<S> {
+#[derive(Debug)]
+pub struct GrpcWebService<S, ResBody = Body> {
     inner: S,
+    _markers: std::marker::PhantomData<fn() -> ResBody>,
+}
+
+impl<S: Clone, ResBody> Clone for GrpcWebService<S, ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _markers: std::marker::PhantomData,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -61,19 +76,24 @@ enum RequestKind<'a> {
     Other(http::Version),
 }
 
-impl<S> GrpcWebService<S> {
+impl<S, ResBody> GrpcWebService<S, ResBody> {
     pub(crate) fn new(inner: S) -> Self {
-        GrpcWebService { inner }
+        GrpcWebService {
+            inner,
+            _markers: std::marker::PhantomData,
+        }
     }
 }
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for GrpcWebService<S>
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for GrpcWebService<S, ResBody>
 where
-    S: Service<Request<Body>, Response = Response<ResBody>>,
-    ReqBody: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    ReqBody::Error: Into<crate::BoxError> + fmt::Display,
-    ResBody: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    ResBody::Error: Into<crate::BoxError> + fmt::Display,
+    S: Service<Request<Body>, Response = Response<ResBody>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError> + Send,
+    ReqBody: HttpBody<Data = bytes::Bytes> + Send + 'static,
+    ReqBody::Error: Into<BoxError> + Send,
+    ResBody: HttpBody<Data = bytes::Bytes> + Send + 'static,
+    ResBody::Error: Error + Send + Sync + 'static,
 {
     type Response = Response<Body>;
     type Error = S::Error;
@@ -103,7 +123,9 @@ where
 
                 ResponseFuture {
                     case: Case::GrpcWeb {
-                        future: self.inner.call(coerce_request(req, encoding)),
+                        future: self
+                            .inner
+                            .call(coerce_request(req, encoding).map(Body::new)),
                         accept,
                     },
                 }
@@ -178,11 +200,12 @@ impl<F> Case<F> {
     }
 }
 
-impl<F, B, E> Future for ResponseFuture<F>
+impl<F, E, ResBody> Future for ResponseFuture<F>
 where
-    F: Future<Output = Result<Response<B>, E>>,
-    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::BoxError> + fmt::Display,
+    F: Future<Output = Result<Response<ResBody>, E>> + Send + 'static,
+    ResBody: HttpBody<Data = bytes::Bytes> + Send + 'static,
+    ResBody::Error: Error + Send + Sync,
+    E: Into<BoxError> + Send,
 {
     type Output = Result<Response<Body>, E>;
 
@@ -193,7 +216,7 @@ where
             CaseProj::GrpcWeb { future, accept } => {
                 let res = ready!(future.poll(cx))?;
 
-                Poll::Ready(Ok(coerce_response(res, *accept)))
+                Poll::Ready(Ok(coerce_response(res, *accept).map(Body::new)))
             }
             CaseProj::Other { future } => future.poll(cx).map_ok(|res| res.map(Body::new)),
             CaseProj::ImmediateResponse { res } => {
@@ -204,7 +227,7 @@ where
     }
 }
 
-impl<S: NamedService> NamedService for GrpcWebService<S> {
+impl<S: NamedService, ResBody> NamedService for GrpcWebService<S, ResBody> {
     const NAME: &'static str = S::NAME;
 }
 
@@ -231,11 +254,10 @@ impl<'a> RequestKind<'a> {
 // Mutating request headers to conform to a gRPC request is not really
 // necessary for us at this point. We could remove most of these except
 // maybe for inserting `header::TE`, which tonic should check?
-fn coerce_request<B>(mut req: Request<B>, encoding: Encoding) -> Request<Body>
-where
-    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::BoxError> + fmt::Display,
-{
+fn coerce_request<ReqBody: HttpBody + Send + 'static>(
+    mut req: Request<ReqBody>,
+    encoding: Encoding,
+) -> Request<GrpcWebCall<ReqBody>> {
     req.headers_mut().remove(header::CONTENT_LENGTH);
 
     req.headers_mut()
@@ -249,17 +271,18 @@ where
         HeaderValue::from_static("identity,deflate,gzip"),
     );
 
-    req.map(|b| Body::new(GrpcWebCall::request(b, encoding)))
+    req.map(|b| GrpcWebCall::request(b, encoding))
 }
 
-fn coerce_response<B>(res: Response<B>, encoding: Encoding) -> Response<Body>
+fn coerce_response<ResBody, D>(
+    res: Response<ResBody>,
+    encoding: Encoding,
+) -> Response<GrpcWebCall<ResBody>>
 where
-    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
-    B::Error: Into<crate::BoxError> + fmt::Display,
+    ResBody: HttpBody<Data = D> + Send + 'static,
+    D: Buf,
 {
-    let mut res = res
-        .map(|b| GrpcWebCall::response(b, encoding))
-        .map(Body::new);
+    let mut res = res.map(|b| GrpcWebCall::response(b, encoding));
 
     res.headers_mut().insert(
         header::CONTENT_TYPE,
@@ -276,6 +299,7 @@ mod tests {
     use http::header::{
         ACCESS_CONTROL_REQUEST_HEADERS, ACCESS_CONTROL_REQUEST_METHOD, CONTENT_TYPE, ORIGIN,
     };
+    use tonic::body::Body;
     use tower_layer::Layer as _;
 
     type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
@@ -304,6 +328,9 @@ mod tests {
     fn enable<S>(service: S) -> tower_http::cors::Cors<GrpcWebService<S>>
     where
         S: Service<http::Request<Body>, Response = http::Response<Body>>,
+        S: Send + 'static,
+        S::Future: Send + 'static,
+        S::Error: Into<BoxError> + Send,
     {
         tower_layer::Stack::new(
             crate::GrpcWebLayer::new(),


### PR DESCRIPTION
This allows applying the GrpcWebLayer to any kind of Service, not just ones that tonic generates. 

## Motivation

This makes it possible to use tonic-web as a grpc-web proxy to a gRPC server implemented in another language for example, I'm using it to proxy a Python gRPC service over grpc-web.

## Solution

We have to be generic over the ResBody of the wrapped service and then box that into a `tonic::body::Body`. I've made the default values of the body type parameters `tonic::body::Body` so I believe this change is backwards compatible.

This is a redo of https://github.com/hyperium/tonic/pull/1366