### PR TITLE
test: enable webpki TLS feature for test

### DIFF
--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -10,7 +10,7 @@ name = "integration-tests"
 bytes = "1.0"
 prost = "0.14"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net", "sync"]}
-tonic = {path = "../../tonic"}
+tonic = {path = "../../tonic", features = ["tls-webpki-roots"]}
 tonic-prost = {path = "../../tonic-prost"}
 tracing-subscriber = {version = "0.3"}
 


### PR DESCRIPTION
Fixes: #2801

This change enables the `tls-webpki-roots` feature for integration tests that verify the identity of `github.com`. 

This issue wasn't caught by CI because our CI configuration currently builds with all feature flags enabled. Please see the attached issue for details on the root cause.


## Tested

Verified that `cargo test` on the workspace root works.