### PR TITLE
grpc: add ConnectionInfo to client's ResponseHeaders and Trailers

### DIFF
--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -361,10 +361,10 @@ impl Invoke for Arc<ActiveChannel> {
         let mut i = self.lb_watcher.iter();
         loop {
             let Some(state) = i.next().await else {
-                return FailingRecvStream::new_stream_pair(StatusError::new(
-                    StatusCodeError::Internal,
-                    "channel has been closed",
-                ));
+                return FailingRecvStream::new_stream_pair(
+                    StatusError::new(StatusCodeError::Internal, "channel has been closed"),
+                    None,
+                );
             };
             let result = &state.picker.pick(&headers);
             match result {
@@ -381,7 +381,7 @@ impl Invoke for Arc<ActiveChannel> {
                     // Continue and retry the RPC with the next picker.
                 }
                 PickResult::Fail(status) => {
-                    return FailingRecvStream::new_stream_pair(status.clone());
+                    return FailingRecvStream::new_stream_pair(status.clone(), None);
                 }
                 PickResult::Drop(status) => {
                     todo!("dropped pick: {:?}", status);

--- a/grpc/src/client/interceptor.rs
+++ b/grpc/src/client/interceptor.rs
@@ -563,7 +563,9 @@ mod test {
             .unwrap();
         assert_eq!(controller.recv_req().await.0, one);
         controller
-            .send_resp(ResponseStreamItem::Headers(ResponseHeaders::default()))
+            .send_resp(ResponseStreamItem::Headers(ResponseHeaders::new(
+                crate::core::test_peer_info(),
+            )))
             .await;
 
         let resp = rx.recv(&mut ByteRecvMsg::new()).await;

--- a/grpc/src/client/interceptor.rs
+++ b/grpc/src/client/interceptor.rs
@@ -564,7 +564,7 @@ mod test {
         assert_eq!(controller.recv_req().await.0, one);
         controller
             .send_resp(ResponseStreamItem::Headers(ResponseHeaders::new(
-                crate::core::test_peer_info(),
+                crate::core::test_connection_info(),
             )))
             .await;
 

--- a/grpc/src/client/metadata_utils.rs
+++ b/grpc/src/client/metadata_utils.rs
@@ -250,7 +250,7 @@ mod tests {
         // Send a Headers response on the call.
         let mut resp_md = MetadataMap::new();
         resp_md.insert("x-resp-header", "resp-value".parse().unwrap());
-        let mut headers = ResponseHeaders::default();
+        let mut headers = ResponseHeaders::new(crate::core::test_peer_info());
         *headers.metadata_mut() = resp_md;
         controller
             .send_resp(ResponseStreamItem::Headers(headers))

--- a/grpc/src/client/metadata_utils.rs
+++ b/grpc/src/client/metadata_utils.rs
@@ -250,7 +250,7 @@ mod tests {
         // Send a Headers response on the call.
         let mut resp_md = MetadataMap::new();
         resp_md.insert("x-resp-header", "resp-value".parse().unwrap());
-        let mut headers = ResponseHeaders::new(crate::core::test_peer_info());
+        let mut headers = ResponseHeaders::new(crate::core::test_connection_info());
         *headers.metadata_mut() = resp_md;
         controller
             .send_resp(ResponseStreamItem::Headers(headers))

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -443,7 +443,7 @@ impl RequestHeaders {
     }
 
     /// Returns the full (e.g. "/Service/Method") method name for these headers.
-    pub fn method_name(&self) -> &String {
+    pub fn method_name(&self) -> &str {
         &self.method_name
     }
 

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -53,6 +53,7 @@ use std::time::Instant;
 
 use tonic::async_trait;
 
+use crate::core::PeerInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::metadata::MetadataMap;
@@ -367,15 +368,19 @@ impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
 }
 
 /// Contains all information transmitted in the response headers of an RPC.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ResponseHeaders {
     metadata: MetadataMap,
+    peer_info: PeerInfo,
 }
 
 impl ResponseHeaders {
     /// Returns a default ResponseHeaders instance.
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(peer_info: PeerInfo) -> Self {
+        Self {
+            metadata: MetadataMap::default(),
+            peer_info,
+        }
     }
 
     /// Replaces the metadata of self with `metadata`.
@@ -396,6 +401,17 @@ impl ResponseHeaders {
 
     pub(crate) fn into_metadata(self) -> MetadataMap {
         self.metadata
+    }
+
+    /// Replaces the peer_info of self with `peer_info`.
+    pub fn with_peer_info(mut self, peer_info: PeerInfo) -> Self {
+        self.peer_info = peer_info;
+        self
+    }
+
+    /// Replaces the peer_info of self with `peer_info`.
+    pub fn peer_info(&self) -> &PeerInfo {
+        &self.peer_info
     }
 }
 
@@ -427,7 +443,7 @@ impl RequestHeaders {
     }
 
     /// Returns the full (e.g. "/Service/Method") method name for these headers.
-    pub fn method_name(&self) -> &str {
+    pub fn method_name(&self) -> &String {
         &self.method_name
     }
 
@@ -454,6 +470,7 @@ impl RequestHeaders {
 pub struct Trailers {
     status: crate::Result<()>,
     metadata: MetadataMap,
+    peer_info: Option<PeerInfo>,
 }
 
 impl Trailers {
@@ -462,6 +479,7 @@ impl Trailers {
         Self {
             status,
             metadata: MetadataMap::default(),
+            peer_info: None,
         }
     }
 
@@ -495,6 +513,23 @@ impl Trailers {
     /// Returns the status in the [`Trailers`], consuming the entire status.
     pub fn into_status(self) -> crate::Result<()> {
         self.status
+    }
+
+    /// Replaces the peer info in self with `peer_info`.
+    pub fn with_peer_info(mut self, peer_info: Option<PeerInfo>) -> Self {
+        self.peer_info = peer_info;
+        self
+    }
+
+    /// Returns the peer info in the trailers, if present.  Peer information
+    /// will not be available in trailers in any the following circumstances:
+    ///
+    /// 1. A ResponseHeaders was already present on the response stream.
+    ///
+    /// 2. The error was generated locally on the client before a connection was
+    ///    chosen for the RPC.
+    pub fn peer_info(&self) -> &Option<PeerInfo> {
+        &self.peer_info
     }
 
     pub(crate) fn into_parts(self) -> (crate::Result<()>, MetadataMap) {

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -53,7 +53,7 @@ use std::time::Instant;
 
 use tonic::async_trait;
 
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::metadata::MetadataMap;
@@ -371,12 +371,12 @@ impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
 #[derive(Debug, Clone)]
 pub struct ResponseHeaders {
     metadata: MetadataMap,
-    peer_info: PeerInfo,
+    peer_info: ConnectionInfo,
 }
 
 impl ResponseHeaders {
     /// Returns a default ResponseHeaders instance.
-    pub fn new(peer_info: PeerInfo) -> Self {
+    pub fn new(peer_info: ConnectionInfo) -> Self {
         Self {
             metadata: MetadataMap::default(),
             peer_info,
@@ -404,13 +404,13 @@ impl ResponseHeaders {
     }
 
     /// Replaces the peer_info of self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: PeerInfo) -> Self {
+    pub fn with_peer_info(mut self, peer_info: ConnectionInfo) -> Self {
         self.peer_info = peer_info;
         self
     }
 
     /// Replaces the peer_info of self with `peer_info`.
-    pub fn peer_info(&self) -> &PeerInfo {
+    pub fn peer_info(&self) -> &ConnectionInfo {
         &self.peer_info
     }
 }
@@ -470,7 +470,7 @@ impl RequestHeaders {
 pub struct Trailers {
     status: crate::Result<()>,
     metadata: MetadataMap,
-    peer_info: Option<PeerInfo>,
+    peer_info: Option<ConnectionInfo>,
 }
 
 impl Trailers {
@@ -516,7 +516,7 @@ impl Trailers {
     }
 
     /// Replaces the peer info in self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: Option<PeerInfo>) -> Self {
+    pub fn with_peer_info(mut self, peer_info: Option<ConnectionInfo>) -> Self {
         self.peer_info = peer_info;
         self
     }
@@ -528,7 +528,7 @@ impl Trailers {
     ///
     /// 2. The error was generated locally on the client before a connection was
     ///    chosen for the RPC.
-    pub fn peer_info(&self) -> &Option<PeerInfo> {
+    pub fn peer_info(&self) -> &Option<ConnectionInfo> {
         &self.peer_info
     }
 

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -371,15 +371,15 @@ impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
 #[derive(Debug, Clone)]
 pub struct ResponseHeaders {
     metadata: MetadataMap,
-    peer_info: ConnectionInfo,
+    connection_info: ConnectionInfo,
 }
 
 impl ResponseHeaders {
     /// Returns a default ResponseHeaders instance.
-    pub fn new(peer_info: ConnectionInfo) -> Self {
+    pub fn new(connection_info: ConnectionInfo) -> Self {
         Self {
             metadata: MetadataMap::default(),
-            peer_info,
+            connection_info,
         }
     }
 
@@ -403,15 +403,15 @@ impl ResponseHeaders {
         self.metadata
     }
 
-    /// Replaces the peer_info of self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: ConnectionInfo) -> Self {
-        self.peer_info = peer_info;
+    /// Replaces the connection of self with `connection_info`.
+    pub fn with_connection_info(mut self, connection_info: ConnectionInfo) -> Self {
+        self.connection_info = connection_info;
         self
     }
 
-    /// Replaces the peer_info of self with `peer_info`.
-    pub fn peer_info(&self) -> &ConnectionInfo {
-        &self.peer_info
+    /// Returns a reference to the connection_info in these headers.
+    pub fn connection_info(&self) -> &ConnectionInfo {
+        &self.connection_info
     }
 }
 
@@ -470,7 +470,7 @@ impl RequestHeaders {
 pub struct Trailers {
     status: crate::Result<()>,
     metadata: MetadataMap,
-    peer_info: Option<ConnectionInfo>,
+    connection_info: Option<ConnectionInfo>,
 }
 
 impl Trailers {
@@ -479,7 +479,7 @@ impl Trailers {
         Self {
             status,
             metadata: MetadataMap::default(),
-            peer_info: None,
+            connection_info: None,
         }
     }
 
@@ -515,21 +515,22 @@ impl Trailers {
         self.status
     }
 
-    /// Replaces the peer info in self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: Option<ConnectionInfo>) -> Self {
-        self.peer_info = peer_info;
+    /// Replaces the connection info in self with `connection_info`.
+    pub fn with_connection_info(mut self, connection_info: Option<ConnectionInfo>) -> Self {
+        self.connection_info = connection_info;
         self
     }
 
-    /// Returns the peer info in the trailers, if present.  Peer information
-    /// will not be available in trailers in any the following circumstances:
+    /// Returns the connection info in the trailers, if present.  Connection
+    /// information will not be available in trailers in any the following
+    /// circumstances:
     ///
     /// 1. A ResponseHeaders was already present on the response stream.
     ///
     /// 2. The error was generated locally on the client before a connection was
     ///    chosen for the RPC.
-    pub fn peer_info(&self) -> &Option<ConnectionInfo> {
-        &self.peer_info
+    pub fn connection_info(&self) -> &Option<ConnectionInfo> {
+        &self.connection_info
     }
 
     pub(crate) fn into_parts(self) -> (crate::Result<()>, MetadataMap) {

--- a/grpc/src/client/stream_util.rs
+++ b/grpc/src/client/stream_util.rs
@@ -37,7 +37,7 @@ use crate::client::SendOptions;
 use crate::client::SendStream;
 use crate::client::Trailers;
 use crate::client::interceptor::Intercept;
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 
@@ -182,7 +182,7 @@ impl SendStream for NopSendStream {
 
 pub(crate) struct FailingRecvStream {
     status: Option<StatusError>,
-    peer_info: Option<PeerInfo>,
+    peer_info: Option<ConnectionInfo>,
 }
 
 impl RecvStream for FailingRecvStream {
@@ -199,7 +199,7 @@ impl RecvStream for FailingRecvStream {
 impl FailingRecvStream {
     pub(crate) fn new_stream_pair(
         status: StatusError,
-        peer_info: Option<PeerInfo>,
+        peer_info: Option<ConnectionInfo>,
     ) -> (Box<dyn DynSendStream>, Box<dyn DynRecvStream>) {
         (
             Box::new(NopSendStream),

--- a/grpc/src/client/stream_util.rs
+++ b/grpc/src/client/stream_util.rs
@@ -37,6 +37,7 @@ use crate::client::SendOptions;
 use crate::client::SendStream;
 use crate::client::Trailers;
 use crate::client::interceptor::Intercept;
+use crate::core::PeerInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 
@@ -181,12 +182,15 @@ impl SendStream for NopSendStream {
 
 pub(crate) struct FailingRecvStream {
     status: Option<StatusError>,
+    peer_info: Option<PeerInfo>,
 }
 
 impl RecvStream for FailingRecvStream {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         match self.status.take() {
-            Some(status) => ResponseStreamItem::Trailers(Trailers::new(Err(status))),
+            Some(status) => ResponseStreamItem::Trailers(
+                Trailers::new(Err(status)).with_peer_info(self.peer_info.take()),
+            ),
             None => ResponseStreamItem::StreamClosed,
         }
     }
@@ -195,11 +199,13 @@ impl RecvStream for FailingRecvStream {
 impl FailingRecvStream {
     pub(crate) fn new_stream_pair(
         status: StatusError,
+        peer_info: Option<PeerInfo>,
     ) -> (Box<dyn DynSendStream>, Box<dyn DynRecvStream>) {
         (
             Box::new(NopSendStream),
             Box::new(Self {
                 status: Some(status),
+                peer_info,
             }),
         )
     }
@@ -240,11 +246,11 @@ mod test {
         let scenarios = [
             vec![ResponseStreamItem::StreamClosed],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::StreamClosed,
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::Message,
                 ResponseStreamItem::StreamClosed,
             ],
@@ -268,13 +274,13 @@ mod test {
     async fn test_validator_headers_repeated() {
         let scenarios = [
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::Message,
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ],
         ];
 
@@ -296,7 +302,7 @@ mod test {
         let scenarios = [
             vec![ResponseStreamItem::Trailers(Trailers::new(Ok(())))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::Trailers(Trailers::new(Ok(()))),
             ],
         ];
@@ -317,7 +323,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_unary_multiple_messages() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
         ]];
@@ -338,7 +344,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
@@ -358,7 +364,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_erroring_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
@@ -384,7 +390,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_unary() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::default()),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Trailers(Trailers::new(Ok(()))),
         ]];
@@ -406,14 +412,14 @@ mod test {
                 StatusError::new(StatusCodeError::Aborted, "some err"),
             )))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::Trailers(Trailers::new(Err(StatusError::new(
                     StatusCodeError::Aborted,
                     "some err",
                 )))),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::default()),
+                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
                 ResponseStreamItem::Message,
                 ResponseStreamItem::Trailers(Trailers::new(Err(StatusError::new(
                     StatusCodeError::Aborted,

--- a/grpc/src/client/stream_util.rs
+++ b/grpc/src/client/stream_util.rs
@@ -182,14 +182,14 @@ impl SendStream for NopSendStream {
 
 pub(crate) struct FailingRecvStream {
     status: Option<StatusError>,
-    peer_info: Option<ConnectionInfo>,
+    connection_info: Option<ConnectionInfo>,
 }
 
 impl RecvStream for FailingRecvStream {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         match self.status.take() {
             Some(status) => ResponseStreamItem::Trailers(
-                Trailers::new(Err(status)).with_peer_info(self.peer_info.take()),
+                Trailers::new(Err(status)).with_connection_info(self.connection_info.take()),
             ),
             None => ResponseStreamItem::StreamClosed,
         }
@@ -199,13 +199,13 @@ impl RecvStream for FailingRecvStream {
 impl FailingRecvStream {
     pub(crate) fn new_stream_pair(
         status: StatusError,
-        peer_info: Option<ConnectionInfo>,
+        connection_info: Option<ConnectionInfo>,
     ) -> (Box<dyn DynSendStream>, Box<dyn DynRecvStream>) {
         (
             Box::new(NopSendStream),
             Box::new(Self {
                 status: Some(status),
-                peer_info,
+                connection_info,
             }),
         )
     }
@@ -246,11 +246,15 @@ mod test {
         let scenarios = [
             vec![ResponseStreamItem::StreamClosed],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::StreamClosed,
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::Message,
                 ResponseStreamItem::StreamClosed,
             ],
@@ -274,13 +278,21 @@ mod test {
     async fn test_validator_headers_repeated() {
         let scenarios = [
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::Message,
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
             ],
         ];
 
@@ -302,7 +314,9 @@ mod test {
         let scenarios = [
             vec![ResponseStreamItem::Trailers(Trailers::new(Ok(())))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::Trailers(Trailers::new(Ok(()))),
             ],
         ];
@@ -323,7 +337,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_unary_multiple_messages() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_connection_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
         ]];
@@ -344,7 +358,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_connection_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
@@ -364,7 +378,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_erroring_stream() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_connection_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
             ResponseStreamItem::Message,
@@ -390,7 +404,7 @@ mod test {
     #[tokio::test]
     async fn test_validator_successful_unary() {
         let scenarios = [vec![
-            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+            ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_connection_info())),
             ResponseStreamItem::Message,
             ResponseStreamItem::Trailers(Trailers::new(Ok(()))),
         ]];
@@ -412,14 +426,18 @@ mod test {
                 StatusError::new(StatusCodeError::Aborted, "some err"),
             )))],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::Trailers(Trailers::new(Err(StatusError::new(
                     StatusCodeError::Aborted,
                     "some err",
                 )))),
             ],
             vec![
-                ResponseStreamItem::Headers(ResponseHeaders::new(crate::core::test_peer_info())),
+                ResponseStreamItem::Headers(ResponseHeaders::new(
+                    crate::core::test_connection_info(),
+                )),
                 ResponseStreamItem::Message,
                 ResponseStreamItem::Trailers(Trailers::new(Err(StatusError::new(
                     StatusCodeError::Aborted,

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -57,7 +57,7 @@ use crate::client::transport::SecurityOpts;
 use crate::client::transport::TransportOptions;
 use crate::client::transport::http_connect::HttpConnectHandshaker;
 use crate::core::Address;
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
 use crate::credentials::common::Authority;
@@ -86,7 +86,7 @@ impl Backoff for NopBackoff {
 
 struct ReadyState {
     service: Box<dyn DynInvoke>,
-    peer_info: PeerInfo,
+    peer_info: ConnectionInfo,
     authority: Authority,
 }
 

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -86,7 +86,7 @@ impl Backoff for NopBackoff {
 
 struct ReadyState {
     service: Box<dyn DynInvoke>,
-    peer_info: ConnectionInfo,
+    connection_info: ConnectionInfo,
     authority: Authority,
 }
 
@@ -195,12 +195,12 @@ impl DynInvoke for InternalSubchannel {
         };
 
         let fail_with = |status| -> (Box<dyn DynSendStream>, Box<dyn DynRecvStream>) {
-            FailingRecvStream::new_stream_pair(status, Some(state.peer_info.clone()))
+            FailingRecvStream::new_stream_pair(status, Some(state.connection_info.clone()))
         };
 
         if let Some(call_creds) = call_creds {
             if call_creds.minimum_channel_security_level()
-                > state.peer_info.security_info().security_level()
+                > state.connection_info.security_info().security_level()
             {
                 return fail_with(StatusError::new(
                     StatusCodeError::Unauthenticated,
@@ -211,9 +211,9 @@ impl DynInvoke for InternalSubchannel {
             let call_details = create_call_details(&state.authority, headers.method_name());
 
             let channel_sec_info = CallClientConnectionSecurityInfo::new(
-                state.peer_info.security_info().security_protocol(),
-                state.peer_info.security_info().security_level(),
-                state.peer_info.security_info().attributes().clone(),
+                state.connection_info.security_info().security_protocol(),
+                state.connection_info.security_info().security_level(),
+                state.connection_info.security_info().attributes().clone(),
             );
 
             if let Err(s) = call_creds
@@ -378,10 +378,10 @@ fn begin_connecting_if_idle(data: Arc<Mutex<InternalSubchannelData>>) {
             }
             result = transport_builder.dyn_connect(&address, runtime, &security_opts, &transport_opts) => {
                     match result {
-                        Ok((service, peer_info, disconnection_listener)) => {
+                        Ok((service, connection_info, disconnection_listener)) => {
                             move_to_ready(data, Arc::new(ReadyState{
                                 service,
-                                peer_info,
+                                connection_info,
                                 authority: security_opts.authority}), disconnection_listener).await;
                         }
                         Err(e) => {

--- a/grpc/src/client/subchannel.rs
+++ b/grpc/src/client/subchannel.rs
@@ -57,7 +57,7 @@ use crate::client::transport::SecurityOpts;
 use crate::client::transport::TransportOptions;
 use crate::client::transport::http_connect::HttpConnectHandshaker;
 use crate::core::Address;
-use crate::credentials::SecurityInfo;
+use crate::core::PeerInfo;
 use crate::credentials::call::CallDetails;
 use crate::credentials::call::ClientConnectionSecurityInfo as CallClientConnectionSecurityInfo;
 use crate::credentials::common::Authority;
@@ -86,7 +86,7 @@ impl Backoff for NopBackoff {
 
 struct ReadyState {
     service: Box<dyn DynInvoke>,
-    security_info: SecurityInfo,
+    peer_info: PeerInfo,
     authority: Authority,
 }
 
@@ -195,11 +195,13 @@ impl DynInvoke for InternalSubchannel {
         };
 
         let fail_with = |status| -> (Box<dyn DynSendStream>, Box<dyn DynRecvStream>) {
-            FailingRecvStream::new_stream_pair(status)
+            FailingRecvStream::new_stream_pair(status, Some(state.peer_info.clone()))
         };
 
         if let Some(call_creds) = call_creds {
-            if call_creds.minimum_channel_security_level() > state.security_info.security_level() {
+            if call_creds.minimum_channel_security_level()
+                > state.peer_info.security_info().security_level()
+            {
                 return fail_with(StatusError::new(
                     StatusCodeError::Unauthenticated,
                     "transport: cannot send secure credentials on an insecure connection",
@@ -209,9 +211,9 @@ impl DynInvoke for InternalSubchannel {
             let call_details = create_call_details(&state.authority, headers.method_name());
 
             let channel_sec_info = CallClientConnectionSecurityInfo::new(
-                state.security_info.security_protocol(),
-                state.security_info.security_level(),
-                state.security_info.attributes().clone(),
+                state.peer_info.security_info().security_protocol(),
+                state.peer_info.security_info().security_level(),
+                state.peer_info.security_info().attributes().clone(),
             );
 
             if let Err(s) = call_creds
@@ -376,10 +378,10 @@ fn begin_connecting_if_idle(data: Arc<Mutex<InternalSubchannelData>>) {
             }
             result = transport_builder.dyn_connect(&address, runtime, &security_opts, &transport_opts) => {
                     match result {
-                        Ok((service, security_info, disconnection_listener)) => {
+                        Ok((service, peer_info, disconnection_listener)) => {
                             move_to_ready(data, Arc::new(ReadyState{
                                 service,
-                                security_info,
+                                peer_info,
                                 authority: security_opts.authority}), disconnection_listener).await;
                         }
                         Err(e) => {

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -30,8 +30,8 @@ use http::HeaderValue;
 use crate::client::DynInvoke;
 use crate::client::Invoke;
 use crate::core::Address;
+use crate::core::PeerInfo;
 use crate::credentials::ChannelCredentials;
-use crate::credentials::SecurityInfo;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
 use crate::rt::GrpcRuntime;
@@ -98,7 +98,7 @@ pub(crate) trait Transport: Sync {
     ) -> Result<
         (
             Self::Service,
-            SecurityInfo,
+            PeerInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -116,7 +116,7 @@ pub(crate) trait DynTransport: Send + Sync {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            SecurityInfo,
+            PeerInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -134,7 +134,7 @@ impl<T: Transport> DynTransport for T {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            SecurityInfo,
+            PeerInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,

--- a/grpc/src/client/transport/mod.rs
+++ b/grpc/src/client/transport/mod.rs
@@ -30,7 +30,7 @@ use http::HeaderValue;
 use crate::client::DynInvoke;
 use crate::client::Invoke;
 use crate::core::Address;
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::credentials::ChannelCredentials;
 use crate::credentials::client::ClientHandshakeInfo;
 use crate::credentials::common::Authority;
@@ -98,7 +98,7 @@ pub(crate) trait Transport: Sync {
     ) -> Result<
         (
             Self::Service,
-            PeerInfo,
+            ConnectionInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -116,7 +116,7 @@ pub(crate) trait DynTransport: Send + Sync {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            PeerInfo,
+            ConnectionInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -134,7 +134,7 @@ impl<T: Transport> DynTransport for T {
     ) -> Result<
         (
             Box<dyn DynInvoke>,
-            PeerInfo,
+            ConnectionInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -85,7 +85,7 @@ use crate::client::transport::Transport;
 use crate::client::transport::TransportOptions;
 use crate::client::transport::registry::GLOBAL_TRANSPORT_REGISTRY;
 use crate::core::Address;
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::private;
@@ -136,7 +136,7 @@ struct TonicTransport {
     grpc: Grpc<TonicService>,
     task_handle: BoxedTaskHandle,
     runtime: GrpcRuntime,
-    peer_info: PeerInfo,
+    peer_info: ConnectionInfo,
 }
 
 impl Drop for TonicTransport {
@@ -234,7 +234,7 @@ impl SendStream for TonicSendStream {
 struct TonicRecvStream {
     state: StreamState,
     cancel_tx: Option<CancellationHandle>,
-    peer_info: Option<PeerInfo>,
+    peer_info: Option<ConnectionInfo>,
 }
 
 impl TonicRecvStream {
@@ -404,7 +404,7 @@ impl Transport for TransportBuilder {
     ) -> Result<
         (
             Self::Service,
-            PeerInfo,
+            ConnectionInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -505,7 +505,7 @@ impl Transport for TransportBuilder {
             .map_err(|e| format!("failed to create URL with authority {}: {}", authority, e))?;
         let grpc = Grpc::with_origin(TonicService { inner: service }, uri);
 
-        let peer_info = PeerInfo::new(
+        let peer_info = ConnectionInfo::new(
             local_address,
             remote_address,
             handshake_ouput.security_info.clone(),

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -319,7 +319,7 @@ impl RecvStream for TonicRecvStream {
                                 return self.trailers_from_grpc_result(
                                     Err(StatusError::new(
                                         StatusCodeError::Internal,
-                                        "required peer info missing",
+                                        "required connection info missing",
                                     )),
                                     None,
                                 );

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -266,6 +266,9 @@ impl TonicRecvStream {
         status: crate::Result<()>,
         md: Option<&TonicMeta>,
     ) -> ResponseStreamItem {
+        if let Some(cancel_tx) = self.cancel_tx.take() {
+            cancel_tx.cancel();
+        }
         let trailers = if let Some(md) = md {
             match md.try_into() {
                 Err(e) => Trailers::new(Err(StatusError::new(
@@ -324,18 +327,13 @@ impl RecvStream for TonicRecvStream {
                             let headers = ResponseHeaders::new(peer_info).with_metadata(md);
                             ResponseStreamItem::Headers(headers)
                         }
-                        Err(e) => {
-                            if let Some(cancel_tx) = self.cancel_tx.take() {
-                                cancel_tx.cancel();
-                            }
-                            self.trailers_from_grpc_result(
-                                Err(StatusError::new(
-                                    StatusCodeError::Internal,
-                                    format!("error decoding response: {e}"),
-                                )),
-                                None,
-                            )
-                        }
+                        Err(e) => self.trailers_from_grpc_result(
+                            Err(StatusError::new(
+                                StatusCodeError::Internal,
+                                format!("error decoding response: {e}"),
+                            )),
+                            None,
+                        ),
                     }
                 }
                 Err(_) => {
@@ -361,18 +359,13 @@ impl RecvStream for TonicRecvStream {
                         self.state = StreamState::Streaming(stream);
                         ResponseStreamItem::Message
                     }
-                    Err(e) => {
-                        if let Some(cancel_tx) = self.cancel_tx.take() {
-                            cancel_tx.cancel();
-                        }
-                        self.trailers_from_grpc_result(
-                            Err(StatusError::new(
-                                StatusCodeError::Internal,
-                                format!("error decoding response: {e}"),
-                            )),
-                            None,
-                        )
-                    }
+                    Err(e) => self.trailers_from_grpc_result(
+                        Err(StatusError::new(
+                            StatusCodeError::Internal,
+                            format!("error decoding response: {e}"),
+                        )),
+                        None,
+                    ),
                 },
                 Err(status) => {
                     // Stay closed after sending trailers (do not set self.state).

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -136,7 +136,7 @@ struct TonicTransport {
     grpc: Grpc<TonicService>,
     task_handle: BoxedTaskHandle,
     runtime: GrpcRuntime,
-    peer_info: ConnectionInfo,
+    connection_info: ConnectionInfo,
 }
 
 impl Drop for TonicTransport {
@@ -192,7 +192,7 @@ impl Invoke for TonicTransport {
             TonicRecvStream {
                 state: StreamState::AwaitingHeaders(resp_rx),
                 cancel_tx: Some(cancel_tx),
-                peer_info: Some(self.peer_info.clone()),
+                connection_info: Some(self.connection_info.clone()),
             },
         )
     }
@@ -206,7 +206,7 @@ impl TonicTransport {
             TonicRecvStream {
                 state: StreamState::LocalError(status),
                 cancel_tx: None,
-                peer_info: Some(self.peer_info.clone()),
+                connection_info: Some(self.connection_info.clone()),
             },
         )
     }
@@ -234,7 +234,7 @@ impl SendStream for TonicSendStream {
 struct TonicRecvStream {
     state: StreamState,
     cancel_tx: Option<CancellationHandle>,
-    peer_info: Option<ConnectionInfo>,
+    connection_info: Option<ConnectionInfo>,
 }
 
 impl TonicRecvStream {
@@ -280,7 +280,7 @@ impl TonicRecvStream {
         } else {
             Trailers::new(status)
         };
-        ResponseStreamItem::Trailers(trailers.with_peer_info(self.peer_info.take()))
+        ResponseStreamItem::Trailers(trailers.with_connection_info(self.connection_info.take()))
     }
 }
 
@@ -315,7 +315,7 @@ impl RecvStream for TonicRecvStream {
                         Ok(md) => {
                             // Start streaming and return the headers.
                             self.state = StreamState::Streaming(stream);
-                            let Some(peer_info) = self.peer_info.take() else {
+                            let Some(connection_info) = self.connection_info.take() else {
                                 return self.trailers_from_grpc_result(
                                     Err(StatusError::new(
                                         StatusCodeError::Internal,
@@ -324,7 +324,7 @@ impl RecvStream for TonicRecvStream {
                                     None,
                                 );
                             };
-                            let headers = ResponseHeaders::new(peer_info).with_metadata(md);
+                            let headers = ResponseHeaders::new(connection_info).with_metadata(md);
                             ResponseStreamItem::Headers(headers)
                         }
                         Err(e) => self.trailers_from_grpc_result(
@@ -505,7 +505,7 @@ impl Transport for TransportBuilder {
             .map_err(|e| format!("failed to create URL with authority {}: {}", authority, e))?;
         let grpc = Grpc::with_origin(TonicService { inner: service }, uri);
 
-        let peer_info = ConnectionInfo::new(
+        let connection_info = ConnectionInfo::new(
             local_address,
             remote_address,
             handshake_ouput.security_info.clone(),
@@ -515,9 +515,9 @@ impl Transport for TransportBuilder {
             grpc,
             task_handle,
             runtime,
-            peer_info: peer_info.clone(),
+            connection_info: connection_info.clone(),
         };
-        Ok((service, peer_info, rx))
+        Ok((service, connection_info, rx))
     }
 }
 

--- a/grpc/src/client/transport/tonic/mod.rs
+++ b/grpc/src/client/transport/tonic/mod.rs
@@ -67,6 +67,8 @@ use tower_service::Service as TowerService;
 
 use crate::StatusCodeError;
 use crate::StatusError;
+use crate::attributes::Attributes;
+use crate::byte_str::ByteStr;
 use crate::client::CallOptions;
 use crate::client::Invoke;
 use crate::client::RecvStream;
@@ -83,9 +85,9 @@ use crate::client::transport::Transport;
 use crate::client::transport::TransportOptions;
 use crate::client::transport::registry::GLOBAL_TRANSPORT_REGISTRY;
 use crate::core::Address;
+use crate::core::PeerInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
-use crate::credentials::SecurityInfo;
 use crate::private;
 use crate::rt::BoxedTaskHandle;
 use crate::rt::GrpcRuntime;
@@ -134,6 +136,7 @@ struct TonicTransport {
     grpc: Grpc<TonicService>,
     task_handle: BoxedTaskHandle,
     runtime: GrpcRuntime,
+    peer_info: PeerInfo,
 }
 
 impl Drop for TonicTransport {
@@ -160,12 +163,13 @@ impl Invoke for TonicTransport {
         let cancel_tx = request.cancellation_handle();
 
         let Ok(path) = PathAndQuery::from_maybe_shared(method) else {
-            return err_streams(StatusError::new(StatusCodeError::Internal, "invalid path"));
+            return self
+                .local_err_streams(StatusError::new(StatusCodeError::Internal, "invalid path"));
         };
 
         let mut grpc = self.grpc.clone();
         if let Err(e) = grpc.ready().await {
-            return err_streams(StatusError::new(
+            return self.local_err_streams(StatusError::new(
                 StatusCodeError::Unavailable,
                 format!("Service was not ready: {e}"),
             ));
@@ -188,39 +192,24 @@ impl Invoke for TonicTransport {
             TonicRecvStream {
                 state: StreamState::AwaitingHeaders(resp_rx),
                 cancel_tx: Some(cancel_tx),
+                peer_info: Some(self.peer_info.clone()),
             },
         )
     }
 }
 
-// Converts from a tonic status to a trailers stream item.
-fn trailers_from_tonic_status(status: &TonicStatus, mut md: TonicMeta) -> ResponseStreamItem {
-    if !status.details().is_empty() {
-        md.insert_bin(
-            "grpc-status-details-bin",
-            tonic::metadata::MetadataValue::from_bytes(status.details()),
-        );
+impl TonicTransport {
+    /// Creates a send/recv stream pair representing locally-produced errors.
+    fn local_err_streams(&self, status: StatusError) -> (TonicSendStream, TonicRecvStream) {
+        (
+            TonicSendStream { sender: Err(()) },
+            TonicRecvStream {
+                state: StreamState::LocalError(status),
+                cancel_tx: None,
+                peer_info: Some(self.peer_info.clone()),
+            },
+        )
     }
-    let status_res = match status.code() {
-        Code::Ok => Ok(()),
-        code => Err(StatusError::new(
-            StatusCodeError::from(code as i32),
-            status.message(),
-        )),
-    };
-    trailers_from_status(status_res, &md)
-}
-
-// Builds a trailers with a status
-fn trailers_from_status(status: crate::Result<()>, md: &TonicMeta) -> ResponseStreamItem {
-    let trailers = match md.try_into() {
-        Err(e) => Trailers::new(Err(StatusError::new(
-            StatusCodeError::Internal,
-            format!("failed to parse metadata: {e}"),
-        ))),
-        Ok(metadata) => Trailers::new(status).with_metadata(metadata),
-    };
-    ResponseStreamItem::Trailers(trailers)
 }
 
 struct TonicSendStream {
@@ -245,10 +234,55 @@ impl SendStream for TonicSendStream {
 struct TonicRecvStream {
     state: StreamState,
     cancel_tx: Option<CancellationHandle>,
+    peer_info: Option<PeerInfo>,
+}
+
+impl TonicRecvStream {
+    // Converts from a tonic status to a trailers stream item.
+    fn trailers_from_tonic_status(
+        &mut self,
+        status: &TonicStatus,
+        mut md: TonicMeta,
+    ) -> ResponseStreamItem {
+        if !status.details().is_empty() {
+            md.insert_bin(
+                "grpc-status-details-bin",
+                tonic::metadata::MetadataValue::from_bytes(status.details()),
+            );
+        }
+        let status_res = match status.code() {
+            Code::Ok => Ok(()),
+            code => Err(StatusError::new(
+                StatusCodeError::from(code as i32),
+                status.message(),
+            )),
+        };
+        self.trailers_from_grpc_result(status_res, Some(&md))
+    }
+
+    // Builds a trailers stream item with a status.
+    fn trailers_from_grpc_result(
+        &mut self,
+        status: crate::Result<()>,
+        md: Option<&TonicMeta>,
+    ) -> ResponseStreamItem {
+        let trailers = if let Some(md) = md {
+            match md.try_into() {
+                Err(e) => Trailers::new(Err(StatusError::new(
+                    StatusCodeError::Internal,
+                    format!("failed to parse metadata: {e}"),
+                ))),
+                Ok(metadata) => Trailers::new(status).with_metadata(metadata),
+            }
+        } else {
+            Trailers::new(status)
+        };
+        ResponseStreamItem::Trailers(trailers.with_peer_info(self.peer_info.take()))
+    }
 }
 
 enum StreamState {
-    Error(StatusError),
+    LocalError(StatusError),
     AwaitingHeaders(oneshot::Receiver<Result<tonic::Response<Streaming<Bytes>>, TonicStatus>>),
     Streaming(Streaming<Bytes>),
     Closed,
@@ -262,8 +296,8 @@ impl RecvStream for TonicRecvStream {
         match state {
             // Closed is terminal.
             StreamState::Closed => ResponseStreamItem::StreamClosed,
-            // Stay closed after sending trailers.
-            StreamState::Error(error) => ResponseStreamItem::Trailers(Trailers::new(Err(error))),
+            // Stay closed after sending trailers (do not set self.state).
+            StreamState::LocalError(error) => self.trailers_from_grpc_result(Err(error), None),
             StreamState::AwaitingHeaders(rx) => match rx.await {
                 Ok(Ok(response)) => {
                     let (metadata, stream, _extensions) = response.into_parts();
@@ -278,32 +312,45 @@ impl RecvStream for TonicRecvStream {
                         Ok(md) => {
                             // Start streaming and return the headers.
                             self.state = StreamState::Streaming(stream);
-                            ResponseStreamItem::Headers(ResponseHeaders::new().with_metadata(md))
+                            let Some(peer_info) = self.peer_info.take() else {
+                                return self.trailers_from_grpc_result(
+                                    Err(StatusError::new(
+                                        StatusCodeError::Internal,
+                                        "required peer info missing",
+                                    )),
+                                    None,
+                                );
+                            };
+                            let headers = ResponseHeaders::new(peer_info).with_metadata(md);
+                            ResponseStreamItem::Headers(headers)
                         }
                         Err(e) => {
                             if let Some(cancel_tx) = self.cancel_tx.take() {
                                 cancel_tx.cancel();
                             }
-                            trailers_from_status(
+                            self.trailers_from_grpc_result(
                                 Err(StatusError::new(
                                     StatusCodeError::Internal,
                                     format!("error decoding response: {e}"),
                                 )),
-                                &TonicMeta::default(),
+                                None,
                             )
                         }
                     }
                 }
-                // Stay closed after sending trailers.
-                Err(_) => trailers_from_status(
-                    Err(StatusError::new(StatusCodeError::Unknown, "Task cancelled")),
-                    &TonicMeta::default(),
-                ),
+                Err(_) => {
+                    // Stay closed after sending trailers (do not set self.state).
+                    self.trailers_from_grpc_result(
+                        Err(StatusError::new(StatusCodeError::Unknown, "Task cancelled")),
+                        None,
+                    )
+                }
                 Ok(Err(mut status)) => {
                     // In a Trailers-only response, the tonic status contains
                     // the metadata.
+                    // Stay closed after sending trailers (do not set self.state).
                     let md = std::mem::take(status.metadata_mut());
-                    trailers_from_tonic_status(&status, md)
+                    self.trailers_from_tonic_status(&status, md)
                 }
             },
             StreamState::Streaming(mut stream) => match stream.message().await {
@@ -318,25 +365,26 @@ impl RecvStream for TonicRecvStream {
                         if let Some(cancel_tx) = self.cancel_tx.take() {
                             cancel_tx.cancel();
                         }
-                        trailers_from_status(
+                        self.trailers_from_grpc_result(
                             Err(StatusError::new(
                                 StatusCodeError::Internal,
                                 format!("error decoding response: {e}"),
                             )),
-                            &TonicMeta::default(),
+                            None,
                         )
                     }
                 },
-                // Stay closed after sending trailers.
                 Err(status) => {
+                    // Stay closed after sending trailers (do not set self.state).
                     let trailers = stream.trailers().await;
                     let md = trailers.unwrap_or_default().unwrap_or_default();
-                    trailers_from_tonic_status(&status, md)
+                    self.trailers_from_tonic_status(&status, md)
                 }
                 Ok(None) => {
+                    // Stay closed after sending trailers (do not set self.state).
                     let trailers = stream.trailers().await;
                     let md = trailers.unwrap_or_default().unwrap_or_default();
-                    trailers_from_status(Ok(()), &md)
+                    self.trailers_from_grpc_result(Ok(()), Some(&md))
                 }
             },
         }
@@ -351,16 +399,6 @@ impl Drop for TonicRecvStream {
     }
 }
 
-fn err_streams(status: StatusError) -> (TonicSendStream, TonicRecvStream) {
-    (
-        TonicSendStream { sender: Err(()) },
-        TonicRecvStream {
-            state: StreamState::Error(status),
-            cancel_tx: None,
-        },
-    )
-}
-
 impl Transport for TransportBuilder {
     type Service = TonicTransport;
 
@@ -373,7 +411,7 @@ impl Transport for TransportBuilder {
     ) -> Result<
         (
             Self::Service,
-            SecurityInfo,
+            PeerInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -432,6 +470,17 @@ impl Transport for TransportBuilder {
             )
             .await?;
 
+        let local_address = Address {
+            network_type: handshake_ouput.endpoint.get_network_type(),
+            address: ByteStr::from(handshake_ouput.endpoint.get_local_address().to_string()),
+            attributes: Attributes::new(),
+        };
+        let remote_address = Address {
+            network_type: handshake_ouput.endpoint.get_network_type(),
+            address: ByteStr::from(handshake_ouput.endpoint.get_peer_address().to_string()),
+            attributes: Attributes::new(),
+        };
+
         let transport = HyperStream::new(handshake_ouput.endpoint);
 
         let (sender, connection) = settings
@@ -463,12 +512,19 @@ impl Transport for TransportBuilder {
             .map_err(|e| format!("failed to create URL with authority {}: {}", authority, e))?;
         let grpc = Grpc::with_origin(TonicService { inner: service }, uri);
 
+        let peer_info = PeerInfo::new(
+            local_address,
+            remote_address,
+            handshake_ouput.security_info.clone(),
+        );
+
         let service = TonicTransport {
             grpc,
             task_handle,
             runtime,
+            peer_info: peer_info.clone(),
         };
-        Ok((service, handshake_ouput.security_info, rx))
+        Ok((service, peer_info, rx))
     }
 }
 

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -23,6 +23,7 @@
  */
 
 use std::fs;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::result::Result;
@@ -271,8 +272,25 @@ async fn grpc_invoke_tonic_unary() {
     let target = format!("dns:///{}", addr);
     let channel = Channel::builder(&target, LocalChannelCredentials::new_arc()).build();
 
-    let (_, resp, trailers) = perform_unary_echo(&channel, "hello interop").await;
+    let (headers, resp, trailers) = perform_unary_echo(&channel, "hello interop").await;
     assert_eq!(resp.message, "hello interop");
+
+    let peer_info = headers.peer_info();
+    assert_eq!(peer_info.local_address().network_type, TCP_IP_NETWORK_TYPE);
+    let local_addr: SocketAddr = peer_info.local_address().address.parse().unwrap();
+    assert_eq!(local_addr.ip(), addr.ip());
+    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+    assert_eq!(
+        peer_info.remote_address().address.to_string(),
+        addr.to_string()
+    );
+    assert_eq!(peer_info.security_info().security_protocol(), "local");
+
+    assert!(
+        trailers.peer_info().is_none(),
+        "trailers should not contain peer_info when headers were present; had {:?}",
+        trailers.peer_info().as_ref().unwrap()
+    );
 
     assert!(
         trailers.status().is_ok(),
@@ -294,9 +312,11 @@ mod unix_tests {
     use tokio_stream::wrappers::UnixListenerStream;
 
     use super::*;
+    use crate::client::name_resolution::UNIX_NETWORK_TYPE;
 
     async fn run_unix_test(bind_path: &PathBuf, target: &str) {
         let listener = UnixListener::bind(bind_path).unwrap();
+        let expected_remote_addr = format!("{:?}", listener.local_addr().unwrap());
         let channel = Channel::builder(target, LocalChannelCredentials::new_arc()).build();
 
         let shutdown_notify = Arc::new(Notify::new());
@@ -318,9 +338,24 @@ mod unix_tests {
         });
 
         let payload = "hello unix";
-        let (_, resp, trailers) = perform_unary_echo(&channel, payload).await;
+        let (headers, resp, trailers) = perform_unary_echo(&channel, payload).await;
         assert_eq!(resp.message, payload);
         assert!(trailers.status().is_ok());
+
+        let peer_info = headers.peer_info();
+        assert_eq!(peer_info.local_address().network_type, UNIX_NETWORK_TYPE);
+        assert!(!peer_info.local_address().address.is_empty());
+        assert_eq!(peer_info.remote_address().network_type, UNIX_NETWORK_TYPE);
+        assert_eq!(
+            peer_info.remote_address().address.to_string(),
+            expected_remote_addr
+        );
+        assert_eq!(peer_info.security_info().security_protocol(), "local");
+        assert!(
+            trailers.peer_info().is_none(),
+            "trailers should not contain peer_info when headers were present; had {:?}",
+            trailers.peer_info().as_ref().unwrap()
+        );
 
         shutdown_notify.notify_one();
         server_handle.await.unwrap();
@@ -472,7 +507,7 @@ async fn grpc_invoke_tonic_unary_tls() {
     let target = format!("dns:///{}", addr);
     let channel = Channel::builder(&target, Arc::new(composite_creds)).build();
 
-    let (headers, resp, trilers) = perform_unary_echo(&channel, "hello interop tls").await;
+    let (headers, resp, trailers) = perform_unary_echo(&channel, "hello interop tls").await;
 
     assert_eq!(
         headers.metadata().get("x-test-metadata-echo").unwrap(),
@@ -480,10 +515,27 @@ async fn grpc_invoke_tonic_unary_tls() {
     );
     assert_eq!(resp.message, "hello interop tls");
 
+    let peer_info = headers.peer_info();
+    assert_eq!(peer_info.local_address().network_type, TCP_IP_NETWORK_TYPE);
+    let local_addr: SocketAddr = peer_info.local_address().address.parse().unwrap();
+    assert_eq!(local_addr.ip(), addr.ip());
+    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+    assert_eq!(
+        peer_info.remote_address().address.to_string(),
+        addr.to_string()
+    );
+    assert_eq!(peer_info.security_info().security_protocol(), "tls");
+
     assert!(
-        trilers.status().is_ok(),
+        trailers.peer_info().is_none(),
+        "trailers should not contain peer_info when headers were present; had {:?}",
+        trailers.peer_info().as_ref().unwrap()
+    );
+
+    assert!(
+        trailers.status().is_ok(),
         "RPC failed: {:?}",
-        trilers.status()
+        trailers.status()
     );
 
     shutdown_notify.notify_one();
@@ -531,6 +583,16 @@ async fn grpc_invoke_failure_cases() {
             trailers.status().as_ref().unwrap_err().code(),
             StatusCodeError::Unauthenticated
         );
+        let peer_info = trailers
+            .peer_info()
+            .as_ref()
+            .expect("peer_info should be present in trailers");
+        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+        assert_eq!(
+            peer_info.remote_address().address.to_string(),
+            addr.to_string()
+        );
+        assert_eq!(peer_info.security_info().security_protocol(), "local");
     }
 
     // Call credentials return error
@@ -560,6 +622,16 @@ async fn grpc_invoke_failure_cases() {
                 .message()
                 .contains("test message")
         );
+        let peer_info = trailers
+            .peer_info()
+            .as_ref()
+            .expect("peer_info should be present in trailers");
+        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+        assert_eq!(
+            peer_info.remote_address().address.to_string(),
+            addr.to_string()
+        );
+        assert_eq!(peer_info.security_info().security_protocol(), "local");
     }
 
     // Call credentials return restricted control plane code (mapped to Internal)
@@ -589,6 +661,16 @@ async fn grpc_invoke_failure_cases() {
                 .message()
                 .contains("test message")
         );
+        let peer_info = trailers
+            .peer_info()
+            .as_ref()
+            .expect("peer_info should be present in trailers");
+        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+        assert_eq!(
+            peer_info.remote_address().address.to_string(),
+            addr.to_string()
+        );
+        assert_eq!(peer_info.security_info().security_protocol(), "local");
     }
 
     shutdown_notify.notify_one();
@@ -961,6 +1043,16 @@ async fn trailers_only_metadata() {
     let metadata_map = trailers.metadata();
     let value = metadata_map.get("x-custom-trailer").unwrap();
     assert_eq!(value, "custom-value");
+
+    let peer_info = trailers
+        .peer_info()
+        .as_ref()
+        .expect("trailers should contain peer_info in trailers-only response");
+    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+    assert_eq!(
+        peer_info.remote_address().address.to_string(),
+        addr.to_string()
+    );
 
     shutdown_notify.notify_one();
     server_handle.await.unwrap();

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -275,21 +275,27 @@ async fn grpc_invoke_tonic_unary() {
     let (headers, resp, trailers) = perform_unary_echo(&channel, "hello interop").await;
     assert_eq!(resp.message, "hello interop");
 
-    let peer_info = headers.peer_info();
-    assert_eq!(peer_info.local_address().network_type, TCP_IP_NETWORK_TYPE);
-    let local_addr: SocketAddr = peer_info.local_address().address.parse().unwrap();
-    assert_eq!(local_addr.ip(), addr.ip());
-    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+    let connection_info = headers.connection_info();
     assert_eq!(
-        peer_info.remote_address().address.to_string(),
+        connection_info.local_address().network_type,
+        TCP_IP_NETWORK_TYPE
+    );
+    let local_addr: SocketAddr = connection_info.local_address().address.parse().unwrap();
+    assert_eq!(local_addr.ip(), addr.ip());
+    assert_eq!(
+        connection_info.remote_address().network_type,
+        TCP_IP_NETWORK_TYPE
+    );
+    assert_eq!(
+        connection_info.remote_address().address.to_string(),
         addr.to_string()
     );
-    assert_eq!(peer_info.security_info().security_protocol(), "local");
+    assert_eq!(connection_info.security_info().security_protocol(), "local");
 
     assert!(
-        trailers.peer_info().is_none(),
-        "trailers should not contain peer_info when headers were present; had {:?}",
-        trailers.peer_info().as_ref().unwrap()
+        trailers.connection_info().is_none(),
+        "trailers should not contain connection_info when headers were present; had {:?}",
+        trailers.connection_info().as_ref().unwrap()
     );
 
     assert!(
@@ -342,19 +348,25 @@ mod unix_tests {
         assert_eq!(resp.message, payload);
         assert!(trailers.status().is_ok());
 
-        let peer_info = headers.peer_info();
-        assert_eq!(peer_info.local_address().network_type, UNIX_NETWORK_TYPE);
-        assert!(!peer_info.local_address().address.is_empty());
-        assert_eq!(peer_info.remote_address().network_type, UNIX_NETWORK_TYPE);
+        let connection_info = headers.connection_info();
         assert_eq!(
-            peer_info.remote_address().address.to_string(),
+            connection_info.local_address().network_type,
+            UNIX_NETWORK_TYPE
+        );
+        assert!(!connection_info.local_address().address.is_empty());
+        assert_eq!(
+            connection_info.remote_address().network_type,
+            UNIX_NETWORK_TYPE
+        );
+        assert_eq!(
+            connection_info.remote_address().address.to_string(),
             expected_remote_addr
         );
-        assert_eq!(peer_info.security_info().security_protocol(), "local");
+        assert_eq!(connection_info.security_info().security_protocol(), "local");
         assert!(
-            trailers.peer_info().is_none(),
-            "trailers should not contain peer_info when headers were present; had {:?}",
-            trailers.peer_info().as_ref().unwrap()
+            trailers.connection_info().is_none(),
+            "trailers should not contain connection_info when headers were present; had {:?}",
+            trailers.connection_info().as_ref().unwrap()
         );
 
         shutdown_notify.notify_one();
@@ -515,21 +527,27 @@ async fn grpc_invoke_tonic_unary_tls() {
     );
     assert_eq!(resp.message, "hello interop tls");
 
-    let peer_info = headers.peer_info();
-    assert_eq!(peer_info.local_address().network_type, TCP_IP_NETWORK_TYPE);
-    let local_addr: SocketAddr = peer_info.local_address().address.parse().unwrap();
-    assert_eq!(local_addr.ip(), addr.ip());
-    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+    let connection_info = headers.connection_info();
     assert_eq!(
-        peer_info.remote_address().address.to_string(),
+        connection_info.local_address().network_type,
+        TCP_IP_NETWORK_TYPE
+    );
+    let local_addr: SocketAddr = connection_info.local_address().address.parse().unwrap();
+    assert_eq!(local_addr.ip(), addr.ip());
+    assert_eq!(
+        connection_info.remote_address().network_type,
+        TCP_IP_NETWORK_TYPE
+    );
+    assert_eq!(
+        connection_info.remote_address().address.to_string(),
         addr.to_string()
     );
-    assert_eq!(peer_info.security_info().security_protocol(), "tls");
+    assert_eq!(connection_info.security_info().security_protocol(), "tls");
 
     assert!(
-        trailers.peer_info().is_none(),
-        "trailers should not contain peer_info when headers were present; had {:?}",
-        trailers.peer_info().as_ref().unwrap()
+        trailers.connection_info().is_none(),
+        "trailers should not contain connection_info when headers were present; had {:?}",
+        trailers.connection_info().as_ref().unwrap()
     );
 
     assert!(
@@ -583,16 +601,19 @@ async fn grpc_invoke_failure_cases() {
             trailers.status().as_ref().unwrap_err().code(),
             StatusCodeError::Unauthenticated
         );
-        let peer_info = trailers
-            .peer_info()
+        let connection_info = trailers
+            .connection_info()
             .as_ref()
-            .expect("peer_info should be present in trailers");
-        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+            .expect("connection_info should be present in trailers");
         assert_eq!(
-            peer_info.remote_address().address.to_string(),
+            connection_info.remote_address().network_type,
+            TCP_IP_NETWORK_TYPE
+        );
+        assert_eq!(
+            connection_info.remote_address().address.to_string(),
             addr.to_string()
         );
-        assert_eq!(peer_info.security_info().security_protocol(), "local");
+        assert_eq!(connection_info.security_info().security_protocol(), "local");
     }
 
     // Call credentials return error
@@ -622,16 +643,19 @@ async fn grpc_invoke_failure_cases() {
                 .message()
                 .contains("test message")
         );
-        let peer_info = trailers
-            .peer_info()
+        let connection_info = trailers
+            .connection_info()
             .as_ref()
-            .expect("peer_info should be present in trailers");
-        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+            .expect("connection_info should be present in trailers");
         assert_eq!(
-            peer_info.remote_address().address.to_string(),
+            connection_info.remote_address().network_type,
+            TCP_IP_NETWORK_TYPE
+        );
+        assert_eq!(
+            connection_info.remote_address().address.to_string(),
             addr.to_string()
         );
-        assert_eq!(peer_info.security_info().security_protocol(), "local");
+        assert_eq!(connection_info.security_info().security_protocol(), "local");
     }
 
     // Call credentials return restricted control plane code (mapped to Internal)
@@ -661,16 +685,19 @@ async fn grpc_invoke_failure_cases() {
                 .message()
                 .contains("test message")
         );
-        let peer_info = trailers
-            .peer_info()
+        let connection_info = trailers
+            .connection_info()
             .as_ref()
-            .expect("peer_info should be present in trailers");
-        assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+            .expect("connection_info should be present in trailers");
         assert_eq!(
-            peer_info.remote_address().address.to_string(),
+            connection_info.remote_address().network_type,
+            TCP_IP_NETWORK_TYPE
+        );
+        assert_eq!(
+            connection_info.remote_address().address.to_string(),
             addr.to_string()
         );
-        assert_eq!(peer_info.security_info().security_protocol(), "local");
+        assert_eq!(connection_info.security_info().security_protocol(), "local");
     }
 
     shutdown_notify.notify_one();
@@ -1044,13 +1071,16 @@ async fn trailers_only_metadata() {
     let value = metadata_map.get("x-custom-trailer").unwrap();
     assert_eq!(value, "custom-value");
 
-    let peer_info = trailers
-        .peer_info()
+    let connection_info = trailers
+        .connection_info()
         .as_ref()
-        .expect("trailers should contain peer_info in trailers-only response");
-    assert_eq!(peer_info.remote_address().network_type, TCP_IP_NETWORK_TYPE);
+        .expect("trailers should contain connection_info in trailers-only response");
     assert_eq!(
-        peer_info.remote_address().address.to_string(),
+        connection_info.remote_address().network_type,
+        TCP_IP_NETWORK_TYPE
+    );
+    assert_eq!(
+        connection_info.remote_address().address.to_string(),
         addr.to_string()
     );
 

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -155,13 +155,13 @@ impl Display for Address {
 /// Information about the connection to the RPC's peer (from the client/server
 /// pair).
 #[derive(Debug, Clone)]
-pub struct PeerInfo {
+pub struct ConnectionInfo {
     local_address: Address,
     remote_address: Address,
     security_info: SecurityInfo,
 }
 
-impl PeerInfo {
+impl ConnectionInfo {
     /// Constructs a new PeerInfo with the given fields.
     pub fn new(
         local_address: Address,
@@ -192,8 +192,8 @@ impl PeerInfo {
 }
 
 #[cfg(test)]
-pub(crate) fn test_peer_info() -> PeerInfo {
-    PeerInfo {
+pub(crate) fn test_peer_info() -> ConnectionInfo {
+    ConnectionInfo {
         local_address: Address {
             network_type: "",
             address: ByteStr::default(),

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -46,6 +46,7 @@ use bytes::Buf;
 
 use crate::attributes::Attributes;
 use crate::byte_str::ByteStr;
+use crate::credentials::SecurityInfo;
 
 /// Represents a message sent by either a client or a server.
 #[allow(unused)]
@@ -148,5 +149,57 @@ impl Display for Address {
     #[allow(clippy::to_string_in_format_args)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}:{}", self.network_type, self.address.to_string())
+    }
+}
+
+/// Information about the connection to the RPC's peer (from the client/server
+/// pair).
+#[derive(Debug, Clone)]
+pub struct PeerInfo {
+    local_address: Address,
+    remote_address: Address,
+    security_info: SecurityInfo,
+}
+
+impl PeerInfo {
+    /// Constructs a new PeerInfo with the given fields.
+    pub fn new(local_address: Address, remote_address: Address, security_info: SecurityInfo) -> Self {
+        Self {
+            local_address,
+            remote_address,
+            security_info,
+        }
+    }
+
+    /// Returns the connection's local address.
+    pub fn local_address(&self) -> &Address {
+        &self.local_address
+    }
+
+    /// Returns the peer's address.
+    pub fn remote_address(&self) -> &Address {
+        &self.remote_address
+    }
+
+    /// Returns the connection's security information (e.g. TLS parameters).
+    pub fn security_info(&self) -> &SecurityInfo {
+        &self.security_info
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_peer_info() -> PeerInfo {
+    PeerInfo {
+        local_address: Address {
+            network_type: "",
+            address: ByteStr::default(),
+            attributes: Attributes::new(),
+        },
+        remote_address: Address {
+            network_type: "",
+            address: ByteStr::default(),
+            attributes: Attributes::new(),
+        },
+        security_info: SecurityInfo::new(""),
     }
 }

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -163,7 +163,11 @@ pub struct PeerInfo {
 
 impl PeerInfo {
     /// Constructs a new PeerInfo with the given fields.
-    pub fn new(local_address: Address, remote_address: Address, security_info: SecurityInfo) -> Self {
+    pub fn new(
+        local_address: Address,
+        remote_address: Address,
+        security_info: SecurityInfo,
+    ) -> Self {
         Self {
             local_address,
             remote_address,

--- a/grpc/src/core/mod.rs
+++ b/grpc/src/core/mod.rs
@@ -162,7 +162,7 @@ pub struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
-    /// Constructs a new PeerInfo with the given fields.
+    /// Constructs a new instance with the given fields.
     pub fn new(
         local_address: Address,
         remote_address: Address,
@@ -192,7 +192,7 @@ impl ConnectionInfo {
 }
 
 #[cfg(test)]
-pub(crate) fn test_peer_info() -> ConnectionInfo {
+pub(crate) fn test_connection_info() -> ConnectionInfo {
     ConnectionInfo {
         local_address: Address {
             network_type: "",

--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -137,6 +137,7 @@ pub enum SecurityLevel {
 }
 
 /// Represents the security state of an established connection.
+#[derive(Debug, Clone)]
 pub struct SecurityInfo {
     security_protocol: &'static str,
     security_level: SecurityLevel,

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -379,10 +379,17 @@ pub struct InMemoryClientRecvStream {
 impl ClientRecvStream for InMemoryClientRecvStream {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         match self.rx.recv().await {
-            Some(InMemoryResponseStreamItem::Headers(h)) => ResponseStreamItem::Headers(
-                ClientResponseHeaders::new(self.peer_info.take().unwrap())
+            Some(InMemoryResponseStreamItem::Headers(h)) => {
+                // Note: peer_info is always set when the stream is created, and
+                // the server should not send headers twice, so expect here
+                // should be safe.
+                ResponseStreamItem::Headers(
+                    ClientResponseHeaders::new(
+                        self.peer_info.take().expect("stream should have peer_info"),
+                    )
                     .with_metadata(h.into_metadata()),
-            ),
+                )
+            }
             Some(InMemoryResponseStreamItem::Message(mut buf)) => {
                 msg.decode(&mut buf).unwrap();
                 ResponseStreamItem::Message
@@ -392,9 +399,9 @@ impl ClientRecvStream for InMemoryClientRecvStream {
                     match trailer_rx.await {
                         Ok(trailers) => {
                             let (status, metadata) = trailers.into_parts();
-                            let mut client_trailers =
-                                ClientTrailers::new(status).with_metadata(metadata);
-                            client_trailers = client_trailers.with_peer_info(self.peer_info.take());
+                            let client_trailers = ClientTrailers::new(status)
+                                .with_metadata(metadata)
+                                .with_peer_info(self.peer_info.take());
                             return ResponseStreamItem::Trailers(client_trailers);
                         }
                         Err(_) => {

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -67,7 +67,7 @@ use crate::client::transport::SecurityOpts;
 use crate::client::transport::Transport;
 use crate::client::transport::TransportOptions;
 use crate::core::Address;
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::credentials::SecurityInfo;
@@ -295,7 +295,7 @@ impl ServerRecvStream for InMemoryServerRecvStream {
 pub struct InMemoryConnection {
     s: mpsc::Sender<InMemoryServerCall>,
     closed_tx: Option<oneshot::Sender<Result<(), String>>>,
-    peer_info: PeerInfo,
+    peer_info: ConnectionInfo,
 }
 
 impl Invoke for InMemoryConnection {
@@ -373,7 +373,7 @@ impl Drop for InMemoryClientSendStream {
 pub struct InMemoryClientRecvStream {
     rx: mpsc::UnboundedReceiver<InMemoryResponseStreamItem>,
     trailer_rx: Option<oneshot::Receiver<ServerTrailers>>,
-    peer_info: Option<PeerInfo>,
+    peer_info: Option<ConnectionInfo>,
 }
 
 impl ClientRecvStream for InMemoryClientRecvStream {
@@ -434,7 +434,7 @@ impl Transport for InMemoryTransport {
     ) -> Result<
         (
             Self::Service,
-            PeerInfo,
+            ConnectionInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -454,7 +454,7 @@ impl Transport for InMemoryTransport {
             address: ByteStr::default(),
             attributes: Attributes::new(),
         };
-        let peer_info = PeerInfo::new(local_address, address.clone(), sec_info);
+        let peer_info = ConnectionInfo::new(local_address, address.clone(), sec_info);
         let conn = InMemoryConnection {
             s: s.clone(),
             closed_tx: Some(closed_tx),

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -295,7 +295,7 @@ impl ServerRecvStream for InMemoryServerRecvStream {
 pub struct InMemoryConnection {
     s: mpsc::Sender<InMemoryServerCall>,
     closed_tx: Option<oneshot::Sender<Result<(), String>>>,
-    peer_info: ConnectionInfo,
+    connection_info: ConnectionInfo,
 }
 
 impl Invoke for InMemoryConnection {
@@ -312,8 +312,8 @@ impl Invoke for InMemoryConnection {
         let (trailer_tx, trailer_rx) = oneshot::channel();
 
         let (method_name, metadata) = headers.into_parts();
-        let server_headers =
-            ServerRequestHeaders::new(method_name, self.peer_info.clone()).with_metadata(metadata);
+        let server_headers = ServerRequestHeaders::new(method_name, self.connection_info.clone())
+            .with_metadata(metadata);
 
         let call = InMemoryServerCall {
             headers: server_headers,
@@ -329,7 +329,7 @@ impl Invoke for InMemoryConnection {
             Box::new(InMemoryClientRecvStream {
                 rx: resp_rx,
                 trailer_rx: Some(trailer_rx),
-                peer_info: Some(self.peer_info.clone()),
+                connection_info: Some(self.connection_info.clone()),
             }),
         )
     }
@@ -373,19 +373,21 @@ impl Drop for InMemoryClientSendStream {
 pub struct InMemoryClientRecvStream {
     rx: mpsc::UnboundedReceiver<InMemoryResponseStreamItem>,
     trailer_rx: Option<oneshot::Receiver<ServerTrailers>>,
-    peer_info: Option<ConnectionInfo>,
+    connection_info: Option<ConnectionInfo>,
 }
 
 impl ClientRecvStream for InMemoryClientRecvStream {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         match self.rx.recv().await {
             Some(InMemoryResponseStreamItem::Headers(h)) => {
-                // Note: peer_info is always set when the stream is created, and
+                // Note: connection_info is always set when the stream is created, and
                 // the server should not send headers twice, so expect here
                 // should be safe.
                 ResponseStreamItem::Headers(
                     ClientResponseHeaders::new(
-                        self.peer_info.take().expect("stream should have peer_info"),
+                        self.connection_info
+                            .take()
+                            .expect("stream should have connection_info"),
                     )
                     .with_metadata(h.into_metadata()),
                 )
@@ -401,7 +403,7 @@ impl ClientRecvStream for InMemoryClientRecvStream {
                             let (status, metadata) = trailers.into_parts();
                             let client_trailers = ClientTrailers::new(status)
                                 .with_metadata(metadata)
-                                .with_peer_info(self.peer_info.take());
+                                .with_connection_info(self.connection_info.take());
                             return ResponseStreamItem::Trailers(client_trailers);
                         }
                         Err(_) => {
@@ -454,14 +456,14 @@ impl Transport for InMemoryTransport {
             address: ByteStr::default(),
             attributes: Attributes::new(),
         };
-        let peer_info = ConnectionInfo::new(local_address, address.clone(), sec_info);
+        let connection_info = ConnectionInfo::new(local_address, address.clone(), sec_info);
         let conn = InMemoryConnection {
             s: s.clone(),
             closed_tx: Some(closed_tx),
-            peer_info: peer_info.clone(),
+            connection_info: connection_info.clone(),
         };
 
-        Ok((conn, peer_info, closed_rx))
+        Ok((conn, connection_info, closed_rx))
     }
 }
 
@@ -528,7 +530,7 @@ mod tests {
 
     use super::*;
     use crate::core::RecvMessage;
-    use crate::core::test_peer_info;
+    use crate::core::test_connection_info;
 
     struct NopRecvMessage;
     impl RecvMessage for NopRecvMessage {
@@ -550,7 +552,7 @@ mod tests {
         let mut stream = InMemoryClientRecvStream {
             rx,
             trailer_rx: Some(trailer_rx),
-            peer_info: Some(test_peer_info()),
+            connection_info: Some(test_connection_info()),
         };
 
         let mut msg = NopRecvMessage;
@@ -632,7 +634,7 @@ mod tests {
         let (trailer_tx, _trailer_rx) = oneshot::channel();
 
         let transport = InMemoryServerCall {
-            headers: RequestHeaders::new("", test_peer_info()),
+            headers: RequestHeaders::new("", test_connection_info()),
             req_rx,
             resp_tx,
             trailer_tx,

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -40,6 +40,8 @@ use tokio::sync::oneshot;
 
 use crate::StatusCodeError;
 use crate::StatusError;
+use crate::attributes::Attributes;
+use crate::byte_str::ByteStr;
 use crate::client::CallOptions;
 use crate::client::DynRecvStream as ClientDynRecvStream;
 use crate::client::DynSendStream as ClientDynSendStream;
@@ -65,6 +67,7 @@ use crate::client::transport::SecurityOpts;
 use crate::client::transport::Transport;
 use crate::client::transport::TransportOptions;
 use crate::core::Address;
+use crate::core::PeerInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::credentials::SecurityInfo;
@@ -292,6 +295,7 @@ impl ServerRecvStream for InMemoryServerRecvStream {
 pub struct InMemoryConnection {
     s: mpsc::Sender<InMemoryServerCall>,
     closed_tx: Option<oneshot::Sender<Result<(), String>>>,
+    peer_info: PeerInfo,
 }
 
 impl Invoke for InMemoryConnection {
@@ -308,9 +312,8 @@ impl Invoke for InMemoryConnection {
         let (trailer_tx, trailer_rx) = oneshot::channel();
 
         let (method_name, metadata) = headers.into_parts();
-        let server_headers = ServerRequestHeaders::new()
-            .with_method_name(method_name)
-            .with_metadata(metadata);
+        let server_headers =
+            ServerRequestHeaders::new(method_name, self.peer_info.clone()).with_metadata(metadata);
 
         let call = InMemoryServerCall {
             headers: server_headers,
@@ -326,6 +329,7 @@ impl Invoke for InMemoryConnection {
             Box::new(InMemoryClientRecvStream {
                 rx: resp_rx,
                 trailer_rx: Some(trailer_rx),
+                peer_info: Some(self.peer_info.clone()),
             }),
         )
     }
@@ -369,13 +373,15 @@ impl Drop for InMemoryClientSendStream {
 pub struct InMemoryClientRecvStream {
     rx: mpsc::UnboundedReceiver<InMemoryResponseStreamItem>,
     trailer_rx: Option<oneshot::Receiver<ServerTrailers>>,
+    peer_info: Option<PeerInfo>,
 }
 
 impl ClientRecvStream for InMemoryClientRecvStream {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         match self.rx.recv().await {
             Some(InMemoryResponseStreamItem::Headers(h)) => ResponseStreamItem::Headers(
-                ClientResponseHeaders::new().with_metadata(h.into_metadata()),
+                ClientResponseHeaders::new(self.peer_info.take().unwrap())
+                    .with_metadata(h.into_metadata()),
             ),
             Some(InMemoryResponseStreamItem::Message(mut buf)) => {
                 msg.decode(&mut buf).unwrap();
@@ -386,9 +392,10 @@ impl ClientRecvStream for InMemoryClientRecvStream {
                     match trailer_rx.await {
                         Ok(trailers) => {
                             let (status, metadata) = trailers.into_parts();
-                            return ResponseStreamItem::Trailers(
-                                ClientTrailers::new(status).with_metadata(metadata),
-                            );
+                            let mut client_trailers =
+                                ClientTrailers::new(status).with_metadata(metadata);
+                            client_trailers = client_trailers.with_peer_info(self.peer_info.take());
+                            return ResponseStreamItem::Trailers(client_trailers);
                         }
                         Err(_) => {
                             return ResponseStreamItem::Trailers(ClientTrailers::new(Err(
@@ -420,7 +427,7 @@ impl Transport for InMemoryTransport {
     ) -> Result<
         (
             Self::Service,
-            SecurityInfo,
+            PeerInfo,
             oneshot::Receiver<Result<(), String>>,
         ),
         String,
@@ -429,17 +436,25 @@ impl Transport for InMemoryTransport {
         let listeners = LISTENERS.lock().unwrap();
         let s = listeners
             .get(target)
-            .ok_or_else(|| format!("no listener for target: {}", target))?;
+            .ok_or_else(|| format!("no listener for target: {}", target))?
+            .clone();
 
         let (closed_tx, closed_rx) = oneshot::channel();
+        let sec_info =
+            SecurityInfo::new("inmemory").with_security_level(SecurityLevel::PrivacyAndIntegrity);
+        let local_address = Address {
+            network_type: address.network_type,
+            address: ByteStr::default(),
+            attributes: Attributes::new(),
+        };
+        let peer_info = PeerInfo::new(local_address, address.clone(), sec_info);
         let conn = InMemoryConnection {
             s: s.clone(),
             closed_tx: Some(closed_tx),
+            peer_info: peer_info.clone(),
         };
-        let sec_info =
-            SecurityInfo::new("inmemory").with_security_level(SecurityLevel::PrivacyAndIntegrity);
 
-        Ok((conn, sec_info, closed_rx))
+        Ok((conn, peer_info, closed_rx))
     }
 }
 
@@ -506,6 +521,7 @@ mod tests {
 
     use super::*;
     use crate::core::RecvMessage;
+    use crate::core::test_peer_info;
 
     struct NopRecvMessage;
     impl RecvMessage for NopRecvMessage {
@@ -527,6 +543,7 @@ mod tests {
         let mut stream = InMemoryClientRecvStream {
             rx,
             trailer_rx: Some(trailer_rx),
+            peer_info: Some(test_peer_info()),
         };
 
         let mut msg = NopRecvMessage;
@@ -608,7 +625,7 @@ mod tests {
         let (trailer_tx, _trailer_rx) = oneshot::channel();
 
         let transport = InMemoryServerCall {
-            headers: RequestHeaders::new(),
+            headers: RequestHeaders::new("", test_peer_info()),
             req_rx,
             resp_tx,
             trailer_tx,

--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -98,6 +98,7 @@ mod test {
     use super::*;
     use crate::client::CallOptions;
     use crate::core::RecvMessage;
+    use crate::core::test_peer_info;
     use crate::server::RequestHeaders;
     use crate::server::ResponseStreamItem;
     use crate::server::SendOptions;
@@ -177,7 +178,7 @@ mod test {
 
         chain
             .handle(
-                RequestHeaders::default(),
+                RequestHeaders::new("", test_peer_info()),
                 CallOptions::default(),
                 &mut tx,
                 rx,
@@ -251,7 +252,7 @@ mod test {
 
         chain
             .handle(
-                RequestHeaders::default(),
+                RequestHeaders::new("", test_peer_info()),
                 CallOptions::default(),
                 &mut tx,
                 rx,

--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -97,7 +97,7 @@ mod test {
 
     use super::*;
     use crate::core::RecvMessage;
-    use crate::core::test_peer_info;
+    use crate::core::test_connection_info;
     use crate::server::RequestHeaders;
     use crate::server::ResponseStreamItem;
     use crate::server::SendOptions;
@@ -177,7 +177,7 @@ mod test {
 
         chain
             .handle(
-                RequestHeaders::new("", test_peer_info()),
+                RequestHeaders::new("", test_connection_info()),
                 CallOptions::default(),
                 &mut tx,
                 rx,
@@ -251,7 +251,7 @@ mod test {
 
         chain
             .handle(
-                RequestHeaders::new("", test_peer_info()),
+                RequestHeaders::new("", test_connection_info()),
                 CallOptions::default(),
                 &mut tx,
                 rx,

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -516,15 +516,15 @@ pub struct RequestHeaders {
     /// The application-specified metadata for the call.
     metadata: MetadataMap,
     /// Information about the client.
-    peer_info: ConnectionInfo,
+    connection_info: ConnectionInfo,
 }
 
 impl RequestHeaders {
     /// Returns a default RequestHeaders instance.
-    pub fn new(method_name: impl Into<String>, peer_info: ConnectionInfo) -> Self {
+    pub fn new(method_name: impl Into<String>, connection_info: ConnectionInfo) -> Self {
         Self {
             method_name: method_name.into(),
-            peer_info,
+            connection_info,
             metadata: MetadataMap::default(),
         }
     }
@@ -556,15 +556,15 @@ impl RequestHeaders {
         &mut self.metadata
     }
 
-    /// Replaces the peer_info of self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: ConnectionInfo) -> Self {
-        self.peer_info = peer_info;
+    /// Replaces the connection_info of self with `connection_info`.
+    pub fn with_connection_info(mut self, connection_info: ConnectionInfo) -> Self {
+        self.connection_info = connection_info;
         self
     }
 
-    /// Replaces the peer_info of self with `peer_info`.
-    pub fn peer_info(&self) -> &ConnectionInfo {
-        &self.peer_info
+    /// Returns a reference to the connection_info in these headers.
+    pub fn connection_info(&self) -> &ConnectionInfo {
+        &self.connection_info
     }
 
     /// Returns the owned fields in the RequestHeaders.
@@ -639,7 +639,7 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::*;
-    use crate::core::test_peer_info;
+    use crate::core::test_connection_info;
 
     /// A mock connection whose completion is controlled by a [`Notify`],
     /// and which records whether [`graceful_shutdown`] was called.
@@ -969,7 +969,7 @@ mod tests {
                 let rx = BoxedRecvStream(Box::new(NopRecvStream));
                 let _ = handler
                     .dyn_handle(
-                        RequestHeaders::new("", test_peer_info()),
+                        RequestHeaders::new("", test_connection_info()),
                         CallOptions::new(),
                         &mut tx,
                         rx,

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -528,7 +528,7 @@ impl RequestHeaders {
     }
 
     /// Returns the full (e.g. "/Service/Method") method name for these headers.
-    pub fn method_name(&self) -> &String {
+    pub fn method_name(&self) -> &str {
         &self.method_name
     }
 

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -52,6 +52,7 @@ use std::sync::Arc;
 use tonic::async_trait;
 
 use crate::client::CallOptions;
+use crate::core::PeerInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::metadata::MetadataMap;
@@ -494,18 +495,24 @@ impl ResponseHeaders {
 }
 
 /// Contains all information transmitted in the request headers of an RPC.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RequestHeaders {
     /// The full (e.g. "/Service/Method") method name specified for the call.
     method_name: String,
     /// The application-specified metadata for the call.
     metadata: MetadataMap,
+    /// Information about the client.
+    peer_info: PeerInfo,
 }
 
 impl RequestHeaders {
     /// Returns a default RequestHeaders instance.
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(method_name: impl Into<String>, peer_info: PeerInfo) -> Self {
+        Self {
+            method_name: method_name.into(),
+            peer_info,
+            metadata: MetadataMap::default(),
+        }
     }
 
     /// Replaces the method name of self with `method_name`.
@@ -521,7 +528,7 @@ impl RequestHeaders {
     }
 
     /// Returns the full (e.g. "/Service/Method") method name for these headers.
-    pub fn method_name(&self) -> &str {
+    pub fn method_name(&self) -> &String {
         &self.method_name
     }
 
@@ -533,6 +540,17 @@ impl RequestHeaders {
     /// Returns a mutable reference to the metadata in these headers.
     pub fn metadata_mut(&mut self) -> &mut MetadataMap {
         &mut self.metadata
+    }
+
+    /// Replaces the peer_info of self with `peer_info`.
+    pub fn with_peer_info(mut self, peer_info: PeerInfo) -> Self {
+        self.peer_info = peer_info;
+        self
+    }
+
+    /// Replaces the peer_info of self with `peer_info`.
+    pub fn peer_info(&self) -> &PeerInfo {
+        &self.peer_info
     }
 
     /// Returns the owned fields in the RequestHeaders.
@@ -607,6 +625,7 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::*;
+    use crate::core::test_peer_info;
 
     /// A mock connection whose completion is controlled by a [`Notify`],
     /// and which records whether [`graceful_shutdown`] was called.
@@ -935,7 +954,12 @@ mod tests {
                 let mut tx = NopSendStream;
                 let rx = BoxedRecvStream(Box::new(NopRecvStream));
                 let _ = handler
-                    .dyn_handle(RequestHeaders::new(), CallOptions::new(), &mut tx, rx)
+                    .dyn_handle(
+                        RequestHeaders::new("", test_peer_info()),
+                        CallOptions::new(),
+                        &mut tx,
+                        rx,
+                    )
                     .await;
             });
             MockServingConnection { inner }

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -51,7 +51,7 @@ use std::sync::Arc;
 
 use tonic::async_trait;
 
-use crate::core::PeerInfo;
+use crate::core::ConnectionInfo;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::metadata::MetadataMap;
@@ -516,12 +516,12 @@ pub struct RequestHeaders {
     /// The application-specified metadata for the call.
     metadata: MetadataMap,
     /// Information about the client.
-    peer_info: PeerInfo,
+    peer_info: ConnectionInfo,
 }
 
 impl RequestHeaders {
     /// Returns a default RequestHeaders instance.
-    pub fn new(method_name: impl Into<String>, peer_info: PeerInfo) -> Self {
+    pub fn new(method_name: impl Into<String>, peer_info: ConnectionInfo) -> Self {
         Self {
             method_name: method_name.into(),
             peer_info,
@@ -557,13 +557,13 @@ impl RequestHeaders {
     }
 
     /// Replaces the peer_info of self with `peer_info`.
-    pub fn with_peer_info(mut self, peer_info: PeerInfo) -> Self {
+    pub fn with_peer_info(mut self, peer_info: ConnectionInfo) -> Self {
         self.peer_info = peer_info;
         self
     }
 
     /// Replaces the peer_info of self with `peer_info`.
-    pub fn peer_info(&self) -> &PeerInfo {
+    pub fn peer_info(&self) -> &ConnectionInfo {
         &self.peer_info
     }
 


### PR DESCRIPTION
Also: return `ConnectionInfo` from `Transport::connect` instead of `SecurityInfo` _(yes, I know I just changed it to produce `SecurityInfo`)_ so that the subchannel can set the full `ConnectionInfo` in Trailers when producing errors locally, since the address of the subchannel may be relevant to those errors.

FWIW I wanted to make the subchannel apply an interceptor that could always set `ConnectionInfo` in response streams (either `ResponseHeaders` or in `Trailers`-only responses), but because the field is mandatory in `ResponseHeaders`, the transport would need to set it to some default/empty value, which felt wrong.  Anything producing a `ResponseHeaders` or `Trailers` should ensure the `ConnectionInfo` is set correctly.

cc @joshuatants as FYI - this is the change that will provide you with the ability to determine the server's address.