### PR TITLE
feat: add lz4 and snappy compression

### DIFF
--- a/tests/compression/Cargo.toml
+++ b/tests/compression/Cargo.toml
@@ -15,7 +15,7 @@ pin-project = "1.0"
 prost = "0.14"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
 tokio-stream = "0.1"
-tonic = {path = "../../tonic", features = ["gzip", "deflate", "zstd"]}
+tonic = {path = "../../tonic", features = ["gzip", "deflate", "zstd", "lz4", "snappy"]}
 tonic-prost = {path = "../../tonic-prost"}
 tower = "0.5"
 tower-http = {version = "0.6", features = ["map-response-body", "map-request-body"]}

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -7,6 +7,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -36,6 +38,8 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
+                CompressionEncoding::Snappy => "snappy",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -89,7 +93,9 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 

--- a/tests/compression/src/bidirectional_stream.rs
+++ b/tests/compression/src/bidirectional_stream.rs
@@ -95,7 +95,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 

--- a/tests/compression/src/client_stream.rs
+++ b/tests/compression/src/client_stream.rs
@@ -7,6 +7,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -33,6 +35,8 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
+                CompressionEncoding::Snappy => "snappy",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -80,6 +84,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -131,6 +137,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -161,7 +169,9 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(
         status.message(),
@@ -174,6 +184,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -215,7 +227,9 @@ async fn compressing_response_from_client_stream(encoding: CompressionEncoding) 
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);

--- a/tests/compression/src/client_stream.rs
+++ b/tests/compression/src/client_stream.rs
@@ -171,7 +171,7 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
         status.message(),
@@ -229,7 +229,7 @@ async fn compressing_response_from_client_stream(encoding: CompressionEncoding) 
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);

--- a/tests/compression/src/compressing_request.rs
+++ b/tests/compression/src/compressing_request.rs
@@ -7,6 +7,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -33,6 +35,8 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
+                CompressionEncoding::Snappy => "snappy",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);
@@ -84,6 +88,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -93,12 +99,14 @@ async fn client_enabled_server_enabled_multi_encoding(encoding: CompressionEncod
     let svc = test_server::TestServer::new(Svc::default())
         .accept_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Deflate);
