### PR TITLE
fix(prost-build): Map wrapper types to primitives

### DIFF
--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -196,9 +196,17 @@ impl tonic_build::Method for TonicBuildMethod {
         {
             // For well-known types, map to absolute paths that will work with super::
             match self.prost_method.input_type.as_str() {
-                ".google.protobuf.Empty" => quote!(()),
                 ".google.protobuf.Any" => quote!(::prost_types::Any),
+                ".google.protobuf.BoolValue" => quote!(bool),
+                ".google.protobuf.BytesValue" => quote!(::prost::bytes::Bytes),
+                ".google.protobuf.DoubleValue" => quote!(f64),
+                ".google.protobuf.Empty" => quote!(()),
+                ".google.protobuf.FloatValue" => quote!(f32),
+                ".google.protobuf.Int32Value" => quote!(i32),
+                ".google.protobuf.Int64Value" => quote!(i64),
                 ".google.protobuf.StringValue" => quote!(::prost::alloc::string::String),
+                ".google.protobuf.UInt32Value" => quote!(u32),
+                ".google.protobuf.UInt64Value" => quote!(u64),
                 _ => {
                     // For other google types, assume they're in prost_types
                     let type_name = self
@@ -238,9 +246,17 @@ impl tonic_build::Method for TonicBuildMethod {
             if is_google_type(&self.prost_method.output_type) && !compile_well_known_types {
                 // For well-known types, map to absolute paths that will work with super::
                 match self.prost_method.output_type.as_str() {
-                    ".google.protobuf.Empty" => quote!(()),
                     ".google.protobuf.Any" => quote!(::prost_types::Any),
+                    ".google.protobuf.BoolValue" => quote!(bool),
+                    ".google.protobuf.BytesValue" => quote!(::prost::bytes::Bytes),
+                    ".google.protobuf.DoubleValue" => quote!(f64),
+                    ".google.protobuf.Empty" => quote!(()),
+                    ".google.protobuf.FloatValue" => quote!(f32),
+                    ".google.protobuf.Int32Value" => quote!(i32),
+                    ".google.protobuf.Int64Value" => quote!(i64),
                     ".google.protobuf.StringValue" => quote!(::prost::alloc::string::String),
+                    ".google.protobuf.UInt32Value" => quote!(u32),
+                    ".google.protobuf.UInt64Value" => quote!(u64),
                     _ => {
                         // For other google types, assume they're in prost_types
                         let type_name = self

--- a/tonic-prost-build/src/tests.rs
+++ b/tonic-prost-build/src/tests.rs
@@ -93,6 +93,37 @@ fn test_request_response_name_google_types_compiled() {
 }
 
 #[test]
+fn test_request_response_name_wrapper_types() {
+    // Test Google well-known types map to primitive types when compile_well_known_types is false.
+    let test_cases = vec![
+        (".google.protobuf.BoolValue", quote!(bool)),
+        (".google.protobuf.Int32Value", quote!(i32)),
+        (".google.protobuf.Int64Value", quote!(i64)),
+        (".google.protobuf.UInt32Value", quote!(u32)),
+        (".google.protobuf.UInt64Value", quote!(u64)),
+        (".google.protobuf.FloatValue", quote!(f32)),
+        (".google.protobuf.DoubleValue", quote!(f64)),
+        (".google.protobuf.BytesValue", quote!(::prost::bytes::Bytes)),
+    ];
+
+    for (type_name, expected) in test_cases {
+        let method = create_test_method(type_name.to_string(), type_name.to_string());
+        let (request, response) = method.request_response_name("super", false);
+
+        assert_eq!(
+            request.to_string(),
+            expected.to_string(),
+            "Failed for input type: {type_name}"
+        );
+        assert_eq!(
+            response.to_string(),
+            expected.to_string(),
+            "Failed for output type: {type_name}"
+        );
+    }
+}
+
+#[test]
 fn test_request_response_name_non_path_types() {
     // Test types in NON_PATH_TYPE_ALLOWLIST
     let method = create_test_method("()".to_string(), "()".to_string());


### PR DESCRIPTION
## Motivation

This commit address the issue raised in #2388, where well-known types such as `google.protobuf.BoolValue` would appear as `super::bool` rather than the correct primitives.

The issue was reproduced [here](https://github.com/jen20/tonic-repros/blob/main/tonic-2388/proto/helloworld.proto#L9), and produces the following output when `cargo build` is run (only the first occurrence is shown):

```
error[E0412]: cannot find type `bool` in module `super`
  --> /Users/James/Code/personal/tonic-repros/tonic-2388/target/debug/build/tonic-2388-685c45971c3ed332/out/helloworld.rs:95:53
   |
95 |             request: impl tonic::IntoRequest<super::bool>,
   |                                                     ^^^^ not found in `super`
   |
help: consider importing this builtin type
   |
11 +     use std::primitive::bool;
   |
help: if you import `bool`, refer to it directly
   |
95 -             request: impl tonic::IntoRequest<super::bool>,
95 +             request: impl tonic::IntoRequest<bool>,
   |
```

## Solution

We address this by adding new cases to the existing enum for the various wrapper types contained in `google/protobuf/wrappers.proto`, when not compiling well-known types as proto structs directly. This is broadly in line with the patch suggested in the issue by @zhaohaiyun9, but is a little less broad and adds test coverage.
