### PR TITLE
feat: Introduce gRPC over Windows named pipes for platform parity

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
       with:
+        rust-version: stable
         components: rustfmt
     - run: cargo fmt --all --check
 
@@ -158,6 +159,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
       with:
+        rust-version: stable
         components: clippy
     - name: Restore protoc and plugin from cache
       id: cache-plugin
@@ -193,6 +195,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - uses: Swatinem/rust-cache@v2
     - run: cargo run --package codegen
     - run: git diff --exit-code
@@ -254,6 +258,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - uses: taiki-e/install-action@cargo-hack
     - name: Restore protoc and plugin from cache
       id: cache-plugin
@@ -294,6 +300,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - name: Resolve MSRV aware dependencies
       run: cargo update
       env:
@@ -330,6 +338,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - name: Restore protoc and plugin from cache
       id: cache-plugin
       uses: actions/cache@v4
@@ -374,6 +384,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - uses: taiki-e/install-action@cargo-hack
     - uses: Swatinem/rust-cache@v2
     - run: cargo hack --no-private test --doc --all-features
@@ -388,6 +400,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: hecrj/setup-rust-action@v2
+      with:
+        rust-version: stable
     - name: Restore protoc and plugin from cache
       id: cache-plugin
       uses: actions/cache@v4

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -251,6 +251,13 @@ path = "src/codec_buffers/server.rs"
 name = "codec-buffers-client"
 path = "src/codec_buffers/client.rs"
 
+[[bin]]
+name = "win-named-pipe-client"
+path = "src/win_named_pipe/client.rs"
+
+[[bin]]
+name = "win-named-pipe-server"
+path = "src/win_named_pipe/server.rs"
 
 [features]
 gcp = ["dep:prost-types", "tonic/tls-ring"]

--- a/examples/src/health/server.rs
+++ b/examples/src/health/server.rs
@@ -35,7 +35,7 @@ async fn twiddle_service_status(reporter: HealthReporter) {
         iter += 1;
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        if iter % 2 == 0 {
+        if iter.is_multiple_of(2) {
             reporter.set_serving::<GreeterServer<MyGreeter>>().await;
         } else {
             reporter.set_not_serving::<GreeterServer<MyGreeter>>().await;

--- a/examples/src/win_named_pipe/client.rs
+++ b/examples/src/win_named_pipe/client.rs
@@ -1,0 +1,28 @@
+#![cfg_attr(not(windows), allow(unused_imports))]
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+use hello_world::{greeter_client::GreeterClient, HelloRequest};
+
+#[cfg(windows)]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Named pipe URI follows [RFC-3986](https://datatracker.ietf.org/doc/html/rfc3986)
+    // which is aligned with [the gRPC naming convention]
+
+     let pipe_name = r"\\.\pipe\tonic\helloworld";
+    let mut client = GreeterClient::connect(pipe_name).await?;
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+    let response = client.say_hello(request).await?;
+    println!("RESPONSE={response:?}");
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    unimplemented!("Named pipes are only supported on Windows");
+}

--- a/examples/src/win_named_pipe/client.rs
+++ b/examples/src/win_named_pipe/client.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Named pipe URI follows [RFC-3986](https://datatracker.ietf.org/doc/html/rfc3986)
     // which is aligned with [the gRPC naming convention]
 
-     let pipe_name = r"\\.\pipe\tonic\helloworld";
+    let pipe_name = r"\\.\pipe\tonic\helloworld";
     let mut client = GreeterClient::connect(pipe_name).await?;
     let request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),

--- a/examples/src/win_named_pipe/server.rs
+++ b/examples/src/win_named_pipe/server.rs
@@ -1,0 +1,146 @@
+#![cfg_attr(not(windows), allow(unused_imports))]
+
+#[cfg(windows)]
+use tonic::transport::server::NamedPipeIncoming;
+#[cfg(windows)]
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::NamedPipeServer;
+#[cfg(windows)]
+use tokio_stream::StreamExt;
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::pin::Pin;
+#[cfg(windows)]
+use std::task::{Context, Poll};
+use tonic::{transport::Server, Request, Response, Status};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+use hello_world::{
+    greeter_server::{Greeter, GreeterServer},
+    HelloReply, HelloRequest,
+};
+
+#[derive(Default)]
+pub struct MyGreeter;
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        #[cfg(windows)]
+        {
+            let conn_info = request
+                .extensions()
+                .get::<PipeConnectInfo>()
+                .expect("connect info missing");
+            println!("Got a request {request:?} with info {conn_info:?}");
+        }
+        let reply = hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[cfg(windows)]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pipe_name = r"\\.\pipe\tonic\helloworld".to_string();
+    let greeter = MyGreeter::default();
+
+    println!("gRPC server listening on {}", pipe_name);
+    let mut next_id: u64 = 1;
+    let incoming = NamedPipeIncoming::new(&pipe_name).map(move |item| {
+        item.map(|server| {
+            let id = next_id;
+            next_id += 1;
+            PipeConn::new(server, PipeConnectInfo::new(&pipe_name, id))
+        })
+    });
+    Server::builder()
+        .add_service(GreeterServer::new(greeter))
+        .serve_with_incoming(incoming)
+        .await?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    unimplemented!("Named pipes are only supported on Windows");
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone)]
+struct PipeConnectInfo {
+    pipe_name: String,
+    connection_id: u64,
+}
+
+#[cfg(windows)]
+impl PipeConnectInfo {
+    fn new(pipe_name: &str, connection_id: u64) -> Self {
+        Self {
+            pipe_name: pipe_name.to_string(),
+            connection_id,
+        }
+    }
+}
+
+#[cfg(windows)]
+struct PipeConn {
+    inner: NamedPipeServer,
+    info: PipeConnectInfo,
+}
+
+#[cfg(windows)]
+impl PipeConn {
+    fn new(inner: NamedPipeServer, info: PipeConnectInfo) -> Self {
+        Self { inner, info }
+    }
+}
+
+#[cfg(windows)]
+impl tonic::transport::server::Connected for PipeConn {
+    type ConnectInfo = PipeConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.info.clone()
+    }
+}
+
+#[cfg(windows)]
+impl AsyncRead for PipeConn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+#[cfg(windows)]
+impl AsyncWrite for PipeConn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}

--- a/examples/src/win_named_pipe/server.rs
+++ b/examples/src/win_named_pipe/server.rs
@@ -1,7 +1,11 @@
 #![cfg_attr(not(windows), allow(unused_imports))]
 
 #[cfg(windows)]
-use tonic::transport::server::NamedPipeIncoming;
+use std::io;
+#[cfg(windows)]
+use std::pin::Pin;
+#[cfg(windows)]
+use std::task::{Context, Poll};
 #[cfg(windows)]
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 #[cfg(windows)]
@@ -9,11 +13,7 @@ use tokio::net::windows::named_pipe::NamedPipeServer;
 #[cfg(windows)]
 use tokio_stream::StreamExt;
 #[cfg(windows)]
-use std::io;
-#[cfg(windows)]
-use std::pin::Pin;
-#[cfg(windows)]
-use std::task::{Context, Poll};
+use tonic::transport::server::NamedPipeIncoming;
 use tonic::{transport::Server, Request, Response, Status};
 
 pub mod hello_world {

--- a/examples/src/win_named_pipe/server.rs
+++ b/examples/src/win_named_pipe/server.rs
@@ -40,7 +40,10 @@ impl Greeter for MyGreeter {
                 .extensions()
                 .get::<PipeConnectInfo>()
                 .expect("connect info missing");
-            println!("Got a request {request:?} with info {conn_info:?}");
+            println!(
+                "Got a request {request:?} on pipe {} (connection {})",
+                conn_info.pipe_name, conn_info.connection_id
+            );
         }
         let reply = hello_world::HelloReply {
             message: format!("Hello {}!", request.into_inner().name),

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -132,7 +132,7 @@ impl RoundRobinPolicy {
             .child_manager
             .resolver_update(resolver_update, None, channel_controller);
         self.update_picker(channel_controller);
-        return Err(err.into());
+        Err(err.into())
     }
 }
 

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -1,7 +1,7 @@
+use super::named_pipe_connector::NamedPipeConnector;
 #[cfg(feature = "_tls-any")]
 use super::service::TlsConnector;
 use super::service::{self, Executor, SharedExec};
-use super::named_pipe_connector::NamedPipeConnector;
 use super::uds_connector::UdsConnector;
 use super::Channel;
 #[cfg(feature = "_tls-any")]
@@ -556,11 +556,9 @@ impl Endpoint {
             EndpointType::Uds(uds_filepath) => {
                 Channel::connect(self.uds_connector(uds_filepath.as_str()), self.clone()).await
             }
-            EndpointType::NamedPipe(pipe_path) => Channel::connect(
-                self.named_pipe_connector(pipe_path.as_str()),
-                self.clone(),
-            )
-            .await,
+            EndpointType::NamedPipe(pipe_path) => {
+                Channel::connect(self.named_pipe_connector(pipe_path.as_str()), self.clone()).await
+            }
         }
     }
 

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -4,6 +4,7 @@ mod endpoint;
 pub(crate) mod service;
 #[cfg(feature = "_tls-any")]
 mod tls;
+mod named_pipe_connector;
 mod uds_connector;
 
 pub use self::service::Change;

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -1,10 +1,10 @@
 //! Client implementation and builder.
 
 mod endpoint;
+mod named_pipe_connector;
 pub(crate) mod service;
 #[cfg(feature = "_tls-any")]
 mod tls;
-mod named_pipe_connector;
 mod uds_connector;
 
 pub use self::service::Change;

--- a/tonic/src/transport/channel/named_pipe_connector.rs
+++ b/tonic/src/transport/channel/named_pipe_connector.rs
@@ -1,0 +1,79 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use http::Uri;
+use hyper_util::rt::TokioIo;
+use tower::Service;
+
+use crate::status::ConnectError;
+
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+
+#[cfg(windows)]
+async fn connect_named_pipe(pipe_path: String) -> Result<NamedPipeClient, ConnectError> {
+    ClientOptions::new()
+        .open(pipe_path)
+        .map_err(|err| ConnectError(From::from(err)))
+}
+
+// Dummy type that will allow us to compile and match trait bounds
+// but is never used.
+#[cfg(not(windows))]
+#[allow(dead_code)]
+type NamedPipeClient = tokio::io::DuplexStream;
+
+#[cfg(not(windows))]
+async fn connect_named_pipe(_pipe_path: String) -> Result<NamedPipeClient, ConnectError> {
+    Err(ConnectError(
+        "named pipe connections are only supported on windows".into(),
+    ))
+}
+
+pub(crate) struct NamedPipeConnector {
+    pipe_path: String,
+}
+
+impl NamedPipeConnector {
+    pub(crate) fn new(pipe_path: &str) -> Self {
+        NamedPipeConnector {
+            pipe_path: pipe_path.to_string(),
+        }
+    }
+}
+
+impl Service<Uri> for NamedPipeConnector {
+    type Response = TokioIo<NamedPipeClient>;
+    type Error = ConnectError;
+    type Future = NamedPipeConnecting;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _: Uri) -> Self::Future {
+        let pipe_path = self.pipe_path.clone();
+        let fut = async move {
+            let stream = connect_named_pipe(pipe_path).await?;
+            Ok(TokioIo::new(stream))
+        };
+        NamedPipeConnecting {
+            inner: Box::pin(fut),
+        }
+    }
+}
+
+type ConnectResult = Result<TokioIo<NamedPipeClient>, ConnectError>;
+
+pub(crate) struct NamedPipeConnecting {
+    inner: Pin<Box<dyn Future<Output = ConnectResult> + Send>>,
+}
+
+impl Future for NamedPipeConnecting {
+    type Output = ConnectResult;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().inner.as_mut().poll(cx)
+    }
+}