+        .accept_compressed(CompressionEncoding::Deflate)
+        .accept_compressed(CompressionEncoding::Lz4)
+        .accept_compressed(CompressionEncoding::Snappy);
 
     let request_bytes_counter = Arc::new(AtomicUsize::new(0));
 
     fn assert_right_encoding<B>(req: http::Request<B>) -> http::Request<B> {
-        let supported_encodings = ["gzip", "zstd", "deflate"];
+        let supported_encodings = ["gzip", "zstd", "deflate", "lz4", "snappy"];
         let req_encoding = req.headers().get("grpc-encoding").unwrap();
         assert!(supported_encodings.iter().any(|e| e == req_encoding));
 
@@ -146,6 +154,8 @@ parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -177,7 +187,9 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(
         status.message(),
@@ -194,6 +206,8 @@ parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -240,6 +254,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[cfg(test)]

--- a/tests/compression/src/compressing_request.rs
+++ b/tests/compression/src/compressing_request.rs
@@ -189,7 +189,7 @@ async fn client_enabled_server_disabled(encoding: CompressionEncoding) {
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(
         status.message(),

--- a/tests/compression/src/compressing_response.rs
+++ b/tests/compression/src/compressing_response.rs
@@ -94,7 +94,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
 
     for _ in 0..3 {
@@ -371,7 +371,7 @@ async fn disabling_compression_on_single_response(encoding: CompressionEncoding)
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -433,7 +433,7 @@ async fn disabling_compression_on_response_but_keeping_compression_on_stream(
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -508,7 +508,7 @@ async fn disabling_compression_on_response_from_client_stream(encoding: Compress
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);

--- a/tests/compression/src/compressing_response.rs
+++ b/tests/compression/src/compressing_response.rs
@@ -6,6 +6,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    snappy: CompressionEncoding::Snappy,
+    lz4: CompressionEncoding::Lz4,
 }
 
 #[allow(dead_code)]
@@ -38,6 +40,8 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
                 CompressionEncoding::Gzip => "gzip",
                 CompressionEncoding::Zstd => "zstd",
                 CompressionEncoding::Deflate => "deflate",
+                CompressionEncoding::Lz4 => "lz4",
+                CompressionEncoding::Snappy => "snappy",
                 _ => panic!("unexpected encoding {:?}", self.encoding),
             };
             assert_eq!(
@@ -88,7 +92,9 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
 
     for _ in 0..3 {
@@ -104,6 +110,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -180,7 +188,9 @@ async fn client_enabled_server_disabled_multi_encoding() {
     let mut client = test_client::TestClient::new(mock_io_channel(client).await)
         .accept_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Deflate);
+        .accept_compressed(CompressionEncoding::Deflate)
+        .accept_compressed(CompressionEncoding::Lz4)
+        .accept_compressed(CompressionEncoding::Snappy);
 
     let res = client.compress_output_unary(()).await.unwrap();
 
@@ -195,6 +205,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -266,6 +278,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -310,6 +324,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -353,7 +369,9 @@ async fn disabling_compression_on_single_response(encoding: CompressionEncoding)
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -366,6 +384,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -411,7 +431,9 @@ async fn disabling_compression_on_response_but_keeping_compression_on_stream(
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -437,6 +459,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -482,7 +506,9 @@ async fn disabling_compression_on_response_from_client_stream(encoding: Compress
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
     let bytes_sent = response_bytes_counter.load(SeqCst);
@@ -494,6 +520,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[cfg(test)]
@@ -536,6 +564,8 @@ async fn limit_decoded_message_size(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
         _ => panic!("unexpected encoding {encoding:?}"),
     };
 

--- a/tests/compression/src/server_stream.rs
+++ b/tests/compression/src/server_stream.rs
@@ -1,6 +1,6 @@
 use super::*;
-use tonic::Streaming;
 use tonic::codec::CompressionEncoding;
+use tonic::Streaming;
 
 util::parametrized_tests! {
     client_enabled_server_enabled,
@@ -51,7 +51,7 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Deflate => "deflate",
         CompressionEncoding::Lz4 => "lz4",
         CompressionEncoding::Snappy => "snappy",
-        _ => panic!("unexpected encoding {:?}", encoding),
+        _ => panic!("unexpected encoding {encoding:?}"),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 

--- a/tests/compression/src/server_stream.rs
+++ b/tests/compression/src/server_stream.rs
@@ -1,12 +1,14 @@
 use super::*;
-use tonic::codec::CompressionEncoding;
 use tonic::Streaming;
+use tonic::codec::CompressionEncoding;
 
 util::parametrized_tests! {
     client_enabled_server_enabled,
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -47,7 +49,9 @@ async fn client_enabled_server_enabled(encoding: CompressionEncoding) {
         CompressionEncoding::Gzip => "gzip",
         CompressionEncoding::Zstd => "zstd",
         CompressionEncoding::Deflate => "deflate",
-        _ => panic!("unexpected encoding {encoding:?}"),
+        CompressionEncoding::Lz4 => "lz4",
+        CompressionEncoding::Snappy => "snappy",
+        _ => panic!("unexpected encoding {:?}", encoding),
     };
     assert_eq!(res.metadata().get("grpc-encoding").unwrap(), expected);
 
@@ -72,6 +76,9 @@ util::parametrized_tests! {
     client_disabled_server_enabled,
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
+    deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]
@@ -124,6 +131,8 @@ util::parametrized_tests! {
     zstd: CompressionEncoding::Zstd,
     gzip: CompressionEncoding::Gzip,
     deflate: CompressionEncoding::Deflate,
+    lz4: CompressionEncoding::Lz4,
+    snappy: CompressionEncoding::Snappy,
 }
 
 #[allow(dead_code)]

--- a/tests/compression/src/util.rs
+++ b/tests/compression/src/util.rs
@@ -7,15 +7,15 @@ use pin_project::pin_project;
 use std::{
     pin::Pin,
     sync::{
-        atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
+        atomic::{AtomicUsize, Ordering::SeqCst},
     },
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::body::Body;
 use tonic::codec::CompressionEncoding;
-use tonic::transport::{server::Connected, Channel};
+use tonic::transport::{Channel, server::Connected};
 use tower_http::map_request_body::MapRequestBodyLayer;
 
 macro_rules! parametrized_tests {
@@ -162,6 +162,8 @@ impl AssertRightEncoding {
             CompressionEncoding::Gzip => "gzip",
             CompressionEncoding::Zstd => "zstd",
             CompressionEncoding::Deflate => "deflate",
+            CompressionEncoding::Lz4 => "lz4",
+            CompressionEncoding::Snappy => "snappy",
             _ => panic!("unexpected encoding {:?}", self.encoding),
         };
         assert_eq!(req.headers().get("grpc-encoding").unwrap(), expected);

--- a/tests/compression/src/util.rs
+++ b/tests/compression/src/util.rs
@@ -7,15 +7,15 @@ use pin_project::pin_project;
 use std::{
     pin::Pin,
     sync::{
-        Arc,
         atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
     },
-    task::{Context, Poll, ready},
+    task::{ready, Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::body::Body;
 use tonic::codec::CompressionEncoding;
-use tonic::transport::{Channel, server::Connected};
+use tonic::transport::{server::Connected, Channel};
 use tower_http::map_request_body::MapRequestBodyLayer;
 
 macro_rules! parametrized_tests {

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -24,6 +24,8 @@ codegen = ["dep:async-trait"]
 gzip = ["dep:flate2"]
 deflate = ["dep:flate2"]
 zstd = ["dep:zstd"]
+lz4 = ["dep:lz4_flex"]
+snappy = ["dep:snap"]
 default = ["router", "transport", "codegen"]
 _tls-any = ["dep:tokio", "tokio?/rt", "tokio?/macros", "tls-connect-info"] # Internal. Please choose one of `tls-ring` or `tls-aws-lc`
 tls-ring = ["_tls-any", "tokio-rustls/ring"]
@@ -89,6 +91,9 @@ webpki-roots = { version = "1", optional = true }
 # compression
 flate2 = {version = "1.0", optional = true}
 zstd = { version = "0.13.0", optional = true }
+lz4_flex = { version = "0.12.0", optional = true }
+snap = { version = "1", optional = true }
+
 
 # channel
 hyper-timeout = {version = "0.5", optional = true}

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -404,7 +404,13 @@ impl GrpcConfig {
             .headers_mut()
             .insert(CONTENT_TYPE, GRPC_CONTENT_TYPE);
 
-        #[cfg(any(feature = "gzip", feature = "deflate", feature = "zstd"))]
+        #[cfg(any(
+            feature = "gzip",
+            feature = "deflate",
+            feature = "zstd",
+            feature = "lz4",
+            feature = "snappy"
+        ))]
         if let Some(encoding) = self.send_compression_encodings {
             request.headers_mut().insert(
                 crate::codec::compression::ENCODING_HEADER,

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -287,10 +287,10 @@ pub(crate) fn compress(
         #[cfg(feature = "lz4")]
         CompressionEncoding::Lz4 => {
             {
+                println!("Compressing with lz4");
                 let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
                 lz4_encoder.write_all(&decompressed_buf[0..len])?;
-                lz4_encoder.finish()?;
-                out_writer.flush()?;
+                lz4_encoder.auto_finish();
                 // lz4_encoder is dropped here, flushing the final frame
             }
         }

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -247,8 +247,6 @@ pub(crate) fn compress(
     let capacity = ((len / buffer_growth_interval) + 1) * buffer_growth_interval;
     out_buf.reserve(capacity);
 
-    println!("Compressing with encoding: {:?}", settings.encoding);
-
     #[cfg(any(
         feature = "gzip",
         feature = "deflate",
@@ -332,8 +330,6 @@ pub(crate) fn decompress(
         feature = "snappy"
     ))]
     let mut out_writer = out_buf.writer();
-
-    println!("Decompressing with encoding: {:?}", settings.encoding);
 
     match settings.encoding {
         #[cfg(feature = "gzip")]

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -1,4 +1,4 @@
-use crate::{Status, metadata::MetadataValue};
+use crate::{metadata::MetadataValue, Status};
 use bytes::{Buf, BufMut, BytesMut};
 #[cfg(feature = "gzip")]
 use flate2::read::{GzDecoder, GzEncoder};

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -247,6 +247,8 @@ pub(crate) fn compress(
     let capacity = ((len / buffer_growth_interval) + 1) * buffer_growth_interval;
     out_buf.reserve(capacity);
 
+    let before_compress_len = out_buf.len();
+
     #[cfg(any(
         feature = "gzip",
         feature = "deflate",
@@ -304,6 +306,14 @@ pub(crate) fn compress(
     }
 
     decompressed_buf.advance(len);
+
+    let after_compress_len = out_buf.len();
+
+    println!(
+        "Compressed {len} bytes into {} bytes with {:?}",
+        after_compress_len - before_compress_len,
+        settings.encoding
+    );
 
     Ok(())
 }

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -288,13 +288,15 @@ pub(crate) fn compress(
         CompressionEncoding::Lz4 => {
             let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
             lz4_encoder.write_all(&decompressed_buf[0..len])?;
-            lz4_encoder.flush()?;
+            lz4_encoder.finish()?;
         }
         #[cfg(feature = "snappy")]
         CompressionEncoding::Snappy => {
-            let mut snappy_encoder = snap::write::FrameEncoder::new(&mut out_writer);
-            snappy_encoder.write_all(&decompressed_buf[0..len])?;
-            snappy_encoder.flush()?;
+            {
+                let mut snappy_encoder = snap::write::FrameEncoder::new(&mut out_writer);
+                snappy_encoder.write_all(&decompressed_buf[0..len])?;
+                // snappy_encoder is dropped here, flushing the final frame
+            }
         }
     }
 

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -287,7 +287,6 @@ pub(crate) fn compress(
         #[cfg(feature = "lz4")]
         CompressionEncoding::Lz4 => {
             {
-                println!("Compressing with lz4");
                 let lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
                 let mut auto_finish_encoder = lz4_encoder.auto_finish();
                 auto_finish_encoder.write_all(&decompressed_buf[0..len])?;

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -247,6 +247,8 @@ pub(crate) fn compress(
     let capacity = ((len / buffer_growth_interval) + 1) * buffer_growth_interval;
     out_buf.reserve(capacity);
 
+    println!("Compressing with encoding: {:?}", settings.encoding);
+
     #[cfg(any(
         feature = "gzip",
         feature = "deflate",
@@ -330,6 +332,8 @@ pub(crate) fn decompress(
         feature = "snappy"
     ))]
     let mut out_writer = out_buf.writer();
+
+    println!("Decompressing with encoding: {:?}", settings.encoding);
 
     match settings.encoding {
         #[cfg(feature = "gzip")]

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -247,8 +247,6 @@ pub(crate) fn compress(
     let capacity = ((len / buffer_growth_interval) + 1) * buffer_growth_interval;
     out_buf.reserve(capacity);
 
-    let before_compress_len = out_buf.len();
-
     #[cfg(any(
         feature = "gzip",
         feature = "deflate",
@@ -306,14 +304,6 @@ pub(crate) fn compress(
     }
 
     decompressed_buf.advance(len);
-
-    let after_compress_len = out_buf.len();
-
-    println!(
-        "Compressed {len} bytes into {} bytes with {:?}",
-        after_compress_len - before_compress_len,
-        settings.encoding
-    );
 
     Ok(())
 }
@@ -520,7 +510,7 @@ mod tests {
         feature = "snappy",
         feature = "lz4"
     ))]
-    fn convert_gzip_and_zstd_into_header_value() {
+    fn convert_gzip_zstd_snappy_and_lz4_into_header_value() {
         let encodings = EnabledCompressionEncodings {
             inner: [
                 Some(CompressionEncoding::Gzip),

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -288,9 +288,9 @@ pub(crate) fn compress(
         CompressionEncoding::Lz4 => {
             {
                 println!("Compressing with lz4");
-                let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
-                lz4_encoder.write_all(&decompressed_buf[0..len])?;
-                lz4_encoder.auto_finish();
+                let lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
+                let mut auto_finish_encoder = lz4_encoder.auto_finish();
+                auto_finish_encoder.write_all(&decompressed_buf[0..len])?;
                 // lz4_encoder is dropped here, flushing the final frame
             }
         }

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -288,11 +288,13 @@ pub(crate) fn compress(
         CompressionEncoding::Lz4 => {
             let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
             lz4_encoder.write_all(&decompressed_buf[0..len])?;
+            lz4_encoder.flush()?;
         }
         #[cfg(feature = "snappy")]
         CompressionEncoding::Snappy => {
             let mut snappy_encoder = snap::write::FrameEncoder::new(&mut out_writer);
             snappy_encoder.write_all(&decompressed_buf[0..len])?;
+            snappy_encoder.flush()?;
         }
     }
 

--- a/tonic/src/codec/compression.rs
+++ b/tonic/src/codec/compression.rs
@@ -286,9 +286,13 @@ pub(crate) fn compress(
         }
         #[cfg(feature = "lz4")]
         CompressionEncoding::Lz4 => {
-            let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
-            lz4_encoder.write_all(&decompressed_buf[0..len])?;
-            lz4_encoder.finish()?;
+            {
+                let mut lz4_encoder = lz4_flex::frame::FrameEncoder::new(&mut out_writer);
+                lz4_encoder.write_all(&decompressed_buf[0..len])?;
+                lz4_encoder.finish()?;
+                out_writer.flush()?;
+                // lz4_encoder is dropped here, flushing the final frame
+            }
         }
         #[cfg(feature = "snappy")]
         CompressionEncoding::Snappy => {

--- a/tonic/src/response.rs
+++ b/tonic/src/response.rs
@@ -120,7 +120,13 @@ impl<T> Response<T> {
     /// **Note**: This only has effect on responses to unary requests and responses to client to
     /// server streams. Response streams (server to client stream and bidirectional streams) will
     /// still be compressed according to the configuration of the server.
-    #[cfg(any(feature = "gzip", feature = "deflate", feature = "zstd"))]
+    #[cfg(any(
+        feature = "gzip",
+        feature = "deflate",
+        feature = "zstd",
+        feature = "lz4",
+        feature = "snappy"
+    ))]
     pub fn disable_compression(&mut self) {
         self.extensions_mut()
             .insert(crate::codec::compression::SingleMessageCompressionOverride::Disable);

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -435,7 +435,13 @@ where
             .headers
             .insert(http::header::CONTENT_TYPE, GRPC_CONTENT_TYPE);
 
-        #[cfg(any(feature = "gzip", feature = "deflate", feature = "zstd"))]
+        #[cfg(any(
+            feature = "gzip",
+            feature = "deflate",
+            feature = "zstd",
+            feature = "lz4",
+            feature = "snappy"
+        ))]
         if let Some(encoding) = accept_encoding {
             // Set the content encoding
             parts.headers.insert(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
We use `GZIP` compression as the default compression for the server. But profiling shows `GZIP` compression takes a portion of CPU under high load, causing the high latency from our server

We look into another type of compression method supported by Tonic (0.12.3). We tested `ZSTD` compared to `GZIP`; `ZSTD` performs better than `GZIP`. 
However, my colleagues want more comparisons between `LZ4` and `SNAPPY`. So we run another round of tests

#### Setup
We have two setups, which are
1. Always return random **String** depends on setting size
    - Accept request and just return a random **String** without querying the database
<img width="751" height="277" alt="image" src="https://github.com/user-attachments/assets/60a5f92b-ea54-4a82-b240-a1bec4774a66" />

2. Replay the production traffic to the server, query, and return the actual response from the database with a different compression method
<img width="634" height="273" alt="image" src="https://github.com/user-attachments/assets/bf4594d1-bed6-47cc-a04b-43de21ee660a" />

Both setups will receive **1,000** requests per second constantly

#### How do we measure the E2E latency?
We measure it from the client side, `start` and `end` in the client request-response interceptor


### Terminology
1. `acm-identity`: expect no compression response back
2. `acm-gzip`: expect `GZIP` compression response back
3. `acm-zstd`: expect `ZSTD` compression response back
4. `acm-lz4`: expect `LZ4` compression response back
5. `acm-snappy`: expect `SNAPPY` compression response back


## Result
For the random string case
- The bigger the message size is, the more `GZIP` CPU usage
  - For example, with a 100KB message. `GZIP` server CPU usage is ~70% while other compression methods is still ~13%
  - The P99 latency for `GZIP` is up to ~13.4ms, while others are still at ~9ms
- `SNAPPY` and `LZ4` compression ratios is almost 1:1 in this case (Comparing from `identity` vs `SNAPPY` and `LZ4`)
- Memory usage is almost the same for all compressions

For replaying the production traffic case
- `SNAPPY` outperforms other compression methods in our use case. CPU usage is ~10.5% while the P99 is ~6.68ms
  - The server SLA is 10ms. So 6.68ms vs 7.60ms (`SNAPPY` vs `ZSTD`) is significant
  - We will deep dive to investigate why `SNAPPY` has low P99 compared to other


#### Result deck
[GRPC Compression evaluation for github PR.pdf](https://github.com/user-attachments/files/25521415/GRPC.Compression.evaluation.for.github.PR.pdf)

