### PR TITLE
grpc: combine client and server SecurityInfo

### DIFF
--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -57,9 +57,9 @@ use crate::client::transport::SecurityOpts;
 use crate::client::transport::TransportOptions;
 use crate::client::transport::http_connect::HttpConnectHandshaker;
 use crate::core::Address;
+use crate::credentials::SecurityInfo;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
-use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::common::Authority;
 use crate::private;
 use crate::rt::GrpcRuntime;
@@ -86,7 +86,7 @@ impl Backoff for NopBackoff {
 
 struct ReadyState {
     service: Box<dyn DynInvoke>,
-    security_info: ChannelSecurityInfo,
+    security_info: SecurityInfo,
     authority: Authority,
 }
 

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -31,7 +31,7 @@ use crate::client::DynInvoke;
 use crate::client::Invoke;
 use crate::core::Address;
 use crate::credentials::ChannelCredentials;
-use crate::credentials::client::ChannelSecurityInfo;
+use crate::credentials::SecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
 use crate::rt::GrpcRuntime;
@@ -98,7 +98,7 @@ pub(crate) trait Transport: Sync {
     ) -> Result<
         (
             Self::Service,
-            ChannelSecurityInfo,
+            SecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -116,7 +116,7 @@ pub(crate) trait DynTransport: Send + Sync {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            ChannelSecurityInfo,
+            SecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -134,7 +134,7 @@ impl<T: Transport> DynTransport for T {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            ChannelSecurityInfo,
+            SecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -87,7 +87,7 @@ use crate::client::transport::registry::GLOBAL_TRANSPORT_REGISTRY;
 use crate::core::Address;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
-use crate::credentials::client::ChannelSecurityInfo;
+use crate::credentials::SecurityInfo;
 use crate::private;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::GrpcRuntime;
@@ -380,7 +380,7 @@ impl Transport for TransportBuilder {
     ) -> Result<
         (
             Self::Service,
-            ChannelSecurityInfo,
+            SecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -475,7 +475,7 @@ impl Transport for TransportBuilder {
             task_handle,
             runtime,
         };
-        Ok((service, handshake_ouput.security, rx))
+        Ok((service, handshake_ouput.security_info, rx))
     }
 }
 

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -853,7 +853,7 @@ impl ChannelCredentials for SlowChannelCredentials {
         runtime.sleep(self.sleep_duration).await;
         Ok(HandshakeOutput {
             endpoint: source,
-            security_info: SecurityInfo::new("mock").with_security_level(SecurityLevel::NoSecurity),
+            security_info: SecurityInfo::new("mock"),
             authority_validator: Box::new(MockConnectionAuthorityValidator),
         })
     }

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -76,14 +76,14 @@ use crate::credentials::ChannelCredentials;
 use crate::credentials::CompositeChannelCredentials;
 use crate::credentials::LocalChannelCredentials;
 use crate::credentials::ProtocolInfo;
+use crate::credentials::SecurityInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::call::CallCredentials;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo;
-use crate::credentials::client::ChannelSecurityContext;
-use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
+use crate::credentials::client::ValidateAuthority;
 use crate::credentials::common::Authority;
 use crate::credentials::rustls::RootCertificates;
 use crate::credentials::rustls::StaticProvider;
@@ -822,8 +822,8 @@ async fn tonic_transport_recv_drop_cancels_send() {
 }
 
 #[derive(Debug, Clone)]
-struct MockConnectionSecurityContext;
-impl ChannelSecurityContext for MockConnectionSecurityContext {
+struct MockConnectionAuthorityValidator;
+impl ValidateAuthority for MockConnectionAuthorityValidator {
     fn validate_authority(&self, _authority: &Authority) -> bool {
         true
     }
@@ -853,12 +853,8 @@ impl ChannelCredentials for SlowChannelCredentials {
         runtime.sleep(self.sleep_duration).await;
         Ok(HandshakeOutput {
             endpoint: source,
-            security: ChannelSecurityInfo::new(
-                "mock",
-                SecurityLevel::NoSecurity,
-                Box::new(MockConnectionSecurityContext),
-                Attributes::new(),
-            ),
+            security_info: SecurityInfo::new("mock").with_security_level(SecurityLevel::NoSecurity),
+            authority_validator: Box::new(MockConnectionAuthorityValidator),
         })
     }
 

--- a/grpc/src/credentials/client.rs
+++ b/grpc/src/credentials/client.rs
@@ -22,6 +22,7 @@
  *
  */
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use tonic::async_trait;
@@ -29,7 +30,7 @@ use tonic::async_trait;
 use crate::attributes::Attributes;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
-use crate::credentials::SecurityLevel;
+use crate::credentials::SecurityInfo;
 use crate::credentials::call::CallCredentials;
 use crate::credentials::call::CompositeCallCredentials;
 use crate::credentials::common::Authority;
@@ -39,10 +40,11 @@ use crate::rt::GrpcRuntime;
 
 pub struct HandshakeOutput {
     pub endpoint: BoxEndpoint,
-    pub security: ChannelSecurityInfo,
+    pub security_info: SecurityInfo,
+    pub authority_validator: Box<dyn ValidateAuthority>,
 }
 
-pub trait ChannelSecurityContext: Send + Sync + 'static {
+pub trait ValidateAuthority: Debug + Send + Sync + 'static {
     /// Checks if the established connection is authorized to send requests to
     /// the given authority.
     ///
@@ -59,50 +61,9 @@ pub trait ChannelSecurityContext: Send + Sync + 'static {
     }
 }
 
-impl ChannelSecurityContext for Box<dyn ChannelSecurityContext> {
+impl ValidateAuthority for Box<dyn ValidateAuthority> {
     fn validate_authority(&self, authority: &Authority) -> bool {
         (**self).validate_authority(authority)
-    }
-}
-
-/// Represents the security state of an established client-side connection.
-pub struct ChannelSecurityInfo {
-    security_protocol: &'static str,
-    security_level: SecurityLevel,
-    security_context: Box<dyn ChannelSecurityContext>,
-    /// Stores extra data derived from the underlying protocol.
-    attributes: Attributes,
-}
-
-impl ChannelSecurityInfo {
-    pub fn new(
-        security_protocol: &'static str,
-        security_level: SecurityLevel,
-        security_context: Box<dyn ChannelSecurityContext>,
-        attributes: Attributes,
-    ) -> Self {
-        Self {
-            security_protocol,
-            security_level,
-            security_context,
-            attributes,
-        }
-    }
-
-    pub fn security_protocol(&self) -> &'static str {
-        self.security_protocol
-    }
-
-    pub fn security_level(&self) -> SecurityLevel {
-        self.security_level
-    }
-
-    pub fn security_context(&self) -> &dyn ChannelSecurityContext {
-        &self.security_context
-    }
-
-    pub fn attributes(&self) -> &Attributes {
-        &self.attributes
     }
 }
 
@@ -188,6 +149,7 @@ mod tests {
 
     use super::*;
     use crate::StatusError;
+    use crate::credentials::SecurityLevel;
     use crate::credentials::call::CallCredentials;
     use crate::credentials::call::CallDetails;
     use crate::credentials::call::ClientConnectionSecurityInfo;
@@ -290,7 +252,10 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(output.security.security_level(), SecurityLevel::NoSecurity);
-        assert_eq!(output.security.security_protocol(), "local");
+        assert_eq!(
+            output.security_info.security_level(),
+            SecurityLevel::NoSecurity
+        );
+        assert_eq!(output.security_info.security_protocol(), "local");
     }
 }

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -28,21 +28,19 @@ use std::sync::Arc;
 
 use tonic::async_trait;
 
-use crate::attributes::Attributes;
 use crate::client::name_resolution::TCP_IP_NETWORK_TYPE;
 use crate::client::name_resolution::UNIX_NETWORK_TYPE;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
+use crate::credentials::SecurityInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::ServerCredentials;
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ChannelSecurityContext;
-use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
+use crate::credentials::client::ValidateAuthority;
 use crate::credentials::common::Authority;
 use crate::credentials::server;
-use crate::credentials::server::ServerConnectionSecurityInfo;
 use crate::private;
 use crate::rt::BoxEndpoint;
 use crate::rt::GrpcRuntime;
@@ -74,9 +72,9 @@ impl LocalChannelCredentials {
 /// An implementation of [`ClientConnectionSecurityContext`] for local
 /// connections.
 #[derive(Debug, Clone)]
-pub struct LocalConnectionSecurityContext;
+pub struct LocalConnectionAuthorityValidator;
 
-impl ChannelSecurityContext for LocalConnectionSecurityContext {
+impl ValidateAuthority for LocalConnectionAuthorityValidator {
     fn validate_authority(&self, _authority: &Authority) -> bool {
         true
     }
@@ -128,12 +126,8 @@ impl ChannelCredentials for LocalChannelCredentials {
             security_level_for_endpoint(source.get_peer_address(), source.get_network_type())?;
         Ok(HandshakeOutput {
             endpoint: source,
-            security: ChannelSecurityInfo::new(
-                PROTOCOL_NAME,
-                security_level,
-                Box::new(LocalConnectionSecurityContext),
-                Attributes::new(),
-            ),
+            security_info: SecurityInfo::new(PROTOCOL_NAME).with_security_level(security_level),
+            authority_validator: Box::new(LocalConnectionAuthorityValidator),
         })
     }
 
@@ -173,11 +167,7 @@ impl ServerCredentials for LocalServerCredentials {
             security_level_for_endpoint(source.get_peer_address(), source.get_network_type())?;
         Ok(server::HandshakeOutput {
             endpoint: source,
-            security: ServerConnectionSecurityInfo::new(
-                PROTOCOL_NAME,
-                security_level,
-                Attributes::new(),
-            ),
+            security: SecurityInfo::new(PROTOCOL_NAME).with_security_level(security_level),
         })
     }
 
@@ -263,7 +253,8 @@ mod test {
             .unwrap();
 
         let endpoint = output.endpoint;
-        let security_info = output.security;
+        let security_info = output.security_info;
+        let authority_validator = output.authority_validator;
 
         // Verify security info.
         assert_eq!(security_info.security_protocol(), "local");
@@ -286,11 +277,7 @@ mod test {
         assert_eq!(buf, test_data);
 
         // Validate arbitrary authority.
-        assert!(
-            security_info
-                .security_context()
-                .validate_authority(&authority)
-        );
+        assert!(authority_validator.validate_authority(&authority));
     }
 
     #[tokio::test]

--- a/grpc/src/credentials/local.rs
+++ b/grpc/src/credentials/local.rs
@@ -69,8 +69,8 @@ impl LocalChannelCredentials {
     }
 }
 
-/// An implementation of [`ClientConnectionSecurityContext`] for local
-/// connections.
+/// An implementation of [`ValidateAuthority`] for local connections, allowing
+/// any authority to be used.
 #[derive(Debug, Clone)]
 pub struct LocalConnectionAuthorityValidator;
 

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -49,6 +49,7 @@ pub use local::LocalChannelCredentials;
 pub use local::LocalServerCredentials;
 use tonic::async_trait;
 
+use crate::attributes::Attributes;
 use crate::credentials::call::CallCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
@@ -133,6 +134,51 @@ pub enum SecurityLevel {
     ///
     /// This is the standard level for secure transports like TLS.
     PrivacyAndIntegrity,
+}
+
+/// Represents the security state of an established connection.
+pub struct SecurityInfo {
+    security_protocol: &'static str,
+    security_level: SecurityLevel,
+    /// Stores extra data derived from the underlying protocol.
+    attributes: Attributes,
+}
+
+impl SecurityInfo {
+    /// Creates a new SecurityInfo with ajdfskjklfdsjklsdfajklsfdajk
+    pub fn new(security_protocol: &'static str) -> Self {
+        Self {
+            security_protocol,
+            security_level: SecurityLevel::NoSecurity,
+            attributes: Attributes::new(),
+        }
+    }
+
+    /// Sets the security level of this `SecurityInfo`.
+    pub fn with_security_level(mut self, security_level: SecurityLevel) -> Self {
+        self.security_level = security_level;
+        self
+    }
+
+    /// Returns the security protocol of this `SecurityInfo`.
+    pub fn security_protocol(&self) -> &'static str {
+        self.security_protocol
+    }
+
+    /// Returns the security level of this `SecurityInfo`.
+    pub fn security_level(&self) -> SecurityLevel {
+        self.security_level
+    }
+
+    /// Returns the attributes of this `SecurityInfo`.
+    pub fn attributes(&self) -> &Attributes {
+        &self.attributes
+    }
+
+    /// Returns the mutable attributes of this `SecurityInfo`.
+    pub fn attributes_mut(&mut self) -> &mut Attributes {
+        &mut self.attributes
+    }
 }
 
 pub(crate) mod common {

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -145,7 +145,7 @@ pub struct SecurityInfo {
 }
 
 impl SecurityInfo {
-    /// Creates a new SecurityInfo with ajdfskjklfdsjklsdfajklsfdajk
+    /// Creates a new SecurityInfo for the security protocol given.
     pub fn new(security_protocol: &'static str) -> Self {
         Self {
             security_protocol,

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -246,7 +246,7 @@ impl RustlsChannelCredentials {
     }
 }
 
-/// Security context for [`rustls`]-based gRPC [`ChannelCredentials`].
+/// Authority validator for [`rustls`]-based gRPC [`ChannelCredentials`].
 #[derive(Debug)]
 pub struct ClientTlsAuthorityValidator {
     verified_peer_cert: Option<CertificateDer<'static>>,

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -36,15 +36,14 @@ use tokio_rustls::TlsConnector;
 use tokio_rustls::TlsStream as RustlsStream;
 use tonic::async_trait;
 
-use crate::attributes::Attributes;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::ProtocolInfo;
+use crate::credentials::SecurityInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::call::CallCredentials;
-use crate::credentials::client::ChannelSecurityContext;
-use crate::credentials::client::ChannelSecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::client::HandshakeOutput;
+use crate::credentials::client::ValidateAuthority;
 use crate::credentials::common::Authority;
 use crate::credentials::rustls::ALPN_PROTO_STR_H2;
 use crate::credentials::rustls::Identity;
@@ -201,7 +200,14 @@ impl RustlsChannelCredentials {
         &self,
         authority: &Authority,
         source: BoxEndpoint,
-    ) -> Result<(TlsStream<BoxEndpoint>, ChannelSecurityInfo), String> {
+    ) -> Result<
+        (
+            TlsStream<BoxEndpoint>,
+            SecurityInfo,
+            Box<dyn ValidateAuthority>,
+        ),
+        String,
+    > {
         let server_name = ServerName::try_from(authority.host())
             .map_err(|e| format!("invalid authority: {}", e))?
             .to_owned();
@@ -227,25 +233,26 @@ impl RustlsChannelCredentials {
             .and_then(|certs| certs.first())
             .map(|c| c.clone().into_owned());
 
-        let cs_info = ChannelSecurityInfo::new(
-            "tls",
-            SecurityLevel::PrivacyAndIntegrity,
-            Box::new(ClientTlsSecurityContext {
+        let cs_info =
+            SecurityInfo::new("tls").with_security_level(SecurityLevel::PrivacyAndIntegrity);
+        let ep = TlsStream::new(RustlsStream::Client(tls_stream));
+        Ok((
+            ep,
+            cs_info,
+            Box::new(ClientTlsAuthorityValidator {
                 verified_peer_cert: peer_cert,
             }),
-            Attributes::new(),
-        );
-        let ep = TlsStream::new(RustlsStream::Client(tls_stream));
-        Ok((ep, cs_info))
+        ))
     }
 }
 
 /// Security context for [`rustls`]-based gRPC [`ChannelCredentials`].
-pub struct ClientTlsSecurityContext {
+#[derive(Debug)]
+pub struct ClientTlsAuthorityValidator {
     verified_peer_cert: Option<CertificateDer<'static>>,
 }
 
-impl ChannelSecurityContext for ClientTlsSecurityContext {
+impl ValidateAuthority for ClientTlsAuthorityValidator {
     fn validate_authority(&self, authority: &Authority) -> bool {
         let server_name = match ServerName::try_from(authority.host()) {
             Ok(n) => n,
@@ -276,10 +283,11 @@ impl ChannelCredentials for RustlsChannelCredentials {
         _rt: &GrpcRuntime,
         _token: private::Internal,
     ) -> Result<HandshakeOutput, String> {
-        let (ep, cs_info) = self.connect_tls(authority, source).await?;
+        let (ep, security_info, authority_validator) = self.connect_tls(authority, source).await?;
         Ok(HandshakeOutput {
             endpoint: Box::new(ep),
-            security: cs_info,
+            security_info,
+            authority_validator,
         })
     }
 

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -288,16 +288,16 @@ async fn test_tls_validate_authority() {
         .await
         .expect("Handshake failed");
 
-    let context = result.security.security_context();
+    let av = result.authority_validator;
 
     // Validate correct authorities
-    assert!(context.validate_authority(&Authority::new("localhost".to_string(), None)));
-    assert!(context.validate_authority(&Authority::new("example.com".to_string(), None)));
-    assert!(context.validate_authority(&Authority::new("127.0.0.1".to_string(), None)));
+    assert!(av.validate_authority(&Authority::new("localhost".to_string(), None)));
+    assert!(av.validate_authority(&Authority::new("example.com".to_string(), None)));
+    assert!(av.validate_authority(&Authority::new("127.0.0.1".to_string(), None)));
 
     // Validate incorrect authorities
-    assert!(!context.validate_authority(&Authority::new("wrong.host".to_string(), None)));
-    assert!(!context.validate_authority(&Authority::new("grpc.io".to_string(), None)));
+    assert!(!av.validate_authority(&Authority::new("wrong.host".to_string(), None)));
+    assert!(!av.validate_authority(&Authority::new("grpc.io".to_string(), None)));
 }
 
 #[tokio::test]
@@ -431,7 +431,7 @@ async fn check_client_resumption_disabled(
             .unwrap();
         let authority = Authority::new("localhost".to_string(), Some(addr.port()));
 
-        let (tls_stream, _security) = creds
+        let (tls_stream, _security, _authority_validator) = creds
             .connect_tls(&authority, endpoint)
             .await
             .expect("Handshake failed");

--- a/grpc/src/credentials/rustls/server/mod.rs
+++ b/grpc/src/credentials/rustls/server/mod.rs
@@ -37,8 +37,8 @@ use tokio_rustls::TlsAcceptor;
 use tokio_rustls::TlsStream as RustlsStream;
 use webpki::EndEntityCert;
 
-use crate::attributes::Attributes;
 use crate::credentials::ProtocolInfo;
+use crate::credentials::SecurityInfo;
 use crate::credentials::SecurityLevel;
 use crate::credentials::ServerCredentials;
 use crate::credentials::rustls::ALPN_PROTO_STR_H2;
@@ -53,7 +53,6 @@ use crate::credentials::rustls::parse_key;
 use crate::credentials::rustls::sanitize_crypto_provider;
 use crate::credentials::rustls::tls_stream::TlsStream;
 use crate::credentials::server::HandshakeOutput;
-use crate::credentials::server::ServerConnectionSecurityInfo;
 use crate::private;
 use crate::rt::BoxEndpoint;
 use crate::rt::EndpointIoStream;
@@ -361,11 +360,8 @@ impl ServerCredentials for RustlsServerCredentials {
             return Err("Client ignored ALPN requirements".into());
         }
 
-        let auth_info = ServerConnectionSecurityInfo::new(
-            "tls",
-            SecurityLevel::PrivacyAndIntegrity,
-            Attributes::new(),
-        );
+        let auth_info =
+            SecurityInfo::new("tls").with_security_level(SecurityLevel::PrivacyAndIntegrity);
         let endpoint = TlsStream::new(RustlsStream::Server(tls_stream));
         Ok(HandshakeOutput {
             endpoint: Box::new(endpoint),

--- a/grpc/src/credentials/server.rs
+++ b/grpc/src/credentials/server.rs
@@ -22,49 +22,10 @@
  *
  */
 
-use crate::attributes::Attributes;
-use crate::credentials::SecurityLevel;
+use crate::credentials::SecurityInfo;
 use crate::rt::BoxEndpoint;
 
 pub struct HandshakeOutput {
     pub endpoint: BoxEndpoint,
-    pub security: ServerConnectionSecurityInfo,
-}
-
-/// Represents the security state of an established server-side connection.
-pub struct ServerConnectionSecurityInfo {
-    security_protocol: &'static str,
-    security_level: SecurityLevel,
-    /// Stores extra data derived from the underlying protocol.
-    attributes: Attributes,
-}
-
-impl ServerConnectionSecurityInfo {
-    /// Creates a new instance of `ServerConnectionSecurityInfo`.
-    pub fn new(
-        security_protocol: &'static str,
-        security_level: SecurityLevel,
-        attributes: Attributes,
-    ) -> Self {
-        Self {
-            security_protocol,
-            security_level,
-            attributes,
-        }
-    }
-
-    /// Returns the security protocol used.
-    pub fn security_protocol(&self) -> &'static str {
-        self.security_protocol
-    }
-
-    /// Returns the security level of the connection.
-    pub fn security_level(&self) -> SecurityLevel {
-        self.security_level
-    }
-
-    /// Returns the attributes associated with the connection.
-    pub fn attributes(&self) -> &Attributes {
-        &self.attributes
-    }
+    pub security: SecurityInfo,
 }

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -23,11 +23,13 @@
  */
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::task::{Context, Poll};
 
 use bytes::Buf;
 use tokio::sync::Mutex as TokioMutex;
@@ -37,7 +39,6 @@ use tokio::sync::oneshot;
 
 use crate::StatusCodeError;
 use crate::StatusError;
-use crate::attributes::Attributes;
 use crate::client::CallOptions;
 use crate::client::DynRecvStream as ClientDynRecvStream;
 use crate::client::DynSendStream as ClientDynSendStream;
@@ -65,10 +66,8 @@ use crate::client::transport::TransportOptions;
 use crate::core::Address;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
+use crate::credentials::SecurityInfo;
 use crate::credentials::SecurityLevel;
-use crate::credentials::client::ChannelSecurityContext;
-use crate::credentials::client::ChannelSecurityInfo;
-use crate::credentials::common::Authority;
 use crate::rt::GrpcRuntime;
 use crate::server::BoxedRecvStream;
 use crate::server::DynHandle;
@@ -82,9 +81,6 @@ use crate::server::SendOptions as ServerSendOptions;
 use crate::server::SendStream as ServerSendStream;
 use crate::server::Trailers as ServerTrailers;
 use crate::server::Transport as ServerTransport;
-
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 static LISTENERS: LazyLock<Mutex<HashMap<String, mpsc::Sender<InMemoryServerCall>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -423,7 +419,7 @@ impl Transport for InMemoryTransport {
     ) -> Result<
         (
             Self::Service,
-            ChannelSecurityInfo,
+            SecurityInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -439,24 +435,10 @@ impl Transport for InMemoryTransport {
             s: s.clone(),
             closed_tx: Some(closed_tx),
         };
-        let sec_info = ChannelSecurityInfo::new(
-            "inmemory",
-            SecurityLevel::PrivacyAndIntegrity,
-            Box::new(InMemoryChannelecurityContext {}),
-            Attributes::new(),
-        );
+        let sec_info =
+            SecurityInfo::new("inmemory").with_security_level(SecurityLevel::PrivacyAndIntegrity);
 
         Ok((conn, sec_info, closed_rx))
-    }
-}
-
-/// An implementation of [`ClientConnectionSecurityContext`] for in-memory connections.
-#[derive(Debug, Clone)]
-struct InMemoryChannelecurityContext;
-
-impl ChannelSecurityContext for InMemoryChannelecurityContext {
-    fn validate_authority(&self, _authority: &Authority) -> bool {
-        true
     }
 }
 
@@ -589,11 +571,12 @@ mod tests {
 
     #[tokio::test]
     async fn inmemory_handler_cancelled_on_connection_drop() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
         use crate::client::CallOptions;
         use crate::server::{RecvStream, SendStream};
         use crate::server::{RequestHeaders, Trailers};
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, Ordering};
 
         let handler_started = Arc::new(AtomicBool::new(false));
         let handler_finished = Arc::new(AtomicBool::new(false));

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -29,7 +29,8 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::task::{Context, Poll};
+use std::task::Context;
+use std::task::Poll;
 
 use bytes::Buf;
 use tokio::sync::Mutex as TokioMutex;

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -573,11 +573,14 @@ mod tests {
     #[tokio::test]
     async fn inmemory_handler_cancelled_on_connection_drop() {
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::Ordering;
 
         use crate::client::CallOptions;
-        use crate::server::{RecvStream, SendStream};
-        use crate::server::{RequestHeaders, Trailers};
+        use crate::server::RecvStream;
+        use crate::server::RequestHeaders;
+        use crate::server::SendStream;
+        use crate::server::Trailers;
 
         let handler_started = Arc::new(AtomicBool::new(false));
         let handler_finished = Arc::new(AtomicBool::new(false));

--- a/grpc/src/rt/address.rs
+++ b/grpc/src/rt/address.rs
@@ -83,8 +83,9 @@ impl ListenerAddress for UnixListenerAddress {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::net::SocketAddr;
+
+    use super::*;
 
     // -- TcpAddress as ListenerAddress --
 

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -598,11 +598,15 @@ impl Trailers {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::task::{Context, Poll};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
+
     use tokio::sync::Notify;
+
+    use super::*;
 
     /// A mock connection whose completion is controlled by a [`Notify`],
     /// and which records whether [`graceful_shutdown`] was called.
@@ -974,8 +978,10 @@ mod tests {
     #[tokio::test]
     async fn listener_dropped_immediately_while_connections_drain() {
         use crate::client::CallOptions;
-        use crate::server::{RecvStream, SendStream};
-        use crate::server::{RequestHeaders, Trailers};
+        use crate::server::RecvStream;
+        use crate::server::RequestHeaders;
+        use crate::server::SendStream;
+        use crate::server::Trailers;
 
         let (listener, dropped, tx) = MockListener::new();
 


### PR DESCRIPTION
Also, rename `SecurityContext` to `ValidateAuthority` since that's what it does.

My plan is to add the common `SecurityInfo` into the upcoming `PeerInfo` struct.
