### PR TITLE
feat(tonic-xds): parse RING_HASH lb policy from CDS (gRFC A42)

### DIFF
--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -166,13 +166,11 @@ mod tests {
             ..Default::default()
         };
         let validated = ClusterResource::validate(cluster).unwrap();
-        assert_eq!(
-            validated.lb_policy,
-            LbPolicy::RingHash(RingHashSettings {
-                min_ring_size: 1024,
-                max_ring_size: 4096,
-            })
-        );
+        let LbPolicy::RingHash(settings) = validated.lb_policy else {
+            panic!("expected RingHash, got {:?}", validated.lb_policy);
+        };
+        assert_eq!(settings.min_ring_size(), 1024);
+        assert_eq!(settings.max_ring_size(), 4096);
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -27,7 +27,20 @@ pub(crate) struct ClusterResource {
 pub(crate) enum LbPolicy {
     RoundRobin,
     LeastRequest,
+    /// Ring-hash (gRFC A42). Carries the validated ring bounds parsed from
+    /// `ring_hash_lb_config`.
+    RingHash {
+        min_ring_size: u64,
+        max_ring_size: u64,
+    },
 }
+
+/// gRFC A42 ring-hash sizing. `minimum_ring_size` defaults to 1024 and
+/// `maximum_ring_size` to the local cap of 4096 when unset; both are clamped to
+/// that cap, and any configured value above the 8M ceiling is rejected.
+const RING_HASH_DEFAULT_MIN_SIZE: u64 = 1024;
+const RING_HASH_SIZE_CAP: u64 = 4096;
+const RING_HASH_SIZE_CEILING: u64 = 8 * 1024 * 1024;
 
 impl Resource for ClusterResource {
     type Message = Cluster;
@@ -58,6 +71,7 @@ impl Resource for ClusterResource {
         let lb_policy = match cluster::LbPolicy::try_from(message.lb_policy) {
             Ok(cluster::LbPolicy::RoundRobin) => LbPolicy::RoundRobin,
             Ok(cluster::LbPolicy::LeastRequest) => LbPolicy::LeastRequest,
+            Ok(cluster::LbPolicy::RingHash) => parse_ring_hash(message.lb_config)?,
             _ => {
                 return Err(Error::Validation(format!(
                     "unsupported load balancing policy: {}",
@@ -85,10 +99,68 @@ impl ClusterResource {
     }
 }
 
+/// Parse and validate `ring_hash_lb_config` (gRFC A42) from a Cluster's
+/// `lb_config` oneof into [`LbPolicy::RingHash`].
+///
+/// Rejects a `hash_function` other than `XX_HASH` and any ring size above the
+/// 8M ceiling. Unset sizes take the xDS defaults (1024 / 8M); the resolved
+/// bounds are then clamped to the local cap.
+fn parse_ring_hash(lb_config: Option<cluster::LbConfig>) -> xds_client::Result<LbPolicy> {
+    use cluster::ring_hash_lb_config::HashFunction;
+
+    let (min_field, max_field, hash_function) = match lb_config {
+        Some(cluster::LbConfig::RingHashLbConfig(c)) => {
+            (c.minimum_ring_size, c.maximum_ring_size, c.hash_function)
+        }
+        // No ring_hash_lb_config → defaults (XX_HASH is the proto default).
+        _ => (None, None, HashFunction::XxHash as i32),
+    };
+
+    match HashFunction::try_from(hash_function) {
+        Ok(HashFunction::XxHash) => {}
+        Ok(other) => {
+            return Err(Error::Validation(format!(
+                "unsupported ring_hash hash function: {}",
+                other.as_str_name()
+            )));
+        }
+        Err(_) => {
+            return Err(Error::Validation(format!(
+                "unknown ring_hash hash function: {hash_function}"
+            )));
+        }
+    }
+
+    let min = min_field.map_or(RING_HASH_DEFAULT_MIN_SIZE, |v| v.value);
+    let max = max_field.map_or(RING_HASH_SIZE_CAP, |v| v.value);
+    if min > RING_HASH_SIZE_CEILING || max > RING_HASH_SIZE_CEILING {
+        return Err(Error::Validation(format!(
+            "ring_hash ring size exceeds the maximum of {RING_HASH_SIZE_CEILING} \
+             (min_ring_size={min}, max_ring_size={max})"
+        )));
+    }
+    // Checked on the resolved sizes before the cap is applied, matching grpc-go.
+    if min > max {
+        return Err(Error::Validation(format!(
+            "ring_hash min_ring_size ({min}) is greater than max_ring_size ({max})"
+        )));
+    }
+
+    Ok(LbPolicy::RingHash {
+        min_ring_size: min.min(RING_HASH_SIZE_CAP),
+        max_ring_size: max.min(RING_HASH_SIZE_CAP),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use envoy_types::pb::envoy::config::cluster::v3::cluster::EdsClusterConfig;
+    use envoy_types::pb::google::protobuf::UInt64Value;
+
+    fn ring_size(value: u64) -> UInt64Value {
+        UInt64Value { value }
+    }
 
     fn make_cluster(name: &str) -> Cluster {
         Cluster {
@@ -143,9 +215,10 @@ mod tests {
 
     #[test]
     fn test_unsupported_lb_policy_is_rejected() {
+        // A policy we don't support (e.g. MAGLEV) is still NACKed.
         let cluster = Cluster {
-            name: "rh-cluster".to_string(),
-            lb_policy: cluster::LbPolicy::RingHash as i32,
+            name: "mg-cluster".to_string(),
+            lb_policy: cluster::LbPolicy::Maglev as i32,
             ..Default::default()
         };
         let err = ClusterResource::validate(cluster).unwrap_err();
@@ -153,6 +226,98 @@ mod tests {
             err.to_string()
                 .contains("unsupported load balancing policy")
         );
+    }
+
+    /// Build a RING_HASH cluster, optionally carrying a `ring_hash_lb_config`.
+    fn ring_hash_cluster(config: Option<cluster::RingHashLbConfig>) -> Cluster {
+        Cluster {
+            name: "rh-cluster".to_string(),
+            lb_policy: cluster::LbPolicy::RingHash as i32,
+            lb_config: config.map(cluster::LbConfig::RingHashLbConfig),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_ring_hash_defaults() {
+        // No ring_hash_lb_config → min 1024, max defaults to 8M then clamps to
+        // the local cap of 4096; XX_HASH is the default hash function.
+        let validated = ClusterResource::validate(ring_hash_cluster(None)).unwrap();
+        assert_eq!(
+            validated.lb_policy,
+            LbPolicy::RingHash {
+                min_ring_size: 1024,
+                max_ring_size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn test_ring_hash_custom_sizes_within_cap() {
+        let validated =
+            ClusterResource::validate(ring_hash_cluster(Some(cluster::RingHashLbConfig {
+                minimum_ring_size: Some(ring_size(2048)),
+                maximum_ring_size: Some(ring_size(3000)),
+                ..Default::default()
+            })))
+            .unwrap();
+        assert_eq!(
+            validated.lb_policy,
+            LbPolicy::RingHash {
+                min_ring_size: 2048,
+                max_ring_size: 3000,
+            }
+        );
+    }
+
+    #[test]
+    fn test_ring_hash_sizes_clamped_to_local_cap() {
+        // Sizes within the 8M ceiling but above the local cap clamp to 4096.
+        let validated =
+            ClusterResource::validate(ring_hash_cluster(Some(cluster::RingHashLbConfig {
+                minimum_ring_size: Some(ring_size(100_000)),
+                maximum_ring_size: Some(ring_size(100_000)),
+                ..Default::default()
+            })))
+            .unwrap();
+        assert_eq!(
+            validated.lb_policy,
+            LbPolicy::RingHash {
+                min_ring_size: 4096,
+                max_ring_size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn test_ring_hash_rejects_non_xx_hash() {
+        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
+            hash_function: cluster::ring_hash_lb_config::HashFunction::MurmurHash2 as i32,
+            ..Default::default()
+        }));
+        let err = ClusterResource::validate(cluster).unwrap_err();
+        assert!(err.to_string().contains("hash function"));
+    }
+
+    #[test]
+    fn test_ring_hash_rejects_size_above_ceiling() {
+        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
+            maximum_ring_size: Some(ring_size(8 * 1024 * 1024 + 1)),
+            ..Default::default()
+        }));
+        let err = ClusterResource::validate(cluster).unwrap_err();
+        assert!(err.to_string().contains("exceeds the maximum"));
+    }
+
+    #[test]
+    fn test_ring_hash_rejects_min_greater_than_max() {
+        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
+            minimum_ring_size: Some(ring_size(3000)),
+            maximum_ring_size: Some(ring_size(2000)),
+            ..Default::default()
+        }));
+        let err = ClusterResource::validate(cluster).unwrap_err();
+        assert!(err.to_string().contains("greater than max_ring_size"));
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -8,6 +8,9 @@ use xds_client::{Error, Resource};
 
 use super::security::{ClusterSecurityConfig, parse_transport_socket};
 
+// Re-exported so other modules keep using the `cluster::LbPolicy` path.
+pub(crate) use super::lb_policy::{LbPolicy, RingHashSettings};
+
 /// Validated Cluster resource.
 #[derive(Debug, Clone)]
 pub(crate) struct ClusterResource {
@@ -21,26 +24,6 @@ pub(crate) struct ClusterResource {
     /// cluster uses plaintext connections.
     pub security: Option<ClusterSecurityConfig>,
 }
-
-/// Load balancing policies.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LbPolicy {
-    RoundRobin,
-    LeastRequest,
-    /// Ring-hash (gRFC A42). Carries the validated ring bounds parsed from
-    /// `ring_hash_lb_config`.
-    RingHash {
-        min_ring_size: u64,
-        max_ring_size: u64,
-    },
-}
-
-/// gRFC A42 ring-hash sizing. `minimum_ring_size` defaults to 1024 and
-/// `maximum_ring_size` to the local cap of 4096 when unset; both are clamped to
-/// that cap, and any configured value above the 8M ceiling is rejected.
-const RING_HASH_DEFAULT_MIN_SIZE: u64 = 1024;
-const RING_HASH_SIZE_CAP: u64 = 4096;
-const RING_HASH_SIZE_CEILING: u64 = 8 * 1024 * 1024;
 
 impl Resource for ClusterResource {
     type Message = Cluster;
@@ -71,7 +54,9 @@ impl Resource for ClusterResource {
         let lb_policy = match cluster::LbPolicy::try_from(message.lb_policy) {
             Ok(cluster::LbPolicy::RoundRobin) => LbPolicy::RoundRobin,
             Ok(cluster::LbPolicy::LeastRequest) => LbPolicy::LeastRequest,
-            Ok(cluster::LbPolicy::RingHash) => parse_ring_hash(message.lb_config)?,
+            Ok(cluster::LbPolicy::RingHash) => {
+                LbPolicy::RingHash(RingHashSettings::validate(message.lb_config)?)
+            }
             _ => {
                 return Err(Error::Validation(format!(
                     "unsupported load balancing policy: {}",
@@ -99,68 +84,10 @@ impl ClusterResource {
     }
 }
 
-/// Parse and validate `ring_hash_lb_config` (gRFC A42) from a Cluster's
-/// `lb_config` oneof into [`LbPolicy::RingHash`].
-///
-/// Rejects a `hash_function` other than `XX_HASH` and any ring size above the
-/// 8M ceiling. Unset sizes take the xDS defaults (1024 / 8M); the resolved
-/// bounds are then clamped to the local cap.
-fn parse_ring_hash(lb_config: Option<cluster::LbConfig>) -> xds_client::Result<LbPolicy> {
-    use cluster::ring_hash_lb_config::HashFunction;
-
-    let (min_field, max_field, hash_function) = match lb_config {
-        Some(cluster::LbConfig::RingHashLbConfig(c)) => {
-            (c.minimum_ring_size, c.maximum_ring_size, c.hash_function)
-        }
-        // No ring_hash_lb_config → defaults (XX_HASH is the proto default).
-        _ => (None, None, HashFunction::XxHash as i32),
-    };
-
-    match HashFunction::try_from(hash_function) {
-        Ok(HashFunction::XxHash) => {}
-        Ok(other) => {
-            return Err(Error::Validation(format!(
-                "unsupported ring_hash hash function: {}",
-                other.as_str_name()
-            )));
-        }
-        Err(_) => {
-            return Err(Error::Validation(format!(
-                "unknown ring_hash hash function: {hash_function}"
-            )));
-        }
-    }
-
-    let min = min_field.map_or(RING_HASH_DEFAULT_MIN_SIZE, |v| v.value);
-    let max = max_field.map_or(RING_HASH_SIZE_CAP, |v| v.value);
-    if min > RING_HASH_SIZE_CEILING || max > RING_HASH_SIZE_CEILING {
-        return Err(Error::Validation(format!(
-            "ring_hash ring size exceeds the maximum of {RING_HASH_SIZE_CEILING} \
-             (min_ring_size={min}, max_ring_size={max})"
-        )));
-    }
-    // Checked on the resolved sizes before the cap is applied, matching grpc-go.
-    if min > max {
-        return Err(Error::Validation(format!(
-            "ring_hash min_ring_size ({min}) is greater than max_ring_size ({max})"
-        )));
-    }
-
-    Ok(LbPolicy::RingHash {
-        min_ring_size: min.min(RING_HASH_SIZE_CAP),
-        max_ring_size: max.min(RING_HASH_SIZE_CAP),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use envoy_types::pb::envoy::config::cluster::v3::cluster::EdsClusterConfig;
-    use envoy_types::pb::google::protobuf::UInt64Value;
-
-    fn ring_size(value: u64) -> UInt64Value {
-        UInt64Value { value }
-    }
 
     fn make_cluster(name: &str) -> Cluster {
         Cluster {
@@ -228,96 +155,24 @@ mod tests {
         );
     }
 
-    /// Build a RING_HASH cluster, optionally carrying a `ring_hash_lb_config`.
-    fn ring_hash_cluster(config: Option<cluster::RingHashLbConfig>) -> Cluster {
-        Cluster {
+    #[test]
+    fn test_ring_hash_lb_policy() {
+        // A RING_HASH cluster validates to LbPolicy::RingHash with the parsed
+        // (here defaulted) settings. Detailed ring_hash_lb_config validation is
+        // covered in the `lb_policy` module.
+        let cluster = Cluster {
             name: "rh-cluster".to_string(),
             lb_policy: cluster::LbPolicy::RingHash as i32,
-            lb_config: config.map(cluster::LbConfig::RingHashLbConfig),
             ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_ring_hash_defaults() {
-        // No ring_hash_lb_config → min 1024, max defaults to 8M then clamps to
-        // the local cap of 4096; XX_HASH is the default hash function.
-        let validated = ClusterResource::validate(ring_hash_cluster(None)).unwrap();
+        };
+        let validated = ClusterResource::validate(cluster).unwrap();
         assert_eq!(
             validated.lb_policy,
-            LbPolicy::RingHash {
+            LbPolicy::RingHash(RingHashSettings {
                 min_ring_size: 1024,
                 max_ring_size: 4096,
-            }
+            })
         );
-    }
-
-    #[test]
-    fn test_ring_hash_custom_sizes_within_cap() {
-        let validated =
-            ClusterResource::validate(ring_hash_cluster(Some(cluster::RingHashLbConfig {
-                minimum_ring_size: Some(ring_size(2048)),
-                maximum_ring_size: Some(ring_size(3000)),
-                ..Default::default()
-            })))
-            .unwrap();
-        assert_eq!(
-            validated.lb_policy,
-            LbPolicy::RingHash {
-                min_ring_size: 2048,
-                max_ring_size: 3000,
-            }
-        );
-    }
-
-    #[test]
-    fn test_ring_hash_sizes_clamped_to_local_cap() {
-        // Sizes within the 8M ceiling but above the local cap clamp to 4096.
-        let validated =
-            ClusterResource::validate(ring_hash_cluster(Some(cluster::RingHashLbConfig {
-                minimum_ring_size: Some(ring_size(100_000)),
-                maximum_ring_size: Some(ring_size(100_000)),
-                ..Default::default()
-            })))
-            .unwrap();
-        assert_eq!(
-            validated.lb_policy,
-            LbPolicy::RingHash {
-                min_ring_size: 4096,
-                max_ring_size: 4096,
-            }
-        );
-    }
-
-    #[test]
-    fn test_ring_hash_rejects_non_xx_hash() {
-        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
-            hash_function: cluster::ring_hash_lb_config::HashFunction::MurmurHash2 as i32,
-            ..Default::default()
-        }));
-        let err = ClusterResource::validate(cluster).unwrap_err();
-        assert!(err.to_string().contains("hash function"));
-    }
-
-    #[test]
-    fn test_ring_hash_rejects_size_above_ceiling() {
-        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
-            maximum_ring_size: Some(ring_size(8 * 1024 * 1024 + 1)),
-            ..Default::default()
-        }));
-        let err = ClusterResource::validate(cluster).unwrap_err();
-        assert!(err.to_string().contains("exceeds the maximum"));
-    }
-
-    #[test]
-    fn test_ring_hash_rejects_min_greater_than_max() {
-        let cluster = ring_hash_cluster(Some(cluster::RingHashLbConfig {
-            minimum_ring_size: Some(ring_size(3000)),
-            maximum_ring_size: Some(ring_size(2000)),
-            ..Default::default()
-        }));
-        let err = ClusterResource::validate(cluster).unwrap_err();
-        assert!(err.to_string().contains("greater than max_ring_size"));
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/lb_policy.rs
+++ b/tonic-xds/src/xds/resource/lb_policy.rs
@@ -15,24 +15,34 @@ pub(crate) enum LbPolicy {
 }
 
 /// Validated gRFC A42 ring-hash sizing parsed from `ring_hash_lb_config`.
+///
+/// Fields are private so a `RingHashSettings` can only be obtained from
+/// [`RingHashSettings::validate`] — i.e. every value is already within bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RingHashSettings {
-    pub min_ring_size: u64,
-    pub max_ring_size: u64,
+    min_ring_size: u64,
+    max_ring_size: u64,
 }
 
 /// gRFC A42 ring-hash sizing. `minimum_ring_size` defaults to 1024 and
-/// `maximum_ring_size` to the xDS default of 8M when unset; both are then
-/// clamped to the local cap of 4096, and any configured value above the 8M
-/// ceiling is rejected. Defaulting an unset max to 8M (rather than directly to
+/// `maximum_ring_size` to the 8M ceiling when unset; both are then clamped to
+/// the local cap of 4096, and any configured value above the ceiling is
+/// rejected. Defaulting an unset max to the ceiling (rather than directly to
 /// the cap) keeps the `min > max` check from rejecting a `min` in the
 /// `(cap, ceiling]` range when `max` is unset.
 pub(crate) const RING_HASH_DEFAULT_MIN_SIZE: u64 = 1024;
-pub(crate) const RING_HASH_DEFAULT_MAX_SIZE: u64 = 8 * 1024 * 1024;
 pub(crate) const RING_HASH_SIZE_CAP: u64 = 4096;
 pub(crate) const RING_HASH_SIZE_CEILING: u64 = 8 * 1024 * 1024;
 
 impl RingHashSettings {
+    pub(crate) fn min_ring_size(&self) -> u64 {
+        self.min_ring_size
+    }
+
+    pub(crate) fn max_ring_size(&self) -> u64 {
+        self.max_ring_size
+    }
+
     /// Validate a Cluster's `lb_config` oneof as `ring_hash_lb_config` (gRFC
     /// A42).
     ///
@@ -65,7 +75,7 @@ impl RingHashSettings {
         }
 
         let min = min_field.map_or(RING_HASH_DEFAULT_MIN_SIZE, |v| v.value);
-        let max = max_field.map_or(RING_HASH_DEFAULT_MAX_SIZE, |v| v.value);
+        let max = max_field.map_or(RING_HASH_SIZE_CEILING, |v| v.value);
         if min > RING_HASH_SIZE_CEILING || max > RING_HASH_SIZE_CEILING {
             return Err(Error::Validation(format!(
                 "ring_hash ring size exceeds the maximum of {RING_HASH_SIZE_CEILING} \

--- a/tonic-xds/src/xds/resource/lb_policy.rs
+++ b/tonic-xds/src/xds/resource/lb_policy.rs
@@ -22,9 +22,13 @@ pub(crate) struct RingHashSettings {
 }
 
 /// gRFC A42 ring-hash sizing. `minimum_ring_size` defaults to 1024 and
-/// `maximum_ring_size` to the local cap of 4096 when unset; both are clamped to
-/// that cap, and any configured value above the 8M ceiling is rejected.
+/// `maximum_ring_size` to the xDS default of 8M when unset; both are then
+/// clamped to the local cap of 4096, and any configured value above the 8M
+/// ceiling is rejected. Defaulting an unset max to 8M (rather than directly to
+/// the cap) keeps the `min > max` check from rejecting a `min` in the
+/// `(cap, ceiling]` range when `max` is unset.
 pub(crate) const RING_HASH_DEFAULT_MIN_SIZE: u64 = 1024;
+pub(crate) const RING_HASH_DEFAULT_MAX_SIZE: u64 = 8 * 1024 * 1024;
 pub(crate) const RING_HASH_SIZE_CAP: u64 = 4096;
 pub(crate) const RING_HASH_SIZE_CEILING: u64 = 8 * 1024 * 1024;
 
@@ -34,8 +38,8 @@ impl RingHashSettings {
     ///
     /// Rejects a `hash_function` other than `XX_HASH`, any ring size above the
     /// 8M ceiling, and `min_ring_size > max_ring_size`. Unset sizes take the
-    /// defaults (1024 / 4096); the resolved bounds are then clamped to the
-    /// local cap.
+    /// defaults (1024 / 8M); the resolved bounds are then clamped to the local
+    /// cap.
     pub(crate) fn validate(lb_config: Option<cluster::LbConfig>) -> xds_client::Result<Self> {
         let (min_field, max_field, hash_function) = match lb_config {
             Some(cluster::LbConfig::RingHashLbConfig(c)) => {
@@ -61,7 +65,7 @@ impl RingHashSettings {
         }
 
         let min = min_field.map_or(RING_HASH_DEFAULT_MIN_SIZE, |v| v.value);
-        let max = max_field.map_or(RING_HASH_SIZE_CAP, |v| v.value);
+        let max = max_field.map_or(RING_HASH_DEFAULT_MAX_SIZE, |v| v.value);
         if min > RING_HASH_SIZE_CEILING || max > RING_HASH_SIZE_CEILING {
             return Err(Error::Validation(format!(
                 "ring_hash ring size exceeds the maximum of {RING_HASH_SIZE_CEILING} \
@@ -173,5 +177,23 @@ mod tests {
         }))
         .unwrap_err();
         assert!(err.to_string().contains("greater than max_ring_size"));
+    }
+
+    #[test]
+    fn ring_hash_min_above_cap_with_unset_max_is_accepted() {
+        // min in (cap, ceiling] with max unset must not NACK: max defaults to
+        // 8M, so min <= max, and both then clamp to the cap.
+        let settings = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            minimum_ring_size: Some(ring_size(5000)),
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(
+            settings,
+            RingHashSettings {
+                min_ring_size: 4096,
+                max_ring_size: 4096,
+            }
+        );
     }
 }

--- a/tonic-xds/src/xds/resource/lb_policy.rs
+++ b/tonic-xds/src/xds/resource/lb_policy.rs
@@ -1,6 +1,8 @@
 //! Cluster load-balancing policy (CDS) and ring-hash config validation.
 
-use envoy_types::pb::envoy::config::cluster::v3::cluster;
+use envoy_types::pb::envoy::config::cluster::v3::cluster::{
+    self, ring_hash_lb_config::HashFunction,
+};
 use xds_client::Error;
 
 /// Load balancing policies.
@@ -35,8 +37,6 @@ impl RingHashSettings {
     /// defaults (1024 / 4096); the resolved bounds are then clamped to the
     /// local cap.
     pub(crate) fn validate(lb_config: Option<cluster::LbConfig>) -> xds_client::Result<Self> {
-        use cluster::ring_hash_lb_config::HashFunction;
-
         let (min_field, max_field, hash_function) = match lb_config {
             Some(cluster::LbConfig::RingHashLbConfig(c)) => {
                 (c.minimum_ring_size, c.maximum_ring_size, c.hash_function)

--- a/tonic-xds/src/xds/resource/lb_policy.rs
+++ b/tonic-xds/src/xds/resource/lb_policy.rs
@@ -1,0 +1,177 @@
+//! Cluster load-balancing policy (CDS) and ring-hash config validation.
+
+use envoy_types::pb::envoy::config::cluster::v3::cluster;
+use xds_client::Error;
+
+/// Load balancing policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LbPolicy {
+    RoundRobin,
+    LeastRequest,
+    /// Ring-hash (gRFC A42), carrying the validated ring bounds.
+    RingHash(RingHashSettings),
+}
+
+/// Validated gRFC A42 ring-hash sizing parsed from `ring_hash_lb_config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RingHashSettings {
+    pub min_ring_size: u64,
+    pub max_ring_size: u64,
+}
+
+/// gRFC A42 ring-hash sizing. `minimum_ring_size` defaults to 1024 and
+/// `maximum_ring_size` to the local cap of 4096 when unset; both are clamped to
+/// that cap, and any configured value above the 8M ceiling is rejected.
+pub(crate) const RING_HASH_DEFAULT_MIN_SIZE: u64 = 1024;
+pub(crate) const RING_HASH_SIZE_CAP: u64 = 4096;
+pub(crate) const RING_HASH_SIZE_CEILING: u64 = 8 * 1024 * 1024;
+
+impl RingHashSettings {
+    /// Validate a Cluster's `lb_config` oneof as `ring_hash_lb_config` (gRFC
+    /// A42).
+    ///
+    /// Rejects a `hash_function` other than `XX_HASH`, any ring size above the
+    /// 8M ceiling, and `min_ring_size > max_ring_size`. Unset sizes take the
+    /// defaults (1024 / 4096); the resolved bounds are then clamped to the
+    /// local cap.
+    pub(crate) fn validate(lb_config: Option<cluster::LbConfig>) -> xds_client::Result<Self> {
+        use cluster::ring_hash_lb_config::HashFunction;
+
+        let (min_field, max_field, hash_function) = match lb_config {
+            Some(cluster::LbConfig::RingHashLbConfig(c)) => {
+                (c.minimum_ring_size, c.maximum_ring_size, c.hash_function)
+            }
+            // No ring_hash_lb_config → defaults (XX_HASH is the proto default).
+            _ => (None, None, HashFunction::XxHash as i32),
+        };
+
+        match HashFunction::try_from(hash_function) {
+            Ok(HashFunction::XxHash) => {}
+            Ok(other) => {
+                return Err(Error::Validation(format!(
+                    "unsupported ring_hash hash function: {}",
+                    other.as_str_name()
+                )));
+            }
+            Err(_) => {
+                return Err(Error::Validation(format!(
+                    "unknown ring_hash hash function: {hash_function}"
+                )));
+            }
+        }
+
+        let min = min_field.map_or(RING_HASH_DEFAULT_MIN_SIZE, |v| v.value);
+        let max = max_field.map_or(RING_HASH_SIZE_CAP, |v| v.value);
+        if min > RING_HASH_SIZE_CEILING || max > RING_HASH_SIZE_CEILING {
+            return Err(Error::Validation(format!(
+                "ring_hash ring size exceeds the maximum of {RING_HASH_SIZE_CEILING} \
+                 (min_ring_size={min}, max_ring_size={max})"
+            )));
+        }
+        // Checked on the resolved sizes before the cap is applied.
+        if min > max {
+            return Err(Error::Validation(format!(
+                "ring_hash min_ring_size ({min}) is greater than max_ring_size ({max})"
+            )));
+        }
+
+        Ok(RingHashSettings {
+            min_ring_size: min.min(RING_HASH_SIZE_CAP),
+            max_ring_size: max.min(RING_HASH_SIZE_CAP),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use envoy_types::pb::google::protobuf::UInt64Value;
+
+    fn ring_size(value: u64) -> UInt64Value {
+        UInt64Value { value }
+    }
+
+    fn lb_config(config: cluster::RingHashLbConfig) -> Option<cluster::LbConfig> {
+        Some(cluster::LbConfig::RingHashLbConfig(config))
+    }
+
+    #[test]
+    fn ring_hash_defaults() {
+        // No ring_hash_lb_config → min 1024, max defaults to the cap; XX_HASH
+        // is the default hash function.
+        let settings = RingHashSettings::validate(None).unwrap();
+        assert_eq!(
+            settings,
+            RingHashSettings {
+                min_ring_size: 1024,
+                max_ring_size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn ring_hash_custom_sizes_within_cap() {
+        let settings = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            minimum_ring_size: Some(ring_size(2048)),
+            maximum_ring_size: Some(ring_size(3000)),
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(
+            settings,
+            RingHashSettings {
+                min_ring_size: 2048,
+                max_ring_size: 3000,
+            }
+        );
+    }
+
+    #[test]
+    fn ring_hash_sizes_clamped_to_cap() {
+        // Sizes within the 8M ceiling but above the local cap clamp to 4096.
+        let settings = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            minimum_ring_size: Some(ring_size(100_000)),
+            maximum_ring_size: Some(ring_size(100_000)),
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(
+            settings,
+            RingHashSettings {
+                min_ring_size: 4096,
+                max_ring_size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn ring_hash_rejects_non_xx_hash() {
+        let err = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            hash_function: cluster::ring_hash_lb_config::HashFunction::MurmurHash2 as i32,
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("hash function"));
+    }
+
+    #[test]
+    fn ring_hash_rejects_size_above_ceiling() {
+        let err = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            maximum_ring_size: Some(ring_size(8 * 1024 * 1024 + 1)),
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("exceeds the maximum"));
+    }
+
+    #[test]
+    fn ring_hash_rejects_min_greater_than_max() {
+        let err = RingHashSettings::validate(lb_config(cluster::RingHashLbConfig {
+            minimum_ring_size: Some(ring_size(3000)),
+            maximum_ring_size: Some(ring_size(2000)),
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert!(err.to_string().contains("greater than max_ring_size"));
+    }
+}

--- a/tonic-xds/src/xds/resource/mod.rs
+++ b/tonic-xds/src/xds/resource/mod.rs
@@ -13,6 +13,7 @@
 pub(crate) mod cluster;
 pub(crate) mod endpoints;
 pub(crate) mod hash_policy;
+pub(crate) mod lb_policy;
 pub(crate) mod listener;
 pub(crate) mod outlier_detection;
 pub(crate) mod route_config;


### PR DESCRIPTION
## Summary

Adds CDS support for the [gRFC A42](https://github.com/grpc/proposal/blob/master/A42-xds-ring-hash-lb-policy.md) ring-hash load-balancing policy. A Cluster with lb_policy: RING_HASH is now accepted and its ring_hash_lb_config validated into LbPolicy::RingHash(RingHashSettings { min_ring_size, max_ring_size }).

Validation rules (mirroring grpc-go's balancer/ringhash/config.go ordering — ceiling → min/max → cap):
- NACK a hash_function other than XX_HASH (rejects MURMUR_HASH_2).
- NACK any ring size above the 8M ceiling.
- NACK min_ring_size > max_ring_size.
- Default unset minimum_ring_size to 1024 and maximum_ring_size to 4096, then clamp both to the local cap of 4096.

## Tests

- RingHashSettings::validate unit tests in lb_policy: defaults; custom sizes within the cap; sizes clamped to the local cap; reject non-XX_HASH; reject size above the 8M ceiling; reject min > max.
- cluster tests: a RING_HASH cluster validates end-to-end to LbPolicy::RingHash(..); an unsupported policy (MAGLEV) is still NACKed.
- cargo fmt, clippy, and cargo test -p tonic-xds all clean.

## Plan
- #2686 — request-hash computation from header hash policies (merged).
- #2695 — RingHashPicker + member tracking (merged).
- This PR — CDS: parse RING_HASH + ring_hash_lb_config.
- Next — RDS: parse RouteAction.hash_policy to drive the request hash.
- Follow-up — weight-proportional rings (EDS endpoint × locality weight) for full A42 conformance.