### PR TITLE
Do not warn if setsockopt fails due to ECONNRESET

### DIFF
--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -1,4 +1,5 @@
 use std::{
+    io::ErrorKind,
     net::{SocketAddr, TcpListener as StdTcpListener},
     pin::Pin,
     task::{Context, Poll},
@@ -148,14 +149,18 @@ fn set_accepted_socket_options(
 ) {
     if let Some(nodelay) = nodelay {
         if let Err(e) = stream.set_nodelay(nodelay) {
-            warn!("error trying to set TCP_NODELAY: {e}");
+            if e.kind() != ErrorKind::ConnectionReset {
+                warn!("error trying to set TCP_NODELAY: {e}");
+            }
         }
     }
 
     if let Some(keepalive) = keepalive {
         let sock_ref = socket2::SockRef::from(&stream);
         if let Err(e) = sock_ref.set_tcp_keepalive(keepalive) {
-            warn!("error trying to set TCP_KEEPALIVE: {e}");
+            if e.kind() != ErrorKind::ConnectionReset {
+                warn!("error trying to set TCP_KEEPALIVE: {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

In case a client disconnects early, setting socket options (nodelay/keepalive) fails and causes warnings. These warnings have little value, given that modifying options on an already broken connection is basically a noop.

This can happen in case of bad connectivity/congestion, but also by design like in haproxy, which "uses RST to close the health check as it free’s[sic!] resources on haproxy and the backend server immediately".

Due to the above we encounter quite some log spam:

    WARN tonic::transport::server::incoming:error trying to set TCP_NODELAY: Connection reset by peer (os error 54)
    WARN tonic::transport::server::incoming:error trying to set TCP_KEEPALIVE: Connection reset by peer (os error 54)
    ...

(This is on FreeBSD, hence "os error 54" (ECONNRESET)).

## Solution

Do not warn in case setting socket options fails due to the connection being reset by the client.