--- a/tonic/src/transport/error.rs
+++ b/tonic/src/transport/error.rs
@@ -20,7 +20,7 @@ pub(crate) enum Kind {
     #[cfg(feature = "channel")]
     InvalidUserAgent,
     #[cfg(all(feature = "_tls-any", feature = "channel"))]
-    InvalidTlsConfigForUds,
+    InvalidTlsConfigForNonTcp,
 }
 
 impl Error {
@@ -57,7 +57,9 @@ impl Error {
             #[cfg(feature = "channel")]
             Kind::InvalidUserAgent => "user agent is not a valid header value",
             #[cfg(all(feature = "_tls-any", feature = "channel"))]
-            Kind::InvalidTlsConfigForUds => "cannot apply TLS config for unix domain socket",
+            Kind::InvalidTlsConfigForNonTcp => {
+                "cannot apply TLS config for unix domain socket or named pipe"
+            }
         }
     }
 }

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use tokio_rustls::rustls::pki_types::CertificateDer;
 #[cfg(feature = "tls-connect-info")]
 use tokio_rustls::server::TlsStream;
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::NamedPipeServer;
 
 /// Trait that connected IO resources implement and use to produce info about the connection.
 ///
@@ -97,6 +99,13 @@ impl Connected for TcpStream {
 }
 
 impl Connected for tokio::io::DuplexStream {
+    type ConnectInfo = ();
+
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+#[cfg(windows)]
+impl Connected for NamedPipeServer {
     type ConnectInfo = ();
 
     fn connect_info(&self) -> Self::ConnectInfo {}

--- a/tonic/src/transport/server/conn.rs
+++ b/tonic/src/transport/server/conn.rs
@@ -3,12 +3,12 @@ use tokio::net::TcpStream;
 
 #[cfg(feature = "tls-connect-info")]
 use std::sync::Arc;
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::NamedPipeServer;
 #[cfg(feature = "tls-connect-info")]
 use tokio_rustls::rustls::pki_types::CertificateDer;
 #[cfg(feature = "tls-connect-info")]
 use tokio_rustls::server::TlsStream;
-#[cfg(windows)]
-use tokio::net::windows::named_pipe::NamedPipeServer;
 
 /// Trait that connected IO resources implement and use to produce info about the connection.
 ///

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -4,13 +4,13 @@ mod conn;
 mod display_error_stack;
 mod incoming;
 mod io_stream;
+#[cfg(windows)]
+mod named_pipe;
 mod service;
 #[cfg(feature = "_tls-any")]
 mod tls;
 #[cfg(unix)]
 mod unix;
-#[cfg(windows)]
-mod named_pipe;
 
 use tokio_stream::StreamExt as _;
 use tracing::{debug, trace};
@@ -36,10 +36,10 @@ pub use conn::TlsConnectInfo;
 #[cfg(feature = "_tls-any")]
 use self::service::TlsAcceptor;
 
-#[cfg(unix)]
-pub use unix::UdsConnectInfo;
 #[cfg(windows)]
 pub use named_pipe::NamedPipeIncoming;
+#[cfg(unix)]
+pub use unix::UdsConnectInfo;
 
 pub use incoming::TcpIncoming;
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -9,6 +9,8 @@ mod service;
 mod tls;
 #[cfg(unix)]
 mod unix;
+#[cfg(windows)]
+mod named_pipe;
 
 use tokio_stream::StreamExt as _;
 use tracing::{debug, trace};
@@ -36,6 +38,8 @@ use self::service::TlsAcceptor;
 
 #[cfg(unix)]
 pub use unix::UdsConnectInfo;
+#[cfg(windows)]
+pub use named_pipe::NamedPipeIncoming;
 
 pub use incoming::TcpIncoming;
 

--- a/tonic/src/transport/server/named_pipe.rs
+++ b/tonic/src/transport/server/named_pipe.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{fmt, fmt::Debug};
 
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 use tokio_stream::Stream;
@@ -12,6 +13,15 @@ use tokio_stream::Stream;
 pub struct NamedPipeIncoming {
     pipe_name: String,
     connecting: Option<Pin<Box<dyn Future<Output = io::Result<NamedPipeServer>> + Send>>>,
+}
+
+impl Debug for NamedPipeIncoming {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NamedPipeIncoming")
+            .field("pipe_name", &self.pipe_name)
+            .field("connecting", &self.connecting.is_some())
+            .finish()
+    }
 }
 
 impl NamedPipeIncoming {

--- a/tonic/src/transport/server/named_pipe.rs
+++ b/tonic/src/transport/server/named_pipe.rs
@@ -1,0 +1,81 @@
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use tokio_stream::Stream;
+
+/// An incoming stream of Windows named pipe connections.
+///
+/// Use this with `Server::serve_with_incoming`.
+pub struct NamedPipeIncoming {
+    pipe_name: String,
+    connecting: Option<Pin<Box<dyn Future<Output = io::Result<NamedPipeServer>> + Send>>>,
+}
+
+impl NamedPipeIncoming {
+    /// Create a new named pipe incoming stream.
+    ///
+    /// The `pipe_name` may be a full pipe path like `\\.\pipe\my-pipe` or a
+    /// short name like `my-pipe`.
+    pub fn new(pipe_name: impl AsRef<str>) -> Self {
+        Self {
+            pipe_name: normalize_pipe_path(pipe_name.as_ref()),
+            connecting: None,
+        }
+    }
+}
+
+impl Stream for NamedPipeIncoming {
+    type Item = io::Result<NamedPipeServer>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.connecting.is_none() {
+            let pipe_name = self.pipe_name.clone();
+            let fut = async move {
+                let server = ServerOptions::new().create(pipe_name)?;
+                server.connect().await?;
+                Ok(server)
+            };
+            self.connecting = Some(Box::pin(fut));
+        }
+
+        let ready = {
+            let fut = self.connecting.as_mut().expect("future just initialized");
+            fut.as_mut().poll(cx)
+        };
+
+        match ready {
+            Poll::Ready(result) => {
+                self.connecting = None;
+                Poll::Ready(Some(result))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn normalize_pipe_path(raw: &str) -> String {
+    if raw.starts_with(r"\\.\pipe\") {
+        return raw.to_string();
+    }
+
+    let mut s = raw.trim().trim_start_matches('/');
+    if let Some(stripped) = s.strip_prefix(r"\\.\pipe\") {
+        s = stripped;
+    }
+    if let Some(stripped) = s.strip_prefix("./") {
+        s = stripped;
+    }
+    if let Some(stripped) = s.strip_prefix("pipe/") {
+        s = stripped;
+    }
+    if let Some(stripped) = s.strip_prefix("/pipe/") {
+        s = stripped;
+    }
+    let s = s.trim_start_matches('/');
+    let mut path = String::from(r"\\.\pipe\");
+    path.push_str(&s.replace('/', "\\"));
+    path
+}


### PR DESCRIPTION
### Motivation

Tonic is widely adopted across many open-source projects for gRPC, and AGNTCY/slim also relies on Tonic for its gRPC implementation. Initially, SLIM supported gRPC communication only over TCP sockets. More recently, we added support for gRPC over Unix Domain Sockets (UDS) on Unix-based systems.

However, on Windows platforms, Tonic currently does not support gRPC over named pipes, which limits parity with Unix-based transports. This PR introduces an implementation to enable gRPC over Windows named pipes in Tonic.

Once this functionality is merged into Tonic, AGNTCY/slim will be able to add native support for gRPC over Windows named pipes as well, bringing feature parity across platforms and improving the Windows developer experience.