### PR TITLE
tonic: connector support for balance channels

### DIFF
--- a/tonic/src/transport/channel/service/discover.rs
+++ b/tonic/src/transport/channel/service/discover.rs
@@ -1,13 +1,18 @@
-use super::super::{Connection, Endpoint};
+use super::super::{service::Connector, Connection, Endpoint};
 
+use http::Uri;
+use hyper::rt;
+use hyper_util::client::legacy::connect::{dns::GaiResolver, HttpConnector};
 use std::{
     hash::Hash,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 use tokio::sync::mpsc::Receiver;
 use tokio_stream::Stream;
 use tower::discover::Change as TowerChange;
+use tower_service::Service;
 
 /// A change in the service set.
 #[derive(Debug, Clone)]
@@ -18,26 +23,64 @@ pub enum Change<K, V> {
     Remove(K),
 }
 
-pub(crate) struct DynamicServiceStream<K: Hash + Eq + Clone> {
-    changes: Receiver<Change<K, Endpoint>>,
-}
-
-impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
-    pub(crate) fn new(changes: Receiver<Change<K, Endpoint>>) -> Self {
-        Self { changes }
+/// Convert an `Endpoint` into a `(Connector<HttpConnector<GaiResolver>>, Endpoint)`.
+///
+/// This is needed so we can support both a stream of just `Endpoints` and a stream of `(Connector, Endpoint)` pairs.
+/// We default to http connector when just `Endpoint` is provided.
+impl From<Endpoint> for (Connector<HttpConnector<GaiResolver>>, Endpoint) {
+    fn from(endpoint: Endpoint) -> Self {
+        (endpoint.http_connector(), endpoint)
     }
 }
 
-impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
+pub(crate) struct DynamicServiceStream<K: Hash + Eq + Clone, V, C>
+where
+    (C, Endpoint): From<V>,
+    C: Service<Uri> + Send + 'static,
+    C::Error: Into<crate::BoxError> + Send,
+    C::Future: Send,
+    C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+{
+    changes: Receiver<Change<K, V>>,
+    _marker: PhantomData<C>,
+}
+
+impl<K: Hash + Eq + Clone, V, C> DynamicServiceStream<K, V, C>
+where
+    (C, Endpoint): From<V>,
+    C: Service<Uri> + Send + 'static,
+    C::Error: Into<crate::BoxError> + Send,
+    C::Future: Send,
+    C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+{
+    pub(crate) fn new(changes: Receiver<Change<K, V>>) -> Self {
+        Self {
+            changes,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<K: Hash + Eq + Clone, V, C> Stream for DynamicServiceStream<K, V, C>
+where
+    (C, Endpoint): From<V>,
+    C: Service<Uri> + Send + 'static,
+    C::Error: Into<crate::BoxError> + Send,
+    C::Future: Send,
+    C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+{
     type Item = Result<TowerChange<K, Connection>, crate::BoxError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.changes).poll_recv(cx) {
             Poll::Pending | Poll::Ready(None) => Poll::Pending,
             Poll::Ready(Some(change)) => match change {
-                Change::Insert(k, endpoint) => {
-                    let connection = Connection::lazy(endpoint.http_connector(), endpoint);
-                    Poll::Ready(Some(Ok(TowerChange::Insert(k, connection))))
+                Change::Insert(k, connection) => {
+                    let (connector, endpoint) = connection.into();
+                    Poll::Ready(Some(Ok(TowerChange::Insert(
+                        k,
+                        Connection::lazy(connector, endpoint),
+                    ))))
                 }
                 Change::Remove(k) => Poll::Ready(Some(Ok(TowerChange::Remove(k)))),
             },
@@ -45,4 +88,12 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
     }
 }
 
-impl<K: Hash + Eq + Clone> Unpin for DynamicServiceStream<K> {}
+impl<K: Hash + Eq + Clone, V, C> Unpin for DynamicServiceStream<K, V, C>
+where
+    (C, Endpoint): From<V>,
+    C: Service<Uri> + Send + 'static,
+    C::Error: Into<crate::BoxError> + Send,
+    C::Future: Send,
+    C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+{
+}


### PR DESCRIPTION
This commit adds the ability for connectors to be
used with balance channels. This commit only adds
new functions but does not change any existing
public functions, so it should be fully backwards
compatible. This commit also modifies the
internal implementation details to support
connectors.

Fixes: #1476

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Previously balance channels only supported http connectors. However, it is very important to be able
to use https and other connectors with the balance channels. This pr adds the extensibility to use any
connector type with balance channels.

## Solution

The pr contains two main parts. Firstly it adds generic parameters `DynamicServiceStream` to work with both just `Endpoint` objects as it did previously and now `(Connector, Endpoint)` pairs so that the connectors can be configured. Secondly the pr adds new functions for `Channel` for creating balancing channels with specific connectors
