### PR TITLE
examples: add server-side timeout example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -244,6 +244,14 @@ name = "cancellation-client"
 path = "src/cancellation/client.rs"
 
 [[bin]]
+name = "timeout-server"
+path = "src/timeout/server.rs"
+
+[[bin]]
+name = "timeout-client"
+path = "src/timeout/client.rs"
+
+[[bin]]
 name = "codec-buffers-server"
 path = "src/codec_buffers/server.rs"
 

--- a/examples/src/timeout/client.rs
+++ b/examples/src/timeout/client.rs
@@ -1,0 +1,63 @@
+//! A client that demonstrates gRPC request timeouts.
+//!
+//! Shows two timeout mechanisms:
+//! 1. **Server-side timeout** — set via `Server::builder().timeout()` on the server.
+//!    The server enforces the deadline and returns CANCELLED if exceeded.
+//! 2. **Client-side deadline** — set via `Request::set_timeout()`, which sends the
+//!    `grpc-timeout` header. The server respects the shorter of the two deadlines.
+//!
+//! ```not_rust
+//! # Start the timeout server first:
+//! cargo run --bin timeout-server
+//!
+//! # Then in another terminal:
+//! cargo run --bin timeout-client
+//! ```
+
+use std::time::Duration;
+
+use hello_world::HelloRequest;
+use hello_world::greeter_client::GreeterClient;
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
+
+    // 1. Fast request — completes within the server's 2s timeout.
+    println!("--- Fast request ---");
+    let request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+    match client.say_hello(request).await {
+        Ok(response) => println!("RESPONSE = {:?}", response.into_inner().message),
+        Err(status) => println!("ERROR = {status}"),
+    }
+
+    // 2. Slow request — exceeds the server's 2s timeout.
+    println!("\n--- Slow request (server timeout) ---");
+    let request = tonic::Request::new(HelloRequest {
+        name: "slow-request".into(),
+    });
+    match client.say_hello(request).await {
+        Ok(response) => println!("RESPONSE = {:?}", response.into_inner().message),
+        Err(status) => println!("ERROR = {status}"),
+    }
+
+    // 3. Client-side deadline — the client sets a 1s deadline via grpc-timeout header,
+    //    which is shorter than the server's 2s timeout.
+    println!("\n--- Fast request with short client deadline (1s) ---");
+    let mut request = tonic::Request::new(HelloRequest {
+        name: "Tonic".into(),
+    });
+    request.set_timeout(Duration::from_secs(1));
+    match client.say_hello(request).await {
+        Ok(response) => println!("RESPONSE = {:?}", response.into_inner().message),
+        Err(status) => println!("ERROR = {status}"),
+    }
+
+    Ok(())
+}

--- a/examples/src/timeout/server.rs
+++ b/examples/src/timeout/server.rs
@@ -1,0 +1,64 @@
+//! A server that enforces a request timeout using `Server::builder().timeout()`.
+//!
+//! The `say_hello` handler sleeps for a configurable duration, allowing you to
+//! test what happens when a request exceeds the server-side timeout.
+//!
+//! ```not_rust
+//! cargo run --bin timeout-server
+//! ```
+
+use std::time::Duration;
+
+use tokio::time::sleep;
+use tonic::{Request, Response, Status, transport::Server};
+
+use hello_world::greeter_server::{Greeter, GreeterServer};
+use hello_world::{HelloReply, HelloRequest};
+
+pub mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+#[derive(Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        let name = request.into_inner().name;
+        println!("Got a request for: {name}");
+
+        // Simulate slow processing for names starting with "slow".
+        if name.starts_with("slow") {
+            println!("Simulating slow processing (3s)...");
+            sleep(Duration::from_secs(3)).await;
+        }
+
+        let reply = HelloReply {
+            message: format!("Hello {name}!"),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = "[::1]:50051".parse().unwrap();
+    let greeter = MyGreeter::default();
+
+    println!("GreeterServer listening on {addr}");
+    println!("Server-side timeout: 2 seconds");
+
+    Server::builder()
+        // Enforce a 2-second timeout on all request handlers.
+        // If a handler takes longer, the client receives a CANCELLED status.
+        .timeout(Duration::from_secs(2))
+        .add_service(GreeterServer::new(greeter))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds a `timeout` example with server and client binaries
- Server uses `Server::builder().timeout()` to enforce a 2-second request deadline
- Client demonstrates both fast and slow requests, plus `Request::set_timeout()` for client-side deadlines
- Reuses the existing `helloworld` proto

### Motivation

The existing `cancellation` example covers client-initiated cancellation but not server-enforced timeouts. `Server::builder().timeout()` is documented in the API but has no dedicated example. Server-side timeouts and gRPC deadline propagation are common production requirements.

### Checklist

- [x] `cargo build --bin timeout-server --bin timeout-client`
- [x] Tested: fast request succeeds, slow request gets `CANCELLED` / `"Timeout expired"`
- [x] `cargo clippy --bin timeout-server --bin timeout-client`
- [x] `cargo fmt --check`