### PR TITLE
prost: relax codec Default bounds

### DIFF
--- a/tonic-prost/src/codec.rs
+++ b/tonic-prost/src/codec.rs
@@ -74,7 +74,7 @@ where
 }
 
 /// A [`Encoder`] that knows how to encode `T`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProstEncoder<T> {
     _pd: PhantomData<T>,
     buffer_settings: BufferSettings,
@@ -87,6 +87,12 @@ impl<T> ProstEncoder<T> {
             _pd: PhantomData,
             buffer_settings,
         }
+    }
+}
+
+impl<T> Default for ProstEncoder<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
     }
 }
 
@@ -107,7 +113,7 @@ impl<T: Message> Encoder for ProstEncoder<T> {
 }
 
 /// A [`Decoder`] that knows how to decode `U`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProstDecoder<U> {
     _pd: PhantomData<U>,
     buffer_settings: BufferSettings,
@@ -120,6 +126,12 @@ impl<U> ProstDecoder<U> {
             _pd: PhantomData,
             buffer_settings,
         }
+    }
+}
+
+impl<U> Default for ProstDecoder<U> {
+    fn default() -> Self {
+        Self::new(Default::default())
     }
 }
 


### PR DESCRIPTION
Manually implement Default for ProstEncoder and ProstDecoder so their message types do not need to implement Default.

Fixes: #2458

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

If this change is intended for tonic `v0.14.x` please make this PR against that branch
otherwise, it may not get included in a relase for a long time.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
`ProstEncoder<T>` and `ProstDecoder<U>` currently derive `Default`, which adds unnecessary `T: Default` / `U: Default` bounds.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Remove the derived `Default` impls for `ProstEncoder` and `ProstDecoder`, and replace them with manual impls that call `Self::new(Default::default())`.
