### PR TITLE
Wire A32 circuit breaking into xDS channels

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -22,8 +22,11 @@
  *
  */
 
+use crate::client::circuit_breaking::{
+    CircuitBreakingClusterDiscovery, CircuitBreakingEndpointService, ClusterCircuitBreakerRegistry,
+};
 use crate::client::cluster::ClusterClientRegistry;
-use crate::client::endpoint::{EndpointAddress, MakeConnector};
+use crate::client::endpoint::{EndpointAddress, EndpointChannel, MakeConnector};
 use crate::client::lb::{ClusterDiscovery, XdsLbService};
 use crate::client::route::{PreRouteInterceptor, Router, XdsRoutingLayer};
 use crate::xds::bootstrap::{BootstrapConfig, BootstrapError};
@@ -42,7 +45,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tonic::{body::Body as TonicBody, client::GrpcService};
+use tonic::{body::Body as TonicBody, client::GrpcService, transport::Channel};
 use tower::{BoxError, Service, ServiceBuilder, load::Load, util::BoxCloneSyncService};
 use xds_client::{
     ClientConfig, MetricsRecorder, Node, ProstCodec, TokioRuntime, TonicTransportBuilder, XdsClient,
@@ -487,12 +490,51 @@ impl XdsChannelBuilder {
     /// feature) and reconstructs each endpoint request body as [`TonicBody`].
     /// Separated so tests can inject a disconnected `XdsClient` and a
     /// pre-populated cache via [`XdsRuntimeParts`].
+    ///
+    /// Circuit breaking is gRPC-only: [`CircuitBreakingEndpointService`] holds
+    /// the permit against a [`TonicBody`] response. Transport-generic channels
+    /// go through [`build_channel`](Self::build_channel) without this wrapper.
     fn build_grpc_channel_from_runtime(&self, parts: XdsRuntimeParts) -> XdsChannelGrpc {
-        self.build_channel::<GrpcMakeConnector, TonicBody, TonicBody, TonicBody, _>(
-            parts,
-            GrpcMakeConnector::new(),
+        let cache = parts.cache.clone();
+        let router: Arc<dyn Router> = Arc::new(match self.retry_classifier_factory.clone() {
+            Some(factory) => XdsRouter::with_retry_factory(&parts.cache, factory),
+            None => XdsRouter::new(&parts.cache),
+        });
+        let retry_layer = RetryLayer::new(Arc::new(RetrySharedConfig::grpc_default()));
+
+        #[cfg(feature = "_tls-any")]
+        let inner: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>> =
+            Arc::new(XdsClusterDiscovery::new(
+                parts.cache,
+                GrpcMakeConnector::new(),
+                parts.cert_provider_registry,
+            ));
+        #[cfg(not(feature = "_tls-any"))]
+        let inner: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>> = Arc::new(
+            XdsClusterDiscovery::new(parts.cache, GrpcMakeConnector::new()),
+        );
+
+        let discovery = Arc::new(
+            CircuitBreakingClusterDiscovery::new(inner, ClusterCircuitBreakerRegistry::default())
+                .with_cluster_cache(cache),
+        );
+        let resources = Arc::new(XdsChannelResources {
+            _resource_manager: parts.resource_manager,
+            _xds_client: parts.xds_client,
+        });
+        let routing_layer = XdsRoutingLayer::new(router, self.pre_route.clone(), self.authority());
+        self.assemble_channel_stack::<
+            CircuitBreakingEndpointService<EndpointChannel<Channel>>,
+            TonicBody,
+            TonicBody,
+            TonicBody,
+            _,
+        >(
+            routing_layer,
+            retry_layer,
+            discovery,
             |req: Request<SharedBody<TonicBody>>| req.map(TonicBody::new),
-            Arc::new(RetrySharedConfig::grpc_default()),
+            Some(resources),
         )
     }
 
@@ -622,6 +664,10 @@ mod tests {
     use super::{XdsChannelBuilder, XdsChannelConfig};
     use crate::XdsUri;
     use crate::client::channel::XdsChannelGrpc;
+    use crate::client::circuit_breaking::{
+        CircuitBreakingClusterDiscovery, CircuitBreakingEndpointService,
+        ClusterCircuitBreakerRegistry,
+    };
     use crate::client::endpoint::EndpointAddress;
     use crate::client::endpoint::EndpointChannel;
 
@@ -639,6 +685,7 @@ mod tests {
     use crate::testutil::grpc::TestServer;
     use crate::xds::cache::XdsCache;
     use crate::xds::resource::EndpointsResource;
+    use crate::xds::resource::circuit_breaking::CircuitBreakingConfig;
     use crate::xds::resource::route_config::RouteConfigResource;
     use std::sync::Arc;
     use std::task::{Context, Poll};
@@ -656,15 +703,45 @@ mod tests {
             retry: Arc<RetrySharedConfig>,
             interceptor: Option<Arc<dyn PreRouteInterceptor>>,
         ) -> XdsChannelGrpc {
+            self.build_grpc_channel_from_parts_with_circuit_breakers(
+                router,
+                discovery,
+                retry,
+                interceptor,
+                ClusterCircuitBreakerRegistry::new_for_test(),
+                None,
+            )
+        }
+
+        pub(crate) fn build_grpc_channel_from_parts_with_circuit_breakers(
+            &self,
+            router: Arc<dyn Router>,
+            discovery: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>>,
+            retry: Arc<RetrySharedConfig>,
+            interceptor: Option<Arc<dyn PreRouteInterceptor>>,
+            circuit_breakers: ClusterCircuitBreakerRegistry,
+            cluster_cache: Option<Arc<XdsCache>>,
+        ) -> XdsChannelGrpc {
             use crate::client::retry::RetryLayer;
             use crate::client::route::XdsRoutingLayer;
             use http::Request;
             use shared_http_body::SharedBody;
             use tonic::body::Body as TonicBody;
 
+            let mut wrapped = CircuitBreakingClusterDiscovery::new(discovery, circuit_breakers);
+            if let Some(cache) = cluster_cache {
+                wrapped = wrapped.with_cluster_cache(cache);
+            }
+            let discovery = Arc::new(wrapped);
             let routing_layer = XdsRoutingLayer::new(router, interceptor, self.authority());
             let retry_layer = RetryLayer::new(retry);
-            self.assemble_channel_stack::<EndpointChannel<Channel>, TonicBody, TonicBody, TonicBody, _>(
+            self.assemble_channel_stack::<
+                CircuitBreakingEndpointService<EndpointChannel<Channel>>,
+                TonicBody,
+                TonicBody,
+                TonicBody,
+                _,
+            >(
                 routing_layer,
                 retry_layer,
                 discovery,
@@ -904,16 +981,222 @@ mod tests {
         assert_eq!(response.into_inner().message, "retry-server: retry-test");
     }
 
+    #[tokio::test]
+    async fn test_xds_channel_enforces_injected_circuit_breaking_limit() {
+        use crate::client::retry::{GrpcRetryClassifier, RetryConfig};
+
+        let (_, servers) = setup_grpc_servers(1).await;
+        let xds_manager = Arc::new(MockXdsManager::from_test_servers(&servers));
+        let circuit_breakers = ClusterCircuitBreakerRegistry::new_for_test();
+        circuit_breakers.set_config("test-cluster", CircuitBreakingConfig { max_requests: 0 });
+
+        let retry = Arc::new(RetrySharedConfig::new(
+            RetryConfig::new().num_retries(1),
+            Arc::new(GrpcRetryClassifier::new(vec![tonic::Code::Unavailable])),
+        ));
+        let xds_channel = XdsChannelBuilder::new(test_config())
+            .build_grpc_channel_from_parts_with_circuit_breakers(
+                xds_manager.clone(),
+                xds_manager.clone(),
+                retry,
+                None,
+                circuit_breakers,
+                None,
+            );
+        let mut client = GreeterClient::new(xds_channel);
+
+        let error = client
+            .say_hello(HelloRequest {
+                name: "limited".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert!(error.message().contains("max_requests limit 0"));
+
+        for server in servers {
+            let _ = server.shutdown.send(());
+            let _ = server.handle.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_xds_channel_uses_cds_circuit_breaking_config() {
+        let cluster_name = "test-cluster";
+        let (_, servers) = setup_grpc_servers(1).await;
+
+        let cache = Arc::new(XdsCache::new());
+        cache.update_route_config(make_test_route_config(cluster_name));
+        cache.update_cluster(
+            cluster_name,
+            make_test_cluster_with_circuit_breaking(
+                cluster_name,
+                CircuitBreakingConfig { max_requests: 0 },
+            ),
+        );
+        cache.update_endpoints(cluster_name, make_test_endpoints(cluster_name, &servers));
+
+        let channel = build_xds_channel_from_cache(cache).await;
+        let mut client = GreeterClient::new(channel);
+        let error = client
+            .say_hello(HelloRequest {
+                name: "cds-limited".to_string(),
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert!(error.message().contains("max_requests limit 0"));
+
+        for server in servers {
+            let _ = server.shutdown.send(());
+            let _ = server.handle.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_xds_channel_waits_for_cds_before_circuit_breaking() {
+        let cluster_name = "test-cluster";
+        let (_, servers) = setup_grpc_servers(1).await;
+
+        let cache = Arc::new(XdsCache::new());
+        cache.update_route_config(make_test_route_config(cluster_name));
+        cache.update_endpoints(cluster_name, make_test_endpoints(cluster_name, &servers));
+
+        let channel = build_xds_channel_from_cache(cache.clone()).await;
+        let mut client = GreeterClient::new(channel);
+        let mut request = Box::pin(client.say_hello(HelloRequest {
+            name: "wait-for-cds".to_string(),
+        }));
+
+        let early =
+            tokio::time::timeout(tokio::time::Duration::from_millis(20), request.as_mut()).await;
+        assert!(
+            early.is_err(),
+            "request should wait for CDS before acquiring a circuit-breaking permit",
+        );
+
+        cache.update_cluster(
+            cluster_name,
+            make_test_cluster_with_circuit_breaking(
+                cluster_name,
+                CircuitBreakingConfig { max_requests: 0 },
+            ),
+        );
+
+        let result = tokio::time::timeout(tokio::time::Duration::from_secs(2), request)
+            .await
+            .expect("request should complete after CDS update");
+        let error = result.unwrap_err();
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert!(error.message().contains("max_requests limit 0"));
+
+        for server in servers {
+            let _ = server.shutdown.send(());
+            let _ = server.handle.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_xds_channel_recovers_cluster_after_remove_and_readd() {
+        let cluster_name = "test-cluster-remove-readd";
+        let (_, servers) = setup_grpc_servers(2).await;
+
+        let cache = Arc::new(XdsCache::new());
+        cache.update_route_config(make_test_route_config(cluster_name));
+        cache.update_cluster(
+            cluster_name,
+            make_test_cluster_with_circuit_breaking(
+                cluster_name,
+                CircuitBreakingConfig { max_requests: 1 },
+            ),
+        );
+        cache.update_endpoints(
+            cluster_name,
+            make_test_endpoints(cluster_name, &servers[..1]),
+        );
+
+        let channel = build_xds_channel_from_cache(cache.clone()).await;
+        let mut client = GreeterClient::new(channel);
+        let first = client
+            .say_hello(HelloRequest {
+                name: "before-removal".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(first.into_inner().message.starts_with("server-0:"));
+
+        cache.remove_cluster(cluster_name);
+        cache.remove_endpoints(cluster_name);
+        cache.update_cluster(
+            cluster_name,
+            make_test_cluster_with_circuit_breaking(
+                cluster_name,
+                CircuitBreakingConfig { max_requests: 0 },
+            ),
+        );
+        cache.update_endpoints(
+            cluster_name,
+            make_test_endpoints(cluster_name, &servers[1..]),
+        );
+
+        let limited = tokio::time::timeout(
+            tokio::time::Duration::from_secs(2),
+            client.say_hello(HelloRequest {
+                name: "readded-limited".to_string(),
+            }),
+        )
+        .await
+        .expect("re-added cluster should become ready")
+        .unwrap_err();
+        assert_eq!(limited.code(), tonic::Code::Unavailable);
+        assert!(limited.message().contains("max_requests limit 0"));
+
+        cache.update_cluster(
+            cluster_name,
+            make_test_cluster_with_circuit_breaking(
+                cluster_name,
+                CircuitBreakingConfig { max_requests: 1 },
+            ),
+        );
+        tokio::task::yield_now().await;
+
+        let second = tokio::time::timeout(
+            tokio::time::Duration::from_secs(2),
+            client.say_hello(HelloRequest {
+                name: "after-readd".to_string(),
+            }),
+        )
+        .await
+        .expect("updated cluster should serve requests")
+        .unwrap();
+        assert!(second.into_inner().message.starts_with("server-1:"));
+
+        for server in servers {
+            let _ = server.shutdown.send(());
+            let _ = server.handle.await;
+        }
+    }
+
     /// Helper: creates a minimal plaintext `ClusterResource` for tests that
     /// drive `XdsClusterDiscovery`. The cluster watch in `discover_cluster`
     /// blocks until a cluster is in the cache.
     fn make_test_cluster(cluster_name: &str) -> Arc<crate::xds::resource::ClusterResource> {
+        make_test_cluster_with_circuit_breaking(cluster_name, CircuitBreakingConfig::default())
+    }
+
+    fn make_test_cluster_with_circuit_breaking(
+        cluster_name: &str,
+        circuit_breaking: CircuitBreakingConfig,
+    ) -> Arc<crate::xds::resource::ClusterResource> {
         use crate::xds::resource::cluster::{ClusterResource, LbPolicy};
         Arc::new(ClusterResource {
             name: cluster_name.to_string(),
             eds_service_name: None,
             lb_policy: LbPolicy::RoundRobin,
             security: None,
+            circuit_breaking,
         })
     }
 
@@ -981,7 +1264,7 @@ mod tests {
                     .unwrap(),
             );
             Arc::new(XdsClusterDiscovery::new(
-                cache,
+                cache.clone(),
                 GrpcMakeConnector::new(),
                 registry,
             ))
@@ -989,14 +1272,19 @@ mod tests {
         #[cfg(not(feature = "_tls-any"))]
         let discovery: Arc<
             dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>,
-        > = Arc::new(XdsClusterDiscovery::new(cache, GrpcMakeConnector::new()));
+        > = Arc::new(XdsClusterDiscovery::new(
+            cache.clone(),
+            GrpcMakeConnector::new(),
+        ));
 
         let builder = XdsChannelBuilder::new(test_config());
-        builder.build_grpc_channel_from_parts(
+        builder.build_grpc_channel_from_parts_with_circuit_breakers(
             router,
             discovery,
             Arc::new(RetrySharedConfig::grpc_default()),
             None,
+            ClusterCircuitBreakerRegistry::new_for_test(),
+            Some(cache),
         )
     }
 

--- a/tonic-xds/src/client/circuit_breaking.rs
+++ b/tonic-xds/src/client/circuit_breaking.rs
@@ -34,15 +34,23 @@ use std::task::{Context, Poll};
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
 use dashmap::DashMap;
+use futures_util::StreamExt as _;
 use http::{Request, Response};
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;
+use tokio::sync::watch;
 use tonic::body::Body as TonicBody;
-use tower::{BoxError, Layer, Service};
+use tower::Layer;
+use tower::discover::Change;
+use tower::load::Load;
+use tower::{BoxError, Service};
 
+use crate::client::lb::{BoxDiscover, ClusterDiscovery};
 use crate::client::route::RouteDecision;
-use crate::common::async_util::BoxFuture;
-use crate::xds::resource::circuit_breaking::CircuitBreakingConfig;
+use crate::common::async_util::{AbortOnDrop, BoxFuture};
+use crate::xds::cache::{CacheEvent, XdsCache};
+use crate::xds::resource::ClusterResource;
+use crate::xds::resource::circuit_breaking::{CircuitBreakingConfig, DEFAULT_MAX_REQUESTS};
 
 static GLOBAL_COUNTERS: OnceLock<Arc<ClusterRequestCounterState>> = OnceLock::new();
 
@@ -85,6 +93,12 @@ impl ClusterCircuitBreakerRegistry {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn set_config(&self, cluster: impl Into<String>, config: CircuitBreakingConfig) {
+        let cluster = cluster.into();
+        self.set_cluster_config(cluster.clone(), cluster, config);
+    }
+
     pub(crate) fn set_cluster_config(
         &self,
         cluster: impl Into<String>,
@@ -103,7 +117,67 @@ impl ClusterCircuitBreakerRegistry {
                 counter_key,
                 counter,
             },
+            0,
         );
+    }
+
+    fn ensure_cluster_watch(
+        &self,
+        cache: &Arc<XdsCache>,
+        cluster: &str,
+        state: &Arc<ClusterCircuitBreakerState>,
+    ) -> u64 {
+        let mut lifecycle = state
+            .watch_lifecycle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if lifecycle.running {
+            return lifecycle.generation;
+        }
+
+        let mut cluster_watch = cache.watch_cluster(cluster);
+        lifecycle.generation = lifecycle.generation.wrapping_add(1).max(1);
+        let generation = lifecycle.generation;
+        lifecycle.running = true;
+        state
+            .active_watch_generation
+            .store(generation, Ordering::Release);
+
+        let weak_registry = Arc::downgrade(&self.inner);
+        let weak_state = Arc::downgrade(state);
+        let task = tokio::spawn(async move {
+            while let Some(event) = cluster_watch.next_event().await {
+                let CacheEvent::Resource {
+                    resource: cluster_resource,
+                    ..
+                } = event
+                else {
+                    break;
+                };
+                let Some(inner) = weak_registry.upgrade() else {
+                    return;
+                };
+                let Some(state) = weak_state.upgrade() else {
+                    return;
+                };
+                let circuit_breakers = ClusterCircuitBreakerRegistry { inner };
+                let config = CircuitBreakerRuntimeConfig::from_cluster(
+                    &cluster_resource,
+                    &circuit_breakers.inner.counters,
+                );
+                circuit_breakers.update_state_config(&state, config, generation);
+            }
+
+            let Some(inner) = weak_registry.upgrade() else {
+                return;
+            };
+            let Some(state) = weak_state.upgrade() else {
+                return;
+            };
+            ClusterCircuitBreakerRegistry { inner }.finish_cluster_watch(&state, generation);
+        });
+        lifecycle._task = Some(AbortOnDrop(task));
+        generation
     }
 
     fn ensure_state(&self, cluster: &str) -> Arc<ClusterCircuitBreakerState> {
@@ -119,25 +193,60 @@ impl ClusterCircuitBreakerRegistry {
     }
 
     fn cluster_breaker(&self, cluster: &str) -> Arc<ClusterCircuitBreaker> {
+        self.cluster_breaker_with_optional_cache(cluster, None)
+    }
+
+    fn cluster_breaker_with_cache(
+        &self,
+        cluster: &str,
+        cluster_cache: Arc<XdsCache>,
+    ) -> Arc<ClusterCircuitBreaker> {
+        self.cluster_breaker_with_optional_cache(cluster, Some(cluster_cache))
+    }
+
+    fn cluster_breaker_with_optional_cache(
+        &self,
+        cluster: &str,
+        cluster_cache: Option<Arc<XdsCache>>,
+    ) -> Arc<ClusterCircuitBreaker> {
         let state = self.ensure_state(cluster);
-        Arc::new(ClusterCircuitBreaker {
-            cluster: Arc::from(cluster),
+        let cluster: Arc<str> = Arc::from(cluster);
+        let default_counter_key = CounterKey::same_cluster(cluster.clone());
+        let breaker = Arc::new(ClusterCircuitBreaker {
+            cluster,
             state,
             counters: self.inner.counters.clone(),
-        })
+            default_counter_key,
+            registry: self.clone(),
+            cluster_cache,
+        });
+        if let Some(cache) = breaker.cluster_cache.as_ref() {
+            self.ensure_cluster_watch(cache, &breaker.cluster, &breaker.state);
+        }
+        breaker
     }
 
     fn update_state_config(
         &self,
         state: &ClusterCircuitBreakerState,
         config: CircuitBreakerRuntimeConfig,
+        watch_generation: u64,
     ) {
         let _update_guard = state
             .update_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if watch_generation != 0
+            && state.active_watch_generation.load(Ordering::Acquire) != watch_generation
+        {
+            return;
+        }
         let previous = state.current_config();
         if previous.as_deref() == Some(&config) {
+            state
+                .config_watch_generation
+                .store(watch_generation, Ordering::Release);
+            state.notify_config_changed();
             return;
         }
 
@@ -153,6 +262,27 @@ impl ClusterCircuitBreakerRegistry {
         if counter_key_changed && let Some(previous) = previous {
             self.deactivate_config(previous);
         }
+        state
+            .config_watch_generation
+            .store(watch_generation, Ordering::Release);
+        state.notify_config_changed();
+    }
+
+    fn finish_cluster_watch(&self, state: &Arc<ClusterCircuitBreakerState>, generation: u64) {
+        let mut lifecycle = state
+            .watch_lifecycle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if lifecycle.generation != generation {
+            return;
+        }
+
+        self.clear_state(state);
+        state
+            .finished_watch_generation
+            .store(generation, Ordering::Release);
+        lifecycle.running = false;
+        state.notify_config_changed();
     }
 
     fn clear_state(&self, state: &ClusterCircuitBreakerState) {
@@ -163,6 +293,7 @@ impl ClusterCircuitBreakerRegistry {
         if let Some(previous) = state.config.swap(None) {
             self.deactivate_config(previous);
         }
+        state.config_watch_generation.store(0, Ordering::Release);
     }
 
     fn deactivate_config(&self, config: Arc<CircuitBreakerRuntimeConfig>) {
@@ -172,18 +303,16 @@ impl ClusterCircuitBreakerRegistry {
         self.inner.counters.cleanup_if_unused(&counter_key);
     }
 
-    fn acquire(&self, cluster: &str) -> Result<Option<CircuitBreakerPermit>, CircuitBreakerLimit> {
+    fn acquire(&self, cluster: &str) -> Result<CircuitBreakerPermit, CircuitBreakerLimit> {
         self.cluster_breaker(cluster).acquire()
     }
 
     #[cfg(test)]
     fn in_flight(&self, cluster: &str) -> u32 {
         let breaker = self.cluster_breaker(cluster);
-        breaker
-            .state
-            .current_config()
-            .map(|config| self.inner.counters.in_flight(&config.counter_key))
-            .unwrap_or(0)
+        self.inner
+            .counters
+            .in_flight(&breaker.current_counter_key())
     }
 
     #[cfg(test)]
@@ -236,6 +365,18 @@ impl PartialEq for CircuitBreakerRuntimeConfig {
 
 impl Eq for CircuitBreakerRuntimeConfig {}
 
+impl CircuitBreakerRuntimeConfig {
+    fn from_cluster(cluster: &ClusterResource, counters: &ClusterRequestCounters) -> Self {
+        let counter_key = CounterKey::new(cluster.name.as_str(), cluster.eds_service_name());
+        let counter = counters.counter(&counter_key);
+        Self {
+            max_requests: cluster.circuit_breaking.max_requests,
+            counter_key,
+            counter,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct CounterKey {
     cluster: Arc<str>,
@@ -249,21 +390,58 @@ impl CounterKey {
             eds_service_name: eds_service_name.into(),
         }
     }
+
+    fn same_cluster(cluster: Arc<str>) -> Self {
+        Self {
+            cluster: cluster.clone(),
+            eds_service_name: cluster,
+        }
+    }
 }
 
 struct ClusterCircuitBreakerState {
     config: ArcSwapOption<CircuitBreakerRuntimeConfig>,
     update_lock: Mutex<()>,
     dropped_requests: AtomicU64,
+    watch_lifecycle: Mutex<ClusterWatchLifecycle>,
+    active_watch_generation: AtomicU64,
+    config_watch_generation: AtomicU64,
+    finished_watch_generation: AtomicU64,
+    config_version: watch::Sender<u64>,
+}
+
+#[derive(Default)]
+struct ClusterWatchLifecycle {
+    generation: u64,
+    running: bool,
+    _task: Option<AbortOnDrop>,
 }
 
 impl fmt::Debug for ClusterCircuitBreakerState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let watch_running = self
+            .watch_lifecycle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .running;
         f.debug_struct("ClusterCircuitBreakerState")
             .field("current_config", &self.current_config())
             .field(
                 "dropped_requests",
                 &self.dropped_requests.load(Ordering::Acquire),
+            )
+            .field("watch_running", &watch_running)
+            .field(
+                "active_watch_generation",
+                &self.active_watch_generation.load(Ordering::Acquire),
+            )
+            .field(
+                "config_watch_generation",
+                &self.config_watch_generation.load(Ordering::Acquire),
+            )
+            .field(
+                "finished_watch_generation",
+                &self.finished_watch_generation.load(Ordering::Acquire),
             )
             .finish()
     }
@@ -271,10 +449,16 @@ impl fmt::Debug for ClusterCircuitBreakerState {
 
 impl ClusterCircuitBreakerState {
     fn new() -> Self {
+        let (config_version, _) = watch::channel(0);
         Self {
             config: ArcSwapOption::empty(),
             update_lock: Mutex::new(()),
             dropped_requests: AtomicU64::new(0),
+            watch_lifecycle: Mutex::new(ClusterWatchLifecycle::default()),
+            active_watch_generation: AtomicU64::new(0),
+            config_watch_generation: AtomicU64::new(0),
+            finished_watch_generation: AtomicU64::new(0),
+            config_version,
         }
     }
 
@@ -286,23 +470,76 @@ impl ClusterCircuitBreakerState {
         self.dropped_requests.fetch_add(1, Ordering::AcqRel);
     }
 
+    fn notify_config_changed(&self) {
+        self.config_version
+            .send_modify(|version| *version = version.wrapping_add(1));
+    }
+
     #[cfg(test)]
     fn dropped_requests(&self) -> u64 {
         self.dropped_requests.load(Ordering::Acquire)
     }
 }
 
-#[derive(Debug)]
 struct ClusterCircuitBreaker {
     cluster: Arc<str>,
     state: Arc<ClusterCircuitBreakerState>,
     counters: ClusterRequestCounters,
+    default_counter_key: CounterKey,
+    registry: ClusterCircuitBreakerRegistry,
+    cluster_cache: Option<Arc<XdsCache>>,
+}
+
+impl fmt::Debug for ClusterCircuitBreaker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClusterCircuitBreaker")
+            .field("cluster", &self.cluster)
+            .field("state", &self.state)
+            .field("watching_cluster_cache", &self.cluster_cache.is_some())
+            .finish()
+    }
 }
 
 impl ClusterCircuitBreaker {
-    fn acquire(&self) -> Result<Option<CircuitBreakerPermit>, CircuitBreakerLimit> {
-        let Some(config) = self.state.current_config() else {
-            return Ok(None);
+    fn acquire(&self) -> Result<CircuitBreakerPermit, CircuitBreakerLimit> {
+        if let Some(config) = self.state.current_config() {
+            return self.acquire_with_config(
+                config.counter_key.clone(),
+                config.counter.clone(),
+                config.max_requests,
+            );
+        }
+
+        let counter = self.counters.counter(&self.default_counter_key);
+        self.acquire_with_config(
+            self.default_counter_key.clone(),
+            counter,
+            DEFAULT_MAX_REQUESTS,
+        )
+    }
+
+    async fn acquire_when_ready(&self) -> Result<CircuitBreakerPermit, Response<TonicBody>> {
+        let Some(cache) = self.cluster_cache.as_ref() else {
+            return self
+                .acquire()
+                .map_err(|limit| limit_exceeded_response(&self.cluster, limit));
+        };
+
+        if let Some(config) = self.current_watched_config() {
+            return self
+                .acquire_with_config(
+                    config.counter_key.clone(),
+                    config.counter.clone(),
+                    config.max_requests,
+                )
+                .map_err(|limit| limit_exceeded_response(&self.cluster, limit));
+        }
+
+        let generation = self
+            .registry
+            .ensure_cluster_watch(cache, &self.cluster, &self.state);
+        let Some(config) = self.wait_for_config(generation).await else {
+            return Err(cluster_unavailable_response(&self.cluster));
         };
 
         self.acquire_with_config(
@@ -310,7 +547,49 @@ impl ClusterCircuitBreaker {
             config.counter.clone(),
             config.max_requests,
         )
-        .map(Some)
+        .map_err(|limit| limit_exceeded_response(&self.cluster, limit))
+    }
+
+    fn current_watched_config(&self) -> Option<Arc<CircuitBreakerRuntimeConfig>> {
+        let generation = self.state.active_watch_generation.load(Ordering::Acquire);
+        if generation == 0 {
+            return None;
+        }
+        self.watched_config_for_generation(generation)
+    }
+
+    fn watched_config_for_generation(
+        &self,
+        generation: u64,
+    ) -> Option<Arc<CircuitBreakerRuntimeConfig>> {
+        if self.state.config_watch_generation.load(Ordering::Acquire) != generation {
+            return None;
+        }
+        let config = self.state.current_config();
+        if self.state.active_watch_generation.load(Ordering::Acquire) == generation
+            && self.state.config_watch_generation.load(Ordering::Acquire) == generation
+        {
+            config
+        } else {
+            None
+        }
+    }
+
+    async fn wait_for_config(&self, generation: u64) -> Option<Arc<CircuitBreakerRuntimeConfig>> {
+        let mut config_version = self.state.config_version.subscribe();
+        loop {
+            if let Some(config) = self.watched_config_for_generation(generation) {
+                return Some(config);
+            }
+            if self.state.finished_watch_generation.load(Ordering::Acquire) == generation
+                || self.state.active_watch_generation.load(Ordering::Acquire) != generation
+            {
+                return None;
+            }
+            if config_version.changed().await.is_err() {
+                return None;
+            }
+        }
     }
 
     fn acquire_with_config(
@@ -327,6 +606,13 @@ impl ClusterCircuitBreaker {
                 Err(limit)
             }
         }
+    }
+
+    fn current_counter_key(&self) -> CounterKey {
+        self.state
+            .current_config()
+            .map(|config| config.counter_key.clone())
+            .unwrap_or_else(|| self.default_counter_key.clone())
     }
 }
 
@@ -465,7 +751,7 @@ impl InFlightCounter {
 }
 
 #[derive(Debug)]
-struct CircuitBreakerPermit {
+pub(crate) struct CircuitBreakerPermit {
     counter: Option<Arc<InFlightCounter>>,
     counter_key: CounterKey,
     counters: ClusterRequestCounters,
@@ -482,6 +768,141 @@ impl Drop for CircuitBreakerPermit {
             }
         }
     }
+}
+
+#[derive(Clone)]
+pub(crate) struct CircuitBreakingClusterDiscovery<Endpoint, S> {
+    inner: Arc<dyn ClusterDiscovery<Endpoint, S>>,
+    circuit_breakers: ClusterCircuitBreakerRegistry,
+    cluster_cache: Option<Arc<XdsCache>>,
+}
+
+impl<Endpoint, S> CircuitBreakingClusterDiscovery<Endpoint, S> {
+    pub(crate) fn new(
+        inner: Arc<dyn ClusterDiscovery<Endpoint, S>>,
+        circuit_breakers: ClusterCircuitBreakerRegistry,
+    ) -> Self {
+        Self {
+            inner,
+            circuit_breakers,
+            cluster_cache: None,
+        }
+    }
+
+    pub(crate) fn with_cluster_cache(mut self, cache: Arc<XdsCache>) -> Self {
+        self.cluster_cache = Some(cache);
+        self
+    }
+}
+
+impl<Endpoint, S> fmt::Debug for CircuitBreakingClusterDiscovery<Endpoint, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircuitBreakingClusterDiscovery")
+            .field("circuit_breakers", &self.circuit_breakers)
+            .field("watching_cluster_cache", &self.cluster_cache.is_some())
+            .finish()
+    }
+}
+
+impl<Endpoint, S> ClusterDiscovery<Endpoint, CircuitBreakingEndpointService<S>>
+    for CircuitBreakingClusterDiscovery<Endpoint, S>
+where
+    Endpoint: Send + 'static,
+    S: Send + 'static,
+{
+    fn discover_cluster(
+        &self,
+        cluster_name: &str,
+    ) -> BoxDiscover<Endpoint, CircuitBreakingEndpointService<S>> {
+        let breaker = match self.cluster_cache.clone() {
+            Some(cache) => self
+                .circuit_breakers
+                .cluster_breaker_with_cache(cluster_name, cache),
+            None => self.circuit_breakers.cluster_breaker(cluster_name),
+        };
+        Box::pin(
+            self.inner
+                .discover_cluster(cluster_name)
+                .map(move |change| {
+                    change.map(|change| match change {
+                        Change::Insert(endpoint, service) => Change::Insert(
+                            endpoint,
+                            CircuitBreakingEndpointService::new(service, breaker.clone()),
+                        ),
+                        Change::Remove(endpoint) => Change::Remove(endpoint),
+                    })
+                }),
+        )
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CircuitBreakingEndpointService<S> {
+    inner: S,
+    breaker: Arc<ClusterCircuitBreaker>,
+}
+
+impl<S> CircuitBreakingEndpointService<S> {
+    fn new(inner: S, breaker: Arc<ClusterCircuitBreaker>) -> Self {
+        Self { inner, breaker }
+    }
+}
+
+impl<S: fmt::Debug> fmt::Debug for CircuitBreakingEndpointService<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircuitBreakingEndpointService")
+            .field("inner", &self.inner)
+            .field("breaker", &self.breaker)
+            .finish()
+    }
+}
+
+impl<S, B> Service<Request<B>> for CircuitBreakingEndpointService<S>
+where
+    S: Service<Request<B>, Response = Response<TonicBody>, Error: Into<BoxError>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<TonicBody>;
+    type Error = BoxError;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, request: Request<B>) -> Self::Future {
+        let breaker = self.breaker.clone();
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move {
+            let permit = match breaker.acquire_when_ready().await {
+                Ok(permit) => permit,
+                Err(response) => return Ok(response),
+            };
+
+            let response = inner.call(request).await.map_err(Into::into)?;
+            Ok(hold_permit(response, permit))
+        })
+    }
+}
+
+impl<S: Load> Load for CircuitBreakingEndpointService<S> {
+    type Metric = S::Metric;
+
+    fn load(&self) -> Self::Metric {
+        self.inner.load()
+    }
+}
+
+pub(crate) fn hold_permit(
+    response: Response<TonicBody>,
+    permit: CircuitBreakerPermit,
+) -> Response<TonicBody> {
+    response.map(|body| TonicBody::new(PermitBody::new(body, permit)))
 }
 
 /// Tower layer that enforces A32 max in-flight requests per xDS cluster.
@@ -598,12 +1019,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, clone);
         Box::pin(async move {
             let response = inner.call(request).await.map_err(Into::into)?;
-            match permit {
-                Some(permit) => {
-                    Ok(response.map(|body| TonicBody::new(PermitBody::new(body, permit))))
-                }
-                None => Ok(response),
-            }
+            Ok(response.map(|body| TonicBody::new(PermitBody::new(body, permit))))
         })
     }
 }
@@ -619,12 +1035,22 @@ enum CircuitBreakingError {
 /// The retry layer uses this extension to distinguish local `UNAVAILABLE` drops
 /// from retryable responses returned by an upstream service.
 #[derive(Clone, Copy, Debug)]
-struct LocalCircuitBreakerDrop;
+pub(crate) struct LocalCircuitBreakerDrop;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LocalPreEndpointResponse;
 
 pub(crate) fn is_local_circuit_breaker_drop<B>(response: &Response<B>) -> bool {
     response
         .extensions()
         .get::<LocalCircuitBreakerDrop>()
+        .is_some()
+}
+
+pub(crate) fn is_local_pre_endpoint_response<B>(response: &Response<B>) -> bool {
+    response
+        .extensions()
+        .get::<LocalPreEndpointResponse>()
         .is_some()
 }
 
@@ -634,6 +1060,15 @@ fn limit_exceeded_response(cluster: &str, limit: CircuitBreakerLimit) -> Respons
         limit.max_requests,
     )));
     response.extensions_mut().insert(LocalCircuitBreakerDrop);
+    response.extensions_mut().insert(LocalPreEndpointResponse);
+    response
+}
+
+fn cluster_unavailable_response(cluster: &str) -> Response<TonicBody> {
+    let mut response = status_response(tonic::Status::unavailable(format!(
+        "cluster '{cluster}' is no longer available",
+    )));
+    response.extensions_mut().insert(LocalPreEndpointResponse);
     response
 }
 
@@ -724,7 +1159,6 @@ mod tests {
     use super::*;
 
     const CLUSTER: &str = "cluster-a";
-    const EDS_SERVICE_NAME: &str = "eds-service-a";
 
     fn request() -> Request<TonicBody> {
         let mut request = Request::new(TonicBody::empty());
@@ -738,12 +1172,18 @@ mod tests {
 
     fn configured_breakers(max_requests: u32) -> ClusterCircuitBreakerRegistry {
         let breakers = ClusterCircuitBreakerRegistry::new_for_test();
-        breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests },
-        );
+        breakers.set_config(CLUSTER, CircuitBreakingConfig { max_requests });
         breakers
+    }
+
+    fn cluster_resource(max_requests: u32) -> Arc<ClusterResource> {
+        Arc::new(ClusterResource {
+            name: CLUSTER.to_string(),
+            eds_service_name: None,
+            lb_policy: crate::xds::resource::cluster::LbPolicy::RoundRobin,
+            security: None,
+            circuit_breaking: CircuitBreakingConfig { max_requests },
+        })
     }
 
     #[tokio::test]
@@ -819,11 +1259,7 @@ mod tests {
             .unwrap();
         assert_eq!(breakers.in_flight(CLUSTER), 2);
 
-        breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests: 1 },
-        );
+        breakers.set_config(CLUSTER, CircuitBreakingConfig { max_requests: 1 });
 
         let third = service
             .ready()
@@ -1020,24 +1456,16 @@ mod tests {
         let counters = ClusterRequestCounters::isolated();
         let first_breakers = ClusterCircuitBreakerRegistry::with_counters(counters.clone());
         let second_breakers = ClusterCircuitBreakerRegistry::with_counters(counters.clone());
-        first_breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests: 1 },
-        );
-        second_breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests: 1 },
-        );
+        first_breakers.set_config(CLUSTER, CircuitBreakingConfig { max_requests: 1 });
+        second_breakers.set_config(CLUSTER, CircuitBreakingConfig { max_requests: 1 });
 
-        let first = first_breakers.acquire(CLUSTER).unwrap().unwrap();
+        let first = first_breakers.acquire(CLUSTER).unwrap();
         assert!(second_breakers.acquire(CLUSTER).is_err());
         assert_eq!(first_breakers.dropped_requests(CLUSTER), 0);
         assert_eq!(second_breakers.dropped_requests(CLUSTER), 1);
 
         drop(first);
-        let second = second_breakers.acquire(CLUSTER).unwrap().unwrap();
+        let second = second_breakers.acquire(CLUSTER).unwrap();
         drop(second);
         drop(first_breakers);
         drop(second_breakers);
@@ -1045,28 +1473,87 @@ mod tests {
     }
 
     #[test]
-    fn unconfigured_cluster_has_no_limit_or_counter() {
+    fn default_limit_rejects_the_1025th_request() {
         let breakers = ClusterCircuitBreakerRegistry::new_for_test();
         let breaker = breakers.cluster_breaker(CLUSTER);
+        let permits: Vec<_> = (0..DEFAULT_MAX_REQUESTS)
+            .map(|_| breaker.acquire().unwrap())
+            .collect();
 
-        for _ in 0..2048 {
-            assert!(breaker.acquire().unwrap().is_none());
-        }
+        assert!(breaker.acquire().is_err());
+        assert_eq!(breakers.dropped_requests(CLUSTER), 1);
 
-        assert_eq!(breakers.dropped_requests(CLUSTER), 0);
+        drop(permits);
         assert_eq!(breakers.counter_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn endpoint_waiting_for_ready_does_not_hold_permit() {
+        let breakers = configured_breakers(1);
+        let service = BackpressuredService {
+            ready_budget: Arc::new(AtomicU32::new(0)),
+            calls: Arc::new(AtomicU32::new(0)),
+        };
+        let mut service =
+            CircuitBreakingEndpointService::new(service, breakers.cluster_breaker(CLUSTER));
+
+        let early =
+            tokio::time::timeout(tokio::time::Duration::from_millis(20), service.ready()).await;
+
+        assert!(
+            early.is_err(),
+            "endpoint wrapper should wait for inner endpoint readiness",
+        );
+        assert_eq!(breakers.in_flight(CLUSTER), 0);
+    }
+
+    #[tokio::test]
+    async fn endpoint_limit_responses_are_not_retried() {
+        use crate::client::retry::{GrpcRetryClassifier, RetryConfig};
+
+        let breakers = configured_breakers(0);
+        let calls = Arc::new(AtomicU32::new(0));
+        let call_counter = calls.clone();
+        let service = service_fn(
+            move |_request: Request<shared_http_body::SharedBody<TonicBody>>| {
+                call_counter.fetch_add(1, Ordering::SeqCst);
+                async { Ok::<_, BoxError>(Response::new(TonicBody::new(PendingBody))) }
+            },
+        );
+        let service =
+            CircuitBreakingEndpointService::new(service, breakers.cluster_breaker(CLUSTER));
+        let retry_policy = RetryPolicy::new(
+            RetryConfig::new().num_retries(1),
+            Arc::new(GrpcRetryClassifier::new(vec![tonic::Code::Unavailable])),
+        );
+        let mut service = tower::ServiceBuilder::new()
+            .layer(RetryLayer::new(retry_policy.into_shared()))
+            .service(service);
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(Request::new(TonicBody::empty()))
+            .await
+            .unwrap();
+        let status = tonic::Status::from_header_map(response.headers()).unwrap();
+
+        assert_eq!(status.code(), Code::Unavailable);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(breakers.dropped_requests(CLUSTER), 1);
     }
 
     #[test]
     fn eds_service_name_change_uses_independent_counter() {
         let breakers = ClusterCircuitBreakerRegistry::new_for_test();
         breakers.set_cluster_config(CLUSTER, "eds-a", CircuitBreakingConfig { max_requests: 1 });
-        let first = breakers.acquire(CLUSTER).unwrap().unwrap();
+        let first = breakers.acquire(CLUSTER).unwrap();
         assert_eq!(breakers.in_flight(CLUSTER), 1);
 
         breakers.set_cluster_config(CLUSTER, "eds-b", CircuitBreakingConfig { max_requests: 1 });
         assert_eq!(breakers.in_flight(CLUSTER), 0);
-        let second = breakers.acquire(CLUSTER).unwrap().unwrap();
+        let second = breakers.acquire(CLUSTER).unwrap();
         assert_eq!(breakers.in_flight(CLUSTER), 1);
         assert!(breakers.acquire(CLUSTER).is_err());
 
@@ -1093,7 +1580,7 @@ mod tests {
     #[test]
     fn cluster_removal_cleans_up_counter_after_in_flight_requests_finish() {
         let breakers = configured_breakers(1);
-        let permit = breakers.acquire(CLUSTER).unwrap().unwrap();
+        let permit = breakers.acquire(CLUSTER).unwrap();
         assert_eq!(breakers.counter_count(), 1);
 
         breakers.clear_cluster_config(CLUSTER);
@@ -1105,14 +1592,134 @@ mod tests {
 
     #[tokio::test]
     async fn cached_breaker_observes_cluster_removal_and_recreation() {
+        let cache = Arc::new(XdsCache::new());
+        cache.update_cluster(CLUSTER, cluster_resource(1));
+        let breakers = ClusterCircuitBreakerRegistry::new_for_test();
+        let breaker = breakers.cluster_breaker_with_cache(CLUSTER, cache.clone());
+
+        let first = breaker.acquire_when_ready().await.unwrap();
+        drop(first);
+
+        let generation = breaker
+            .state
+            .active_watch_generation
+            .load(Ordering::Acquire);
+        cache.remove_cluster(CLUSTER);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while breaker
+                .state
+                .finished_watch_generation
+                .load(Ordering::Acquire)
+                != generation
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cache.update_cluster(CLUSTER, cluster_resource(1));
+        let second = tokio::time::timeout(Duration::from_secs(1), breaker.acquire_when_ready())
+            .await
+            .expect("re-added cluster should wake the cached breaker")
+            .expect("re-added cluster should be available");
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn removal_before_watch_task_runs_wakes_waiting_request() {
+        let cache = Arc::new(XdsCache::new());
+        let breakers = ClusterCircuitBreakerRegistry::new_for_test();
+        let breaker = breakers.cluster_breaker_with_cache(CLUSTER, cache.clone());
+
+        cache.remove_cluster(CLUSTER);
+        let response = tokio::time::timeout(Duration::from_secs(1), breaker.acquire_when_ready())
+            .await
+            .expect("cluster removal should wake the request")
+            .expect_err("removed cluster should be unavailable");
+        let status = tonic::Status::from_header_map(response.headers()).unwrap();
+        assert_eq!(status.code(), Code::Unavailable);
+        assert!(is_local_pre_endpoint_response(&response));
+        assert!(!is_local_circuit_breaker_drop(&response));
+    }
+
+    #[tokio::test]
+    async fn waiting_request_does_not_cross_watch_generations() {
+        let cache = Arc::new(XdsCache::new());
+        let breakers = ClusterCircuitBreakerRegistry::new_for_test();
+        let breaker = breakers.cluster_breaker_with_cache(CLUSTER, cache.clone());
+        let old_generation = breaker
+            .state
+            .active_watch_generation
+            .load(Ordering::Acquire);
+        let mut old_request = Box::pin(breaker.acquire_when_ready());
+
+        std::future::poll_fn(|cx| {
+            assert!(matches!(old_request.as_mut().poll(cx), Poll::Pending));
+            Poll::Ready(())
+        })
+        .await;
+
+        cache.remove_cluster(CLUSTER);
+        cache.update_cluster(CLUSTER, cluster_resource(1));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while breaker
+                .state
+                .finished_watch_generation
+                .load(Ordering::Acquire)
+                != old_generation
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let new_permit = breaker.acquire_when_ready().await.unwrap();
+        drop(new_permit);
+
+        let response = old_request
+            .await
+            .expect_err("old request must not consume the re-added cluster config");
+        assert_eq!(
+            tonic::Status::from_header_map(response.headers())
+                .unwrap()
+                .code(),
+            Code::Unavailable,
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_cache_backed_breaker_releases_watcher_owners() {
+        let cache = Arc::new(XdsCache::new());
+        cache.update_cluster(CLUSTER, cluster_resource(1));
+        let breakers = ClusterCircuitBreakerRegistry::new_for_test();
+        let breaker = breakers.cluster_breaker_with_cache(CLUSTER, cache.clone());
+        let permit = breaker.acquire_when_ready().await.unwrap();
+        drop(permit);
+
+        let weak_cache = Arc::downgrade(&cache);
+        let weak_registry = Arc::downgrade(&breakers.inner);
+        drop(breaker);
+        drop(breakers);
+        drop(cache);
+        tokio::task::yield_now().await;
+
+        assert!(weak_cache.upgrade().is_none());
+        assert!(weak_registry.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn endpoint_holds_positive_limit_until_response_body_drops() {
         let breakers = configured_breakers(1);
         let calls = Arc::new(AtomicU32::new(0));
         let call_counter = calls.clone();
         let service = service_fn(move |_request: Request<TonicBody>| {
             call_counter.fetch_add(1, Ordering::SeqCst);
-            async { Ok::<_, BoxError>(Response::new(TonicBody::empty())) }
+            async { Ok::<_, BoxError>(Response::new(TonicBody::new(PendingBody))) }
         });
-        let mut service = CircuitBreakingLayer::new(breakers.clone()).layer(service);
+        let mut service =
+            CircuitBreakingEndpointService::new(service, breakers.cluster_breaker(CLUSTER));
 
         let first = service
             .ready()
@@ -1121,9 +1728,8 @@ mod tests {
             .call(request())
             .await
             .unwrap();
-        drop(first);
+        assert_eq!(breakers.in_flight(CLUSTER), 1);
 
-        breakers.clear_cluster_config(CLUSTER);
         let second = service
             .ready()
             .await
@@ -1131,14 +1737,13 @@ mod tests {
             .call(request())
             .await
             .unwrap();
-        assert!(tonic::Status::from_header_map(second.headers()).is_none());
-        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let status = tonic::Status::from_header_map(second.headers()).unwrap();
+        assert_eq!(status.code(), Code::Unavailable);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
 
-        breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests: 0 },
-        );
+        drop(first);
+        assert_eq!(breakers.in_flight(CLUSTER), 0);
+
         let third = service
             .ready()
             .await
@@ -1146,21 +1751,16 @@ mod tests {
             .call(request())
             .await
             .unwrap();
-        let status = tonic::Status::from_header_map(third.headers()).unwrap();
-        assert_eq!(status.code(), Code::Unavailable);
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+        drop(third);
     }
 
     #[test]
     fn dropping_breakers_releases_config_counter_ref() {
         let counters = ClusterRequestCounters::isolated();
         let breakers = ClusterCircuitBreakerRegistry::with_counters(counters.clone());
-        breakers.set_cluster_config(
-            CLUSTER,
-            EDS_SERVICE_NAME,
-            CircuitBreakingConfig { max_requests: 1 },
-        );
-        let permit = breakers.acquire(CLUSTER).unwrap().unwrap();
+        breakers.set_config(CLUSTER, CircuitBreakingConfig { max_requests: 1 });
+        let permit = breakers.acquire(CLUSTER).unwrap();
         drop(permit);
         assert_eq!(counters.counter_count(), 1);
 
@@ -1172,7 +1772,7 @@ mod tests {
     #[test]
     fn cleanup_keeps_counter_with_outstanding_clone() {
         let counters = ClusterRequestCounters::isolated();
-        let counter_key = CounterKey::new(CLUSTER, EDS_SERVICE_NAME);
+        let counter_key = CounterKey::new(CLUSTER, CLUSTER);
         let counter = counters.counter(&counter_key);
 
         counters.cleanup_if_unused(&counter_key);
@@ -1194,6 +1794,19 @@ mod tests {
 
         assert!(!Arc::ptr_eq(&first, &second));
         assert_eq!(counters.counter_count(), 2);
+    }
+
+    #[test]
+    fn cached_cluster_breaker_does_not_pin_default_counter() {
+        let counters = ClusterRequestCounters::isolated();
+        let breakers = ClusterCircuitBreakerRegistry::with_counters(counters.clone());
+        let breaker = breakers.cluster_breaker(CLUSTER);
+        let permit = breaker.acquire().unwrap();
+        assert_eq!(counters.counter_count(), 1);
+
+        drop(permit);
+        assert_eq!(counters.counter_count(), 0);
+        assert_eq!(breaker.cluster.as_ref(), CLUSTER);
     }
 
     #[tokio::test]

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -62,6 +62,7 @@ use tower::discover::{Change, Discover};
 
 use arc_swap::ArcSwap;
 
+use crate::client::circuit_breaking::is_local_pre_endpoint_response;
 use crate::client::endpoint::{Connector, EndpointAddress};
 use crate::client::loadbalance::channel_state::{
     EjectionConfig, IdleChannel, ReadyChannel, UnejectedChannel,
@@ -71,6 +72,36 @@ use crate::client::loadbalance::keyed_futures::KeyedFutures;
 use crate::client::loadbalance::outlier_detection::{OutlierDetector, OutlierStatsRegistry};
 use crate::client::loadbalance::pickers::ChannelPicker;
 use crate::xds::resource::outlier_detection::OutlierDetectionConfig;
+
+/// Lets the generic load balancer identify responses produced locally before
+/// the selected endpoint was called, so they do not affect that endpoint's
+/// outlier statistics.
+trait LbResponseOutcome {
+    /// Returns whether this response was produced before reaching the endpoint.
+    ///
+    /// The default treats responses as endpoint outcomes; response types that
+    /// carry a local-response marker can override this classification.
+    fn is_local_pre_endpoint_response(&self) -> bool {
+        false
+    }
+}
+
+impl<B> LbResponseOutcome for http::Response<B> {
+    fn is_local_pre_endpoint_response(&self) -> bool {
+        is_local_pre_endpoint_response(self)
+    }
+}
+
+/// Maps a completed call to an outlier-detection sample: `Some(true)` records
+/// endpoint success, `Some(false)` records endpoint failure, and `None`
+/// excludes a locally produced response from the endpoint's statistics.
+fn outlier_outcome<Resp: LbResponseOutcome, Error>(result: &Result<Resp, Error>) -> Option<bool> {
+    match result {
+        Ok(response) if response.is_local_pre_endpoint_response() => None,
+        Ok(_) => Some(true),
+        Err(_) => Some(false),
+    }
+}
 
 /// Future returned by [`LoadBalancer::call`]. Either resolves
 /// immediately with an [`LbError`] or drives the selected channel.
@@ -340,7 +371,7 @@ where
     D::Error: Into<tower::BoxError>,
     C: Connector + Send + Sync + 'static,
     C::Service: Service<Req> + Clone + Send + 'static,
-    <C::Service as Service<Req>>::Response: Send + 'static,
+    <C::Service as Service<Req>>::Response: LbResponseOutcome + Send + 'static,
     <C::Service as Service<Req>>::Error: Into<tower::BoxError>,
     <C::Service as Service<Req>>::Future: Send + 'static,
     Req: Send + 'static,
@@ -393,7 +424,9 @@ where
                 .await
                 .map_err(|e| LbError::LbChannelPollReadyError(e.into()))?;
             let result = svc.call(req).await;
-            svc.record_outcome(result.is_ok());
+            if let Some(success) = outlier_outcome(&result) {
+                svc.record_outcome(success);
+            }
             result.map_err(|e| LbError::LbChannelCallError(e.into()))
         }))
     }
@@ -402,6 +435,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::circuit_breaking::LocalPreEndpointResponse;
     use crate::client::endpoint::Connector;
     use crate::client::loadbalance::pickers::p2c::P2cPicker;
     use crate::common::async_util::BoxFuture;
@@ -466,6 +500,8 @@ mod tests {
             self.load.load(Ordering::Relaxed)
         }
     }
+
+    impl LbResponseOutcome for &'static str {}
 
     // -- Mock connector --
 
@@ -609,6 +645,22 @@ mod tests {
 
     fn remove(port: u16) -> DiscoverItem {
         Ok(Change::Remove(addr(port)))
+    }
+
+    #[test]
+    fn circuit_breaker_drops_are_not_endpoint_outlier_outcomes() {
+        let normal: Result<http::Response<()>, tower::BoxError> = Ok(http::Response::new(()));
+        assert_eq!(outlier_outcome(&normal), Some(true));
+
+        let mut dropped_response = http::Response::new(());
+        dropped_response
+            .extensions_mut()
+            .insert(LocalPreEndpointResponse);
+        let dropped: Result<http::Response<()>, tower::BoxError> = Ok(dropped_response);
+        assert_eq!(outlier_outcome(&dropped), None);
+
+        let error: Result<http::Response<()>, tower::BoxError> = Err("endpoint error".into());
+        assert_eq!(outlier_outcome(&error), Some(false));
     }
 
     /// A burst of inserts drained in one poll rebuilds the ring exactly once,

--- a/tonic-xds/src/xds/cache.rs
+++ b/tonic-xds/src/xds/cache.rs
@@ -35,42 +35,183 @@ use tokio::sync::watch;
 
 use crate::xds::resource::{ClusterResource, EndpointsResource, RouteConfigResource};
 
-/// A wrapper around [`watch::Receiver`] that exposes only a single `next()`
-/// method, preventing misuse of the raw watch API.
+enum WatchValue<T> {
+    Pending {
+        generation: u64,
+        revision: u64,
+    },
+    Resource {
+        generation: u64,
+        revision: u64,
+        resource: Arc<T>,
+    },
+    Removed {
+        generation: u64,
+        revision: u64,
+    },
+}
+
+impl<T> Clone for WatchValue<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Pending {
+                generation,
+                revision,
+            } => Self::Pending {
+                generation: *generation,
+                revision: *revision,
+            },
+            Self::Resource {
+                generation,
+                revision,
+                resource,
+            } => Self::Resource {
+                generation: *generation,
+                revision: *revision,
+                resource: Arc::clone(resource),
+            },
+            Self::Removed {
+                generation,
+                revision,
+            } => Self::Removed {
+                generation: *generation,
+                revision: *revision,
+            },
+        }
+    }
+}
+
+impl<T> WatchValue<T> {
+    fn generation(&self) -> u64 {
+        match self {
+            Self::Pending { generation, .. }
+            | Self::Resource { generation, .. }
+            | Self::Removed { generation, .. } => *generation,
+        }
+    }
+
+    fn revision(&self) -> u64 {
+        match self {
+            Self::Pending { revision, .. }
+            | Self::Resource { revision, .. }
+            | Self::Removed { revision, .. } => *revision,
+        }
+    }
+}
+
+pub(crate) enum CacheEvent<T> {
+    Resource {
+        generation: u64,
+        revision: u64,
+        resource: Arc<T>,
+    },
+    Removed,
+}
+
+/// A wrapper around [`watch::Receiver`] that preserves resource-removal events.
 pub(crate) struct CacheWatch<T> {
-    rx: watch::Receiver<Option<Arc<T>>>,
+    rx: watch::Receiver<WatchValue<T>>,
+    generation: u64,
+    revision: u64,
+    pending_resource: Option<(u64, u64, Arc<T>)>,
 }
 
 impl<T> CacheWatch<T> {
-    fn new(mut rx: watch::Receiver<Option<Arc<T>>>) -> Self {
+    fn new(mut rx: watch::Receiver<WatchValue<T>>) -> Self {
+        let generation = rx.borrow().generation();
+        let revision = rx.borrow().revision();
         // Ensure late watchers see the existing value on first next().
         rx.mark_changed();
-        Self { rx }
+        Self {
+            rx,
+            generation,
+            revision,
+            pending_resource: None,
+        }
     }
 
     /// Waits for the next resource update and returns it.
     ///
-    /// Returns `None` if the sender was dropped (resource removed from cache).
+    /// Resource removals are skipped; use [`Self::next_event`] when they must be
+    /// observed. Returns `None` only when the cache is dropped.
     pub(crate) async fn next(&mut self) -> Option<Arc<T>> {
+        while let Some(event) = self.next_event().await {
+            if let CacheEvent::Resource { resource, .. } = event {
+                return Some(resource);
+            }
+        }
+        None
+    }
+
+    /// Waits for the next resource update or removal.
+    pub(crate) async fn next_event(&mut self) -> Option<CacheEvent<T>> {
+        if let Some((generation, revision, resource)) = self.pending_resource.take() {
+            return Some(CacheEvent::Resource {
+                generation,
+                revision,
+                resource,
+            });
+        }
+
         loop {
             if self.rx.changed().await.is_err() {
                 return None;
             }
-            let val = self.rx.borrow_and_update().clone();
-            if val.is_some() {
-                return val;
+            match self.rx.borrow_and_update().clone() {
+                WatchValue::Pending {
+                    generation,
+                    revision,
+                } => {
+                    self.generation = generation;
+                    self.revision = revision;
+                }
+                WatchValue::Resource {
+                    generation,
+                    revision,
+                    resource,
+                } if generation != self.generation => {
+                    self.generation = generation;
+                    self.revision = revision;
+                    self.pending_resource = Some((generation, revision, resource));
+                    return Some(CacheEvent::Removed);
+                }
+                WatchValue::Resource {
+                    generation,
+                    revision,
+                    resource,
+                } => {
+                    self.generation = generation;
+                    self.revision = revision;
+                    return Some(CacheEvent::Resource {
+                        generation,
+                        revision,
+                        resource,
+                    });
+                }
+                WatchValue::Removed {
+                    generation,
+                    revision,
+                } => {
+                    self.generation = generation;
+                    self.revision = revision;
+                    return Some(CacheEvent::Removed);
+                }
             }
         }
+    }
+
+    pub(crate) fn current_revision(&self) -> u64 {
+        self.rx.borrow().revision()
     }
 }
 
 /// A keyed collection of [`watch`] channels for a single xDS resource type.
 ///
 /// Each entry is lazily created on first access (watch or update) and
-/// starts with `None`. Writers call [`update`](Self::update) to set the value;
-/// consumers call [`watch`](Self::watch) to receive changes.
+/// starts pending. Removed entries remain as tombstones so late watchers do not
+/// mistake a known removal for a resource that has not arrived yet.
 struct WatchMap<T> {
-    inner: DashMap<String, watch::Sender<Option<Arc<T>>>>,
+    inner: DashMap<String, watch::Sender<WatchValue<T>>>,
 }
 
 impl<T> WatchMap<T> {
@@ -85,7 +226,13 @@ impl<T> WatchMap<T> {
     /// Lazily creates the watch channel if this is the first access for the key.
     fn update(&self, key: &str, value: Arc<T>) {
         let tx = self.ensure(key);
-        tx.send_replace(Some(value));
+        tx.send_modify(move |current| {
+            *current = WatchValue::Resource {
+                generation: current.generation(),
+                revision: current.revision().wrapping_add(1),
+                resource: value,
+            };
+        });
     }
 
     /// Watches resource changes for the given key.
@@ -96,18 +243,28 @@ impl<T> WatchMap<T> {
         CacheWatch::new(tx.subscribe())
     }
 
-    /// Removes the watch channel for the given key.
-    ///
-    /// Dropping the sender closes all watcher receivers.
+    /// Marks the resource removed and notifies current and future watchers.
     fn remove(&self, key: &str) {
-        self.inner.remove(key);
+        let tx = self.ensure(key);
+        tx.send_modify(|current| {
+            *current = WatchValue::Removed {
+                generation: current.generation().wrapping_add(1),
+                revision: current.revision().wrapping_add(1),
+            };
+        });
     }
 
     /// Returns the sender for `key`, creating the watch channel if needed.
-    fn ensure(&self, key: &str) -> watch::Sender<Option<Arc<T>>> {
+    fn ensure(&self, key: &str) -> watch::Sender<WatchValue<T>> {
         self.inner
             .entry(key.to_string())
-            .or_insert_with(|| watch::channel(None).0)
+            .or_insert_with(|| {
+                watch::channel(WatchValue::Pending {
+                    generation: 0,
+                    revision: 0,
+                })
+                .0
+            })
             .value()
             .clone()
     }
@@ -124,7 +281,7 @@ impl<T> WatchMap<T> {
 ///   CDS readiness, then [`watch_endpoints`](Self::watch_endpoints) to track EDS updates.
 pub(crate) struct XdsCache {
     /// Active route configuration (from LDS inline or RDS).
-    route_config_tx: watch::Sender<Option<Arc<RouteConfigResource>>>,
+    route_config_tx: watch::Sender<WatchValue<RouteConfigResource>>,
 
     /// Per-cluster CDS state with readiness gating.
     clusters: WatchMap<ClusterResource>,
@@ -136,7 +293,10 @@ pub(crate) struct XdsCache {
 impl XdsCache {
     /// Creates a new empty cache with no resources.
     pub(crate) fn new() -> Self {
-        let (route_config_tx, _) = watch::channel(None);
+        let (route_config_tx, _) = watch::channel(WatchValue::Pending {
+            generation: 0,
+            revision: 0,
+        });
         Self {
             route_config_tx,
             clusters: WatchMap::new(),
@@ -146,7 +306,13 @@ impl XdsCache {
 
     /// Updates the active route configuration and notifies all watchers.
     pub(crate) fn update_route_config(&self, config: Arc<RouteConfigResource>) {
-        self.route_config_tx.send_replace(Some(config));
+        self.route_config_tx.send_modify(move |current| {
+            *current = WatchValue::Resource {
+                generation: current.generation(),
+                revision: current.revision().wrapping_add(1),
+                resource: config,
+            };
+        });
     }
 
     /// Watches route configuration changes.
@@ -216,11 +382,14 @@ mod tests {
     }
 
     fn make_cluster(name: &str, lb: LbPolicy) -> Arc<ClusterResource> {
+        use crate::xds::resource::circuit_breaking::CircuitBreakingConfig;
+
         Arc::new(ClusterResource {
             name: name.to_string(),
             eds_service_name: None,
             lb_policy: lb,
             security: None,
+            circuit_breaking: CircuitBreakingConfig::default(),
         })
     }
 
@@ -280,14 +449,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cluster_remove_closes_watcher() {
+    async fn cluster_remove_notifies_watcher() {
         let cache = XdsCache::new();
         let mut watch = cache.watch_cluster("c1");
         cache.update_cluster("c1", make_cluster("c1", LbPolicy::RoundRobin));
         watch.next().await; // consume
 
         cache.remove_cluster("c1");
-        assert!(watch.next().await.is_none());
+        assert!(matches!(
+            watch.next_event().await,
+            Some(CacheEvent::Removed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn late_cluster_watcher_observes_removal_and_readd() {
+        let cache = XdsCache::new();
+        cache.remove_cluster("c1");
+
+        let mut event_watch = cache.watch_cluster("c1");
+        assert!(matches!(
+            event_watch.next_event().await,
+            Some(CacheEvent::Removed)
+        ));
+
+        let mut standard_watch = cache.watch_cluster("c1");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), standard_watch.next())
+                .await
+                .is_err(),
+            "generic late watchers should await a future re-add",
+        );
+
+        cache.update_cluster("c1", make_cluster("c1", LbPolicy::LeastRequest));
+        let cluster = standard_watch.next().await.unwrap();
+        assert_eq!(cluster.lb_policy, LbPolicy::LeastRequest);
+    }
+
+    #[tokio::test]
+    async fn watcher_preserves_coalesced_removal_before_readd() {
+        let cache = XdsCache::new();
+        let mut watch = cache.watch_cluster("c1");
+        cache.update_cluster("c1", make_cluster("c1", LbPolicy::RoundRobin));
+        watch.next().await.unwrap();
+
+        cache.remove_cluster("c1");
+        cache.update_cluster("c1", make_cluster("c1", LbPolicy::LeastRequest));
+
+        assert!(matches!(
+            watch.next_event().await,
+            Some(CacheEvent::Removed)
+        ));
+        let Some(CacheEvent::Resource {
+            resource: cluster, ..
+        }) = watch.next_event().await
+        else {
+            panic!("expected re-added cluster after removal");
+        };
+        assert_eq!(cluster.lb_policy, LbPolicy::LeastRequest);
     }
 
     #[tokio::test]
@@ -315,14 +534,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_endpoints_closes_watchers() {
+    async fn remove_endpoints_notifies_watchers() {
         let cache = XdsCache::new();
         let mut watch = cache.watch_endpoints("c1");
         cache.update_endpoints("c1", make_endpoints("c1"));
         watch.next().await; // consume
 
         cache.remove_endpoints("c1");
-        assert!(watch.next().await.is_none());
+        assert!(matches!(
+            watch.next_event().await,
+            Some(CacheEvent::Removed)
+        ));
     }
 
     #[tokio::test]

--- a/tonic-xds/src/xds/cluster_discovery.rs
+++ b/tonic-xds/src/xds/cluster_discovery.rs
@@ -29,8 +29,8 @@
 //!
 //! 1. The cluster resource watch — produces a fresh [`Connector`] on each
 //!    CDS update (e.g. when `transport_socket` changes). The connector is
-//!    held inside a [`ConnectorSwap`] so the diff loop reads the latest
-//!    snapshot per endpoint connection.
+//!    published with its cache generation so re-added endpoints cannot use
+//!    transport settings from the removed cluster generation.
 //! 2. The endpoint watch — produces `Change::Insert` / `Change::Remove`
 //!    events forwarded to the LB layer.
 //!
@@ -40,8 +40,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use arc_swap::ArcSwap;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::{Channel, Endpoint};
@@ -54,10 +53,10 @@ use crate::client::endpoint::{
 use crate::client::endpoint::{ClusterTlsConfig, ClusterTlsError};
 use crate::client::lb::{BoxDiscover, ClusterDiscovery};
 use crate::common::async_util::BoxFuture;
-use crate::xds::cache::XdsCache;
+use crate::xds::cache::{CacheEvent, XdsCache};
 #[cfg(feature = "_tls-any")]
 use crate::xds::cert_provider::{CertProviderRegistry, CertificateProvider};
-use crate::xds::endpoint_manager::{ConnectorSwap, EndpointManager};
+use crate::xds::endpoint_manager::{ConnectorState, EndpointManager};
 
 /// Buffer capacity for the discovery channel between the spawned task and
 /// Tower's LB layer.
@@ -141,9 +140,21 @@ impl<MC: MakeConnector> ClusterDiscovery<EndpointAddress, MC::Service> for XdsCl
         tokio::spawn(async move {
             let mut cluster_watch = cache.watch_cluster(&cluster_name);
 
-            let connector_swap: ConnectorSwap<MC::Service> = loop {
-                let Some(cluster) = cluster_watch.next().await else {
+            let (generation, connector) = loop {
+                let event = tokio::select! {
+                    _ = tx.closed() => return,
+                    event = cluster_watch.next_event() => event,
+                };
+                let Some(event) = event else {
                     return;
+                };
+                let CacheEvent::Resource {
+                    generation,
+                    resource: cluster,
+                    ..
+                } = event
+                else {
+                    continue;
                 };
                 let cluster_config = ClusterConfig::from_resource(
                     &cluster,
@@ -151,7 +162,7 @@ impl<MC: MakeConnector> ClusterDiscovery<EndpointAddress, MC::Service> for XdsCl
                     &registry,
                 );
                 match make_connector.make_connector(cluster_config) {
-                    Ok(c) => break Arc::new(ArcSwap::from_pointee(c)),
+                    Ok(connector) => break (generation, connector),
                     Err(e) => tracing::warn!(
                         cluster = %cluster_name,
                         error = %e,
@@ -160,29 +171,57 @@ impl<MC: MakeConnector> ClusterDiscovery<EndpointAddress, MC::Service> for XdsCl
                 }
             };
 
-            let manager = EndpointManager::new(Arc::clone(&connector_swap));
+            let (connector_tx, connector_rx) =
+                watch::channel(Arc::new(ConnectorState::new(generation, connector)));
+            let manager = EndpointManager::new(connector_rx);
             let mut endpoints = manager.discover_endpoints(cache.watch_endpoints(&cluster_name));
 
             loop {
                 tokio::select! {
+                    _ = tx.closed() => return,
                     Some(change) = endpoints.next() => {
                         if tx.send(change).await.is_err() {
                             return;
                         }
                     }
-                    Some(cluster) = cluster_watch.next() => {
+                    event = cluster_watch.next_event() => {
+                        let Some(event) = event else {
+                            return;
+                        };
+                        let CacheEvent::Resource {
+                            generation,
+                            resource: cluster,
+                            ..
+                        } = event
+                        else {
+                            continue;
+                        };
                         let cluster_config = ClusterConfig::from_resource(
                             &cluster,
                             #[cfg(feature = "_tls-any")]
                             &registry,
                         );
                         match make_connector.make_connector(cluster_config) {
-                            Ok(new) => connector_swap.store(Arc::new(new)),
-                            Err(e) => tracing::warn!(
-                                cluster = %cluster_name,
-                                error = %e,
-                                "CDS update rejected; keeping previous connector",
-                            ),
+                            Ok(connector) => {
+                                connector_tx.send_replace(Arc::new(ConnectorState::new(
+                                    generation,
+                                    connector,
+                                )));
+                            }
+                            Err(e) if connector_tx.borrow().generation() == generation => {
+                                tracing::warn!(
+                                    cluster = %cluster_name,
+                                    error = %e,
+                                    "CDS update rejected; keeping previous connector",
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    cluster = %cluster_name,
+                                    error = %e,
+                                    "re-added CDS update rejected; endpoints remain unavailable",
+                                );
+                            }
                         }
                     }
                     else => return,
@@ -363,6 +402,7 @@ impl Connector for TlsConnector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::xds::resource::circuit_breaking::CircuitBreakingConfig;
     use crate::xds::resource::cluster::{ClusterResource, LbPolicy};
 
     #[cfg(feature = "_tls-any")]
@@ -378,6 +418,7 @@ mod tests {
             eds_service_name: None,
             lb_policy: LbPolicy::RoundRobin,
             security: None,
+            circuit_breaking: CircuitBreakingConfig::default(),
         }
     }
 
@@ -388,6 +429,7 @@ mod tests {
             eds_service_name: None,
             lb_policy: LbPolicy::RoundRobin,
             security: Some(security),
+            circuit_breaking: CircuitBreakingConfig::default(),
         }
     }
 

--- a/tonic-xds/src/xds/endpoint_manager.rs
+++ b/tonic-xds/src/xds/endpoint_manager.rs
@@ -33,42 +33,55 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use arc_swap::ArcSwap;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tower::BoxError;
 use tower::discover::Change;
 
 use crate::client::endpoint::{Connector, EndpointAddress};
 use crate::client::lb::BoxDiscover;
-use crate::xds::cache::CacheWatch;
+use crate::xds::cache::{CacheEvent, CacheWatch};
 use crate::xds::resource::EndpointsResource;
 
 /// Buffer capacity for the endpoint change channel between the diff loop
 /// and Tower's load balancer.
 const ENDPOINT_CHANNEL_CAPACITY: usize = 64;
 
-/// An atomically-swappable [`Connector`] held by an [`EndpointManager`].
-///
-/// `XdsClusterDiscovery` stores a snapshot of the cluster's per-CDS-update
-/// connector here. The diff loop calls `load_full()` on every new endpoint
-/// so each connection picks up the latest snapshot. Existing endpoint
-/// channels keep their `EndpointChannel` instance (and any in-flight TLS
-/// session) — only freshly-discovered endpoints see the swapped value.
-pub(crate) type ConnectorSwap<S> = Arc<ArcSwap<Arc<dyn Connector<Service = S> + Send + Sync>>>;
+pub(crate) struct ConnectorState<S> {
+    generation: u64,
+    connector: Arc<dyn Connector<Service = S> + Send + Sync>,
+}
+
+impl<S> ConnectorState<S> {
+    pub(crate) fn new(
+        generation: u64,
+        connector: Arc<dyn Connector<Service = S> + Send + Sync>,
+    ) -> Self {
+        Self {
+            generation,
+            connector,
+        }
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
+pub(crate) type ConnectorWatch<S> = watch::Receiver<Arc<ConnectorState<S>>>;
 
 /// Converts endpoint cache watches into incremental [`Change`] streams.
 ///
 /// `EndpointManager` is a pure diff-and-connect component: the caller
 /// (typically `XdsClusterDiscovery`) obtains a [`CacheWatch`] from the
 /// [`XdsCache`](crate::xds::cache::XdsCache) and passes it here, plus a
-/// [`ConnectorSwap`] that the caller may swap on CDS updates.
+/// [`ConnectorWatch`] updated from CDS.
 pub(crate) struct EndpointManager<S: Send + 'static> {
-    connector: ConnectorSwap<S>,
+    connector: ConnectorWatch<S>,
 }
 
 impl<S: Send + 'static> EndpointManager<S> {
-    pub(crate) fn new(connector: ConnectorSwap<S>) -> Self {
+    pub(crate) fn new(connector: ConnectorWatch<S>) -> Self {
         Self { connector }
     }
 
@@ -84,9 +97,7 @@ impl<S: Send + 'static> EndpointManager<S> {
         let connector = self.connector.clone();
         let (tx, rx) = mpsc::channel(ENDPOINT_CHANNEL_CAPACITY);
 
-        // The spawned task exits naturally when either:
-        // - The CacheWatch closes (cache.remove_endpoints() drops the watch sender)
-        // - The receiver is dropped (consumer no longer reading Change events)
+        // The spawned task exits when the cache or the consumer is dropped.
         tokio::spawn(diff_loop(watch, connector, tx));
 
         Box::pin(ReceiverStream::new(rx))
@@ -100,19 +111,58 @@ impl<S: Send + 'static> EndpointManager<S> {
 /// new endpoints followed by `Remove` for gone ones.
 async fn diff_loop<S: Send + 'static>(
     mut watch: CacheWatch<EndpointsResource>,
-    connector: ConnectorSwap<S>,
+    mut connector: ConnectorWatch<S>,
     tx: mpsc::Sender<Result<Change<EndpointAddress, S>, BoxError>>,
 ) {
     let mut active: HashSet<EndpointAddress> = HashSet::new();
 
-    while let Some(endpoints) = watch.next().await {
+    'events: loop {
+        let event = tokio::select! {
+            _ = tx.closed() => return,
+            event = watch.next_event() => event,
+        };
+        let Some(event) = event else {
+            return;
+        };
+        let CacheEvent::Resource {
+            generation,
+            revision,
+            resource: endpoints,
+        } = event
+        else {
+            for removed in active.drain() {
+                if tx.send(Ok(Change::Remove(removed))).await.is_err() {
+                    return;
+                }
+            }
+            continue;
+        };
+        let connector = tokio::select! {
+            _ = tx.closed() => return,
+            connector = connector_for_generation(&mut connector, generation) => connector,
+        };
+        let Some(connector) = connector else {
+            continue;
+        };
+        if watch.current_revision() != revision {
+            continue;
+        }
+
         let new_set: HashSet<EndpointAddress> = endpoints
             .healthy_endpoints()
             .map(|ep| ep.address.clone())
             .collect();
+        let added: Vec<_> = new_set.difference(&active).cloned().collect();
+        let removed: Vec<_> = active.difference(&new_set).cloned().collect();
 
-        for added in new_set.difference(&active) {
-            let svc = connector.load_full().connect(added).await;
+        for added in added {
+            if watch.current_revision() != revision {
+                continue 'events;
+            }
+            let svc = connector.connect(&added).await;
+            if watch.current_revision() != revision {
+                continue 'events;
+            }
             if tx
                 .send(Ok(Change::Insert(added.clone(), svc)))
                 .await
@@ -120,15 +170,35 @@ async fn diff_loop<S: Send + 'static>(
             {
                 return;
             }
+            active.insert(added);
         }
 
-        for removed in active.difference(&new_set) {
+        for removed in removed {
+            if watch.current_revision() != revision {
+                continue 'events;
+            }
             if tx.send(Ok(Change::Remove(removed.clone()))).await.is_err() {
                 return;
             }
+            active.remove(&removed);
         }
+    }
+}
 
-        active = new_set;
+async fn connector_for_generation<S>(
+    connector: &mut ConnectorWatch<S>,
+    generation: u64,
+) -> Option<Arc<dyn Connector<Service = S> + Send + Sync>> {
+    loop {
+        let current = connector.borrow().clone();
+        match current.generation.cmp(&generation) {
+            std::cmp::Ordering::Equal => return Some(Arc::clone(&current.connector)),
+            std::cmp::Ordering::Greater => return None,
+            std::cmp::Ordering::Less => {}
+        }
+        if connector.changed().await.is_err() {
+            return None;
+        }
     }
 }
 
@@ -152,9 +222,18 @@ mod tests {
         }
     }
 
-    fn test_swap() -> ConnectorSwap<String> {
+    fn test_connector_channel(
+        generation: u64,
+    ) -> (
+        watch::Sender<Arc<ConnectorState<String>>>,
+        ConnectorWatch<String>,
+    ) {
         let conn: Arc<dyn Connector<Service = String> + Send + Sync> = Arc::new(StringConnector);
-        Arc::new(ArcSwap::from_pointee(conn))
+        watch::channel(Arc::new(ConnectorState::new(generation, conn)))
+    }
+
+    fn test_connector_watch() -> ConnectorWatch<String> {
+        test_connector_channel(0).1
     }
 
     fn make_endpoints(cluster: &str, addrs: &[(&str, u16)]) -> Arc<EndpointsResource> {
@@ -179,7 +258,7 @@ mod tests {
     #[tokio::test]
     async fn initial_endpoints_emitted_as_inserts() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints(
             "c1",
@@ -202,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn added_endpoint_emits_insert() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
 
@@ -223,7 +302,7 @@ mod tests {
     #[tokio::test]
     async fn removed_endpoint_emits_remove() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints(
             "c1",
@@ -247,7 +326,7 @@ mod tests {
     #[tokio::test]
     async fn unhealthy_endpoint_removed() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
 
@@ -276,9 +355,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_removal_closes_stream() {
+    async fn cache_removal_clears_endpoints_and_readd_recovers() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let (connector_tx, connector_rx) = test_connector_channel(0);
+        let manager = EndpointManager::new(connector_rx);
 
         cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
 
@@ -287,13 +367,58 @@ mod tests {
 
         cache.remove_endpoints("c1");
 
-        assert!(stream.next().await.is_none());
+        match stream.next().await.unwrap().unwrap() {
+            Change::Remove(addr) => assert_eq!(addr.to_string(), "10.0.0.1:8080"),
+            Change::Insert(..) => panic!("expected Remove after cache removal"),
+        }
+
+        let connector: Arc<dyn Connector<Service = String> + Send + Sync> =
+            Arc::new(StringConnector);
+        connector_tx.send_replace(Arc::new(ConnectorState::new(1, connector)));
+        cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
+        match stream.next().await.unwrap().unwrap() {
+            Change::Insert(addr, _) => assert_eq!(addr.to_string(), "10.0.0.1:8080"),
+            Change::Remove(..) => panic!("expected Insert after cache re-add"),
+        }
+    }
+
+    #[tokio::test]
+    async fn readded_endpoints_wait_for_matching_connector_generation() {
+        let cache = XdsCache::new();
+        let (connector_tx, connector_rx) = test_connector_channel(0);
+        let manager = EndpointManager::new(connector_rx);
+        cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
+        let mut stream = manager.discover_endpoints(cache.watch_endpoints("c1"));
+        let _ = stream.next().await; // consume initial insert
+
+        cache.remove_endpoints("c1");
+        cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.2", 8080)]));
+
+        match stream.next().await.unwrap().unwrap() {
+            Change::Remove(addr) => assert_eq!(addr.to_string(), "10.0.0.1:8080"),
+            Change::Insert(..) => panic!("expected old endpoint removal"),
+        }
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), stream.next())
+                .await
+                .is_err(),
+            "re-added endpoints must wait for their CDS connector generation",
+        );
+
+        cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.3", 8080)]));
+        let connector: Arc<dyn Connector<Service = String> + Send + Sync> =
+            Arc::new(StringConnector);
+        connector_tx.send_replace(Arc::new(ConnectorState::new(1, connector)));
+        match stream.next().await.unwrap().unwrap() {
+            Change::Insert(addr, _) => assert_eq!(addr.to_string(), "10.0.0.3:8080"),
+            Change::Remove(..) => panic!("expected re-added endpoint insert"),
+        }
     }
 
     #[tokio::test]
     async fn multiple_clusters_independent() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
         cache.update_endpoints("c2", make_endpoints("c2", &[("10.0.0.2", 9090)]));
@@ -314,7 +439,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_swap_emits_insert_then_remove() {
         let cache = XdsCache::new();
-        let manager = EndpointManager::new(test_swap());
+        let manager = EndpointManager::new(test_connector_watch());
 
         cache.update_endpoints("c1", make_endpoints("c1", &[("10.0.0.1", 8080)]));
 

--- a/tonic-xds/src/xds/resource/circuit_breaking.rs
+++ b/tonic-xds/src/xds/resource/circuit_breaking.rs
@@ -29,9 +29,7 @@
 //! because they are connection-pool or retry specific and do not apply to gRPC's
 //! A32 request limiter.
 //!
-//! Client-side limiter primitives can consume this config; production CDS wiring
-//! is added separately so validation only advertises support once enforcement is
-//! in the request path.
+//! `ClusterResource` carries this config to the client-side limiter.
 //!
 //! [gRFC A32]: https://github.com/grpc/proposal/blob/master/A32-xds-circuit-breaking.md
 

--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -30,6 +30,7 @@ use prost::Message;
 use xds_client::resource::TypeUrl;
 use xds_client::{Error, Resource};
 
+use super::circuit_breaking::CircuitBreakingConfig;
 use super::security::{ClusterSecurityConfig, parse_transport_socket};
 
 /// Validated Cluster resource.
@@ -44,6 +45,8 @@ pub(crate) struct ClusterResource {
     /// TLS security config parsed from `transport_socket`. `None` means the
     /// cluster uses plaintext connections.
     pub security: Option<ClusterSecurityConfig>,
+    /// Circuit-breaking config for the cluster.
+    pub circuit_breaking: CircuitBreakingConfig,
 }
 
 /// Load balancing policies.
@@ -91,12 +94,14 @@ impl Resource for ClusterResource {
         };
 
         let security = parse_transport_socket(message.transport_socket)?;
+        let circuit_breaking = CircuitBreakingConfig::from_proto(message.circuit_breakers.as_ref());
 
         Ok(ClusterResource {
             name,
             eds_service_name,
             lb_policy,
             security,
+            circuit_breaking,
         })
     }
 }
@@ -130,6 +135,7 @@ mod tests {
         assert_eq!(validated.name, "my-cluster");
         assert_eq!(validated.lb_policy, LbPolicy::RoundRobin);
         assert!(validated.eds_service_name.is_none());
+        assert_eq!(validated.circuit_breaking, CircuitBreakingConfig::default());
     }
 
     #[test]
@@ -164,6 +170,34 @@ mod tests {
         };
         let validated = ClusterResource::validate(cluster).unwrap();
         assert_eq!(validated.lb_policy, LbPolicy::LeastRequest);
+    }
+
+    #[test]
+    fn test_circuit_breaking_config() {
+        use envoy_types::pb::envoy::config::cluster::v3::CircuitBreakers;
+        use envoy_types::pb::envoy::config::cluster::v3::circuit_breakers::Thresholds;
+        use envoy_types::pb::envoy::config::core::v3::RoutingPriority;
+        use envoy_types::pb::google::protobuf::UInt32Value;
+
+        let cluster = Cluster {
+            name: "cb-cluster".to_string(),
+            lb_policy: cluster::LbPolicy::RoundRobin as i32,
+            circuit_breakers: Some(CircuitBreakers {
+                thresholds: vec![Thresholds {
+                    priority: RoutingPriority::Default as i32,
+                    max_requests: Some(UInt32Value { value: 7 }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let validated = ClusterResource::validate(cluster).unwrap();
+        assert_eq!(
+            validated.circuit_breaking,
+            CircuitBreakingConfig { max_requests: 7 },
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR connects gRFC A32 circuit breaking to the xDS request path in `tonic-xds`. The circuit breaker works like a shared pool of slots: before an endpoint attempt begins, the channel reserves one slot for the selected `{cluster, EDS service}`. The CDS `max_requests` value sets the pool size, with the A32 default of 1024 when the field is omitted. If no slot is available, the client returns a local, non-retryable gRPC `UNAVAILABLE` response without contacting an endpoint.

- Circuit-breaking limits follow live CDS updates. A permit stays reserved until the response body completes, errors, or is dropped, so the process-wide counter represents active RPC attempts across channels.
- Local circuit-breaker responses are identified as pre-endpoint outcomes. Retry handling does not retry them, and outlier detection does not count them as endpoint failures.
- The xDS cache preserves resource removals with generation and revision tracking. Removing CDS or EDS state clears obsolete breaker state and endpoints; re-added endpoints wait for a connector from the matching generation instead of reusing stale limits, connectors, or endpoint state.

When CDS omits `max_requests`, `tonic-xds` applies 1024 concurrent in-flight requests, matching [gRFC A32](https://github.com/grpc/proposal/blob/master/A32-xds-circuit-breaking.md), Envoy, Java, and Go. A control plane can effectively disable the breaker by sending an explicitly high `max_requests` value.

Part of #2444.

## Testing Done

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p tonic-xds circuit_breaking` — 33 passed, 0 failed, 378 filtered out.
