### PR TITLE
refactor(credentials): make ServerCredentials trait dyn-compatible

### DIFF
--- a/grpc/src/client/transport/http_connect/test.rs
+++ b/grpc/src/client/transport/http_connect/test.rs
@@ -94,7 +94,7 @@ async fn run_mock_tls_server(listener: TcpListener, creds: RustlsServerCredentia
     let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
     let runtime = GrpcRuntime::new(TokioRuntime::default());
     let handshake_res = creds
-        .accept(stream, runtime, private::Internal)
+        .accept(Box::new(stream), runtime, private::Internal)
         .await
         .unwrap();
 

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -45,7 +45,6 @@ use crate::credentials::server;
 use crate::credentials::server::ServerConnectionSecurityInfo;
 use crate::private;
 use crate::rt::BoxEndpoint;
-use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
 pub const PROTOCOL_NAME: &str = "local";
@@ -162,15 +161,14 @@ impl LocalServerCredentials {
     }
 }
 
+#[async_trait]
 impl ServerCredentials for LocalServerCredentials {
-    type Output<I> = I;
-
-    async fn accept<Input: GrpcEndpoint>(
+    async fn accept(
         &self,
-        source: Input,
+        source: BoxEndpoint,
         _runtime: GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<server::HandshakeOutput<Self::Output<Input>>, String> {
+    ) -> Result<server::HandshakeOutput, String> {
         let security_level =
             security_level_for_endpoint(source.get_peer_address(), source.get_network_type())?;
         Ok(server::HandshakeOutput {
@@ -321,7 +319,7 @@ mod test {
         let server_stream = StreamEndpoint::new_from_tcp(stream).unwrap();
 
         let output = creds
-            .accept(server_stream, runtime, private::Internal)
+            .accept(Box::new(server_stream), runtime, private::Internal)
             .await
             .unwrap();
         let endpoint = output.endpoint;
@@ -336,6 +334,58 @@ mod test {
             .await
             .unwrap();
         assert_eq!(&buf[..], b"hello grpc");
+
+        client_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_dyn_server_credential_dispatch() {
+        let creds = LocalServerCredentials::new();
+        let dyn_creds: Arc<dyn ServerCredentials> = Arc::new(creds);
+
+        let info = dyn_creds.info();
+        assert_eq!(info.security_protocol, "local");
+
+        let addr = "127.0.0.1:0";
+        let runtime = rt::default_runtime();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
+
+        let client_handle = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(server_addr).await.unwrap();
+            let data = b"hello dynamic grpc server";
+            stream.write_all(data).await.unwrap();
+
+            // Keep the connection alive for a bit so server can read
+            let mut buf = vec![0u8; 1];
+            let _ = stream.read(&mut buf).await;
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let server_stream = StreamEndpoint::new_from_tcp(stream).unwrap();
+
+        let result = dyn_creds
+            .accept(
+                Box::new(server_stream) as BoxEndpoint,
+                runtime,
+                private::Internal,
+            )
+            .await;
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let endpoint = output.endpoint;
+        let security_info = output.security;
+
+        assert_eq!(security_info.security_protocol(), "local");
+        assert_eq!(security_info.security_level(), SecurityLevel::NoSecurity);
+
+        let mut buf = vec![0u8; 25];
+        EndpointIoStream::new(endpoint)
+            .read_exact(&mut buf)
+            .await
+            .unwrap();
+        assert_eq!(&buf[..], b"hello dynamic grpc server");
 
         client_handle.abort();
     }

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -37,7 +37,6 @@
 
 pub mod call;
 pub(crate) mod client;
-pub(crate) mod dyn_wrapper;
 mod local;
 #[cfg(feature = "tls-rustls")]
 pub mod rustls;
@@ -56,7 +55,6 @@ use crate::credentials::client::HandshakeOutput;
 use crate::credentials::common::Authority;
 use crate::private;
 use crate::rt::BoxEndpoint;
-use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
 /// Client-side trait for all live gRPC wire protocols and supported transport
@@ -100,11 +98,8 @@ pub trait ChannelCredentials: Send + Sync + 'static {
 
 /// Server-side trait for all live gRPC wire protocols and supported
 /// transport security protocols (e.g., TLS, ALTS).
-#[trait_variant::make(Send)]
-pub trait ServerCredentials: Sync + 'static {
-    #[doc(hidden)]
-    type Output<I>;
-
+#[async_trait]
+pub trait ServerCredentials: Send + Sync + 'static {
     /// Provides the ProtocolInfo of these credentials.
     fn info(&self) -> &ProtocolInfo;
 
@@ -113,12 +108,12 @@ pub trait ServerCredentials: Sync + 'static {
     /// This method wraps the incoming raw `source` connection with the configured
     /// security protocol (e.g., TLS).
     #[doc(hidden)]
-    async fn accept<Input: GrpcEndpoint>(
+    async fn accept(
         &self,
-        source: Input,
+        source: BoxEndpoint,
         runtime: GrpcRuntime,
         token: private::Internal,
-    ) -> Result<server::HandshakeOutput<Self::Output<Input>>, String>;
+    ) -> Result<server::HandshakeOutput, String>;
 }
 
 /// Defines the level of protection provided by an established connection.

--- a/grpc/src/credentials/rustls/server/mod.rs
+++ b/grpc/src/credentials/rustls/server/mod.rs
@@ -55,8 +55,8 @@ use crate::credentials::rustls::tls_stream::TlsStream;
 use crate::credentials::server::HandshakeOutput;
 use crate::credentials::server::ServerConnectionSecurityInfo;
 use crate::private;
+use crate::rt::BoxEndpoint;
 use crate::rt::EndpointIoStream;
-use crate::rt::GrpcEndpoint;
 use crate::rt::GrpcRuntime;
 
 #[cfg(test)]
@@ -341,15 +341,14 @@ impl ProducesTickets for NoTicketer {
     }
 }
 
+#[tonic::async_trait]
 impl ServerCredentials for RustlsServerCredentials {
-    type Output<Input> = TlsStream<Input>;
-
-    async fn accept<Input: GrpcEndpoint>(
+    async fn accept(
         &self,
-        source: Input,
+        source: BoxEndpoint,
         _runtime: GrpcRuntime,
         _token: private::Internal,
-    ) -> Result<HandshakeOutput<Self::Output<Input>>, String> {
+    ) -> Result<HandshakeOutput, String> {
         let input_io = EndpointIoStream::new(source);
         let tls_stream = self
             .acceptor
@@ -369,7 +368,7 @@ impl ServerCredentials for RustlsServerCredentials {
         );
         let endpoint = TlsStream::new(RustlsStream::Server(tls_stream));
         Ok(HandshakeOutput {
-            endpoint,
+            endpoint: Box::new(endpoint),
             security: auth_info,
         })
     }

--- a/grpc/src/credentials/rustls/server/test.rs
+++ b/grpc/src/credentials/rustls/server/test.rs
@@ -74,7 +74,9 @@ async fn test_tls_server_handshake() {
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
-        let result = creds.accept(stream, runtime, private::Internal).await;
+        let result = creds
+            .accept(Box::new(stream), runtime, private::Internal)
+            .await;
         assert!(
             result.is_ok(),
             "Server handshake failed: {:?}",
@@ -130,7 +132,9 @@ async fn test_tls_server_handshake_no_alpn() {
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
-        let result = creds.accept(stream, runtime, private::Internal).await;
+        let result = creds
+            .accept(Box::new(stream), runtime, private::Internal)
+            .await;
         assert!(result.is_err(), "Server handshake should have failed");
     });
 
@@ -174,7 +178,9 @@ async fn test_tls_server_handshake_bad_alpn() {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
         let runtime = rt::default_runtime();
-        let result = creds.accept(stream, runtime, private::Internal).await;
+        let result = creds
+            .accept(Box::new(stream), runtime, private::Internal)
+            .await;
         assert!(result.is_err(), "Server handshake should have failed");
     });
 
@@ -212,7 +218,7 @@ async fn test_tls_handshake_alpn_h1_and_h2() {
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
         let runtime = rt::default_runtime();
         creds
-            .accept(stream, runtime, private::Internal)
+            .accept(Box::new(stream), runtime, private::Internal)
             .await
             .unwrap();
     });
@@ -257,7 +263,9 @@ async fn test_tls_server_mtls_require_fail() {
     let server_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
-        let result = creds.accept(stream, runtime, private::Internal).await;
+        let result = creds
+            .accept(Box::new(stream), runtime, private::Internal)
+            .await;
         assert!(result.is_err(), "Handshake should fail without client cert");
     });
 
@@ -309,7 +317,7 @@ async fn test_tls_server_mtls_success() {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
         let result = creds
-            .accept(stream, runtime, private::Internal)
+            .accept(Box::new(stream), runtime, private::Internal)
             .await
             .expect("Server handshake failed");
         let mut stream = EndpointIoStream::new(result.endpoint);
@@ -369,7 +377,7 @@ async fn test_tls_server_mtls_optional() {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
         let result = creds
-            .accept(stream, runtime, private::Internal)
+            .accept(Box::new(stream), runtime, private::Internal)
             .await
             .expect("Server handshake failed");
         let mut stream = EndpointIoStream::new(result.endpoint);
@@ -419,7 +427,7 @@ async fn test_tls_server_key_log() {
         let (stream, _) = listener.accept().await.unwrap();
         let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
         let result = creds
-            .accept(stream, runtime, private::Internal)
+            .accept(Box::new(stream), runtime, private::Internal)
             .await
             .expect("Server handshake failed");
         let mut stream = EndpointIoStream::new(result.endpoint);
@@ -473,7 +481,9 @@ async fn check_resumption_disabled(versions: Vec<&'static rustls::SupportedProto
             let (stream, _) = listener.accept().await.unwrap();
             let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
             let runtime = rt::default_runtime();
-            let result = creds.accept(stream, runtime, private::Internal).await;
+            let result = creds
+                .accept(Box::new(stream), runtime, private::Internal)
+                .await;
             assert!(result.is_ok());
             let stream = result.unwrap().endpoint;
             EndpointIoStream::new(stream)
@@ -549,7 +559,9 @@ async fn test_tls_server_sni() {
             let (stream, _) = listener.accept().await.unwrap();
             let stream = StreamEndpoint::new_from_tcp(stream).unwrap();
             let runtime = rt::default_runtime();
-            let result = creds.accept(stream, runtime, private::Internal).await;
+            let result = creds
+                .accept(Box::new(stream), runtime, private::Internal)
+                .await;
             assert!(
                 result.is_ok(),
                 "Server handshake failed: {:?}",

--- a/grpc/src/credentials/server.rs
+++ b/grpc/src/credentials/server.rs
@@ -24,9 +24,10 @@
 
 use crate::attributes::Attributes;
 use crate::credentials::SecurityLevel;
+use crate::rt::BoxEndpoint;
 
-pub struct HandshakeOutput<T> {
-    pub endpoint: T,
+pub struct HandshakeOutput {
+    pub endpoint: BoxEndpoint,
     pub security: ServerConnectionSecurityInfo,
 }
 


### PR DESCRIPTION
Mirror the ChannelCredentials dyn-compat treatment from upstream PR #2703:
- Remove associated type Output<I> and generic accept<Input>
- Use BoxEndpoint and #[async_trait] for object safety
- Delete DynServerCredentials bridge trait (dyn_wrapper.rs)
- Update LocalServerCredentials and RustlsServerCredendials impls