### PR TITLE
feat(build): Preserve error from ready() as Status source

### DIFF
--- a/grpc/src/generated/grpc_examples_echo.rs
+++ b/grpc/src/generated/grpc_examples_echo.rs
@@ -101,9 +101,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -126,9 +129,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -150,9 +156,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -177,9 +186,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/grpc/src/generated/grpc_examples_echo.rs
+++ b/grpc/src/generated/grpc_examples_echo.rs
@@ -101,9 +101,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -126,9 +129,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -150,9 +156,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -177,9 +186,12 @@ pub mod echo_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -237,14 +237,17 @@ fn generate_unary<T: Service>(
             &mut self,
             request: impl tonic::IntoRequest<#request>,
         ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
-           self.inner.ready().await.map_err(|e| {
-               tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-           })?;
-           let codec = #codec_name::default();
-           let path = http::uri::PathAndQuery::from_static(#path);
-           let mut req = request.into_request();
-           req.extensions_mut().insert(GrpcMethod::new(#service_name, #method_name));
-           self.inner.unary(req, path, codec).await
+            self.inner.ready().await.map_err(|e| {
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {}", e));
+                status.set_source(e.into());
+                status
+            })?;
+            let codec = #codec_name::default();
+            let path = http::uri::PathAndQuery::from_static(#path);
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(#service_name, #method_name));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -269,7 +272,10 @@ fn generate_server_streaming<T: Service>(
             request: impl tonic::IntoRequest<#request>,
         ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {}", e));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -300,7 +306,10 @@ fn generate_client_streaming<T: Service>(
             request: impl tonic::IntoStreamingRequest<Message = #request>
         ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {}", e));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -331,7 +340,10 @@ fn generate_streaming<T: Service>(
             request: impl tonic::IntoStreamingRequest<Message = #request>
         ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {}", e));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);

--- a/tonic-build/src/client.rs
+++ b/tonic-build/src/client.rs
@@ -237,14 +237,17 @@ fn generate_unary<T: Service>(
             &mut self,
             request: impl tonic::IntoRequest<#request>,
         ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
-           self.inner.ready().await.map_err(|e| {
-               tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-           })?;
-           let codec = #codec_name::default();
-           let path = http::uri::PathAndQuery::from_static(#path);
-           let mut req = request.into_request();
-           req.extensions_mut().insert(GrpcMethod::new(#service_name, #method_name));
-           self.inner.unary(req, path, codec).await
+            self.inner.ready().await.map_err(|e| {
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {e}"));
+                status.set_source(e.into());
+                status
+            })?;
+            let codec = #codec_name::default();
+            let path = http::uri::PathAndQuery::from_static(#path);
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(#service_name, #method_name));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -269,7 +272,10 @@ fn generate_server_streaming<T: Service>(
             request: impl tonic::IntoRequest<#request>,
         ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {e}"));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -300,7 +306,10 @@ fn generate_client_streaming<T: Service>(
             request: impl tonic::IntoStreamingRequest<Message = #request>
         ) -> std::result::Result<tonic::Response<#response>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {e}"));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);
@@ -331,7 +340,10 @@ fn generate_streaming<T: Service>(
             request: impl tonic::IntoStreamingRequest<Message = #request>
         ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<#response>>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+                let e = e.into();
+                let mut status = tonic::Status::unknown(format!("Service was not ready: {e}"));
+                status.set_source(e.into());
+                status
             })?;
             let codec = #codec_name::default();
             let path = http::uri::PathAndQuery::from_static(#path);

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -148,9 +148,12 @@ pub mod health_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -187,9 +190,12 @@ pub mod health_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-health/src/generated/grpc_health_v1.rs
+++ b/tonic-health/src/generated/grpc_health_v1.rs
@@ -148,9 +148,12 @@ pub mod health_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
@@ -187,9 +190,12 @@ pub mod health_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -239,9 +239,12 @@ pub mod server_reflection_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-reflection/src/generated/grpc_reflection_v1.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1.rs
@@ -239,9 +239,12 @@ pub mod server_reflection_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -239,9 +239,12 @@ pub mod server_reflection_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(

--- a/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
+++ b/tonic-reflection/src/generated/grpc_reflection_v1alpha.rs
@@ -239,9 +239,12 @@ pub mod server_reflection_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
+                    let e = e.into();
+                    let mut status = tonic::Status::unknown(
+                        format!("Service was not ready: {e}"),
+                    );
+                    status.set_source(e.into());
+                    status
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(


### PR DESCRIPTION
Client APIs await `ready()` on their inner Service before sending anything, but currently any errors from `ready()` are flattened to a message on an `Unknown` Status. Changing to `Status::from_error` would be a more drastic change and lose the custom message, but we can at least save the original error as an `Error::source`.

This comes up when e.g. a connection is no longer accepting new requests; getting a plain `Unknown` back for that is rather inscrutable, and doubly so when not logging the message out of an abundance of caution around user data.

Still to do: add a test, because I wasn't sure where it should live. But I'm happy to write it! I'm also not sure if this qualifies as a semantically-breaking change that can't go into v0.14.x.