### PR TITLE
fix/silence all clippy warnings

### DIFF
--- a/examples/src/grpc-gcp/client.rs
+++ b/examples/src/grpc-gcp/client.rs
@@ -22,7 +22,7 @@
  *
  */
 
-#[allow(unused)]
+#[allow(unused, clippy::all)]
 mod generated {
     pub mod api {
         grpc::include_proto!("google/pubsub/v1", "pubsub");

--- a/examples/src/grpc-helloworld/client.rs
+++ b/examples/src/grpc-helloworld/client.rs
@@ -22,7 +22,7 @@
  *
  */
 
-#[allow(unused)]
+#[allow(unused, clippy::all)]
 mod generated {
     pub mod helloworld {
         grpc::include_generated_proto!("generated/helloworld", "helloworld");

--- a/examples/src/grpc-routeguide/client.rs
+++ b/examples/src/grpc-routeguide/client.rs
@@ -24,7 +24,7 @@
 
 use protobuf::proto;
 
-#[allow(unused)]
+#[allow(unused, clippy::all)]
 mod generated {
     pub mod routeguide {
         grpc::include_generated_proto!("generated/routeguide", "route_guide");

--- a/examples/src/health/server.rs
+++ b/examples/src/health/server.rs
@@ -59,7 +59,7 @@ async fn twiddle_service_status(reporter: HealthReporter) {
         iter += 1;
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        if iter % 2 == 0 {
+        if iter.is_multiple_of(2) {
             reporter.set_serving::<GreeterServer<MyGreeter>>().await;
         } else {
             reporter.set_not_serving::<GreeterServer<MyGreeter>>().await;

--- a/grpc-benchmark/src/lib.rs
+++ b/grpc-benchmark/src/lib.rs
@@ -22,7 +22,7 @@
  *
  */
 
-#[allow(unused)]
+#[allow(unused, clippy::all)]
 pub mod generated {
     pub mod grpc {
         pub mod testing {

--- a/grpc-protobuf/src/status.rs
+++ b/grpc-protobuf/src/status.rs
@@ -176,7 +176,7 @@ impl StatusError {
     /// Create a new [`StatusError`] with the given code and message.
     pub fn new(code: StatusCodeError, message: impl Into<String>) -> Self {
         StatusError {
-            code: code,
+            code,
             message: message.into(),
             payloads: BTreeMap::new(),
         }

--- a/grpc-protobuf/src/trailers_conv.rs
+++ b/grpc-protobuf/src/trailers_conv.rs
@@ -29,7 +29,7 @@ use protobuf_well_known_types::Any;
 
 use crate::status::*;
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::all)]
 mod google_rpc {
     include!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/grpc/src/credentials/rustls/key_log.rs
+++ b/grpc/src/credentials/rustls/key_log.rs
@@ -62,7 +62,7 @@ impl KeyLogFileInner {
             return Ok(());
         };
 
-        self.buf.truncate(0);
+        self.buf.clear();
         write!(self.buf, "{label} ")?;
         for b in client_random.iter() {
             write!(self.buf, "{b:02x}")?;

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -31,19 +31,12 @@ pub mod server_prost;
 pub mod server_protobuf;
 
 pub mod pb {
-    #![allow(dead_code, unused_imports)]
+    #![allow(dead_code, unused_imports, clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
 }
 
 pub mod grpc_pb {
-    #![allow(
-        dead_code,
-        unused_imports,
-        clippy::clone_on_copy,
-        clippy::useless_conversion,
-        clippy::unnecessary_fallible_conversions,
-        clippy::derivable_impls
-    )]
+    #![allow(dead_code, unused_imports, clippy::all)]
     grpc::include_proto!("test");
 }
 

--- a/tonic-build/src/lib.rs
+++ b/tonic-build/src/lib.rs
@@ -292,10 +292,10 @@ fn naive_snake_case(name: &str) -> String {
 
     while let Some(x) = it.next() {
         s.push(x.to_ascii_lowercase());
-        if let Some(y) = it.peek() {
-            if y.is_uppercase() {
-                s.push('_');
-            }
+        if let Some(y) = it.peek()
+            && y.is_uppercase()
+        {
+            s.push('_');
         }
     }
 

--- a/tonic-prost-build/src/lib.rs
+++ b/tonic-prost-build/src/lib.rs
@@ -777,6 +777,7 @@ impl Builder {
         };
 
         config.out_dir(&out_dir);
+        config.type_attribute(".", "#[allow(clippy::all)]");
 
         for (proto_path, rust_path) in &self.extern_path {
             config.extern_path(proto_path, rust_path);

--- a/tonic-prost/src/codec.rs
+++ b/tonic-prost/src/codec.rs
@@ -404,7 +404,7 @@ mod tests {
                 cx: &mut Context<'_>,
             ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
                 // every other call to poll_data returns data
-                let should_send = self.count % 2 == 0;
+                let should_send = self.count.is_multiple_of(2);
                 let data_len = self.data.len();
                 let partial_len = self.partial_len;
                 let count = self.count;

--- a/tonic-types/src/richer_error/mod.rs
+++ b/tonic-types/src/richer_error/mod.rs
@@ -875,10 +875,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_retry_info(&self) -> Option<RetryInfo> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == RetryInfo::TYPE_URL {
-                if let Ok(detail) = RetryInfo::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == RetryInfo::TYPE_URL
+                && let Ok(detail) = RetryInfo::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -887,10 +887,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_debug_info(&self) -> Option<DebugInfo> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == DebugInfo::TYPE_URL {
-                if let Ok(detail) = DebugInfo::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == DebugInfo::TYPE_URL
+                && let Ok(detail) = DebugInfo::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -899,10 +899,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_quota_failure(&self) -> Option<QuotaFailure> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == QuotaFailure::TYPE_URL {
-                if let Ok(detail) = QuotaFailure::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == QuotaFailure::TYPE_URL
+                && let Ok(detail) = QuotaFailure::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -911,10 +911,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_error_info(&self) -> Option<ErrorInfo> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == ErrorInfo::TYPE_URL {
-                if let Ok(detail) = ErrorInfo::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == ErrorInfo::TYPE_URL
+                && let Ok(detail) = ErrorInfo::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -923,10 +923,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_precondition_failure(&self) -> Option<PreconditionFailure> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == PreconditionFailure::TYPE_URL {
-                if let Ok(detail) = PreconditionFailure::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == PreconditionFailure::TYPE_URL
+                && let Ok(detail) = PreconditionFailure::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -935,10 +935,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_bad_request(&self) -> Option<BadRequest> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == BadRequest::TYPE_URL {
-                if let Ok(detail) = BadRequest::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == BadRequest::TYPE_URL
+                && let Ok(detail) = BadRequest::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -947,10 +947,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_request_info(&self) -> Option<RequestInfo> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == RequestInfo::TYPE_URL {
-                if let Ok(detail) = RequestInfo::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == RequestInfo::TYPE_URL
+                && let Ok(detail) = RequestInfo::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -959,10 +959,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_resource_info(&self) -> Option<ResourceInfo> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == ResourceInfo::TYPE_URL {
-                if let Ok(detail) = ResourceInfo::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == ResourceInfo::TYPE_URL
+                && let Ok(detail) = ResourceInfo::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -971,10 +971,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_help(&self) -> Option<Help> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == Help::TYPE_URL {
-                if let Ok(detail) = Help::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == Help::TYPE_URL
+                && let Ok(detail) = Help::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 
@@ -983,10 +983,10 @@ impl RpcStatusExt for pb::Status {
 
     fn get_details_localized_message(&self) -> Option<LocalizedMessage> {
         for any in self.details.iter() {
-            if any.type_url.as_str() == LocalizedMessage::TYPE_URL {
-                if let Ok(detail) = LocalizedMessage::from_any_ref(any) {
-                    return Some(detail);
-                }
+            if any.type_url.as_str() == LocalizedMessage::TYPE_URL
+                && let Ok(detail) = LocalizedMessage::from_any_ref(any)
+            {
+                return Some(detail);
             }
         }
 

--- a/tonic-xds/examples/xds_server.rs
+++ b/tonic-xds/examples/xds_server.rs
@@ -128,7 +128,7 @@ impl Snapshot {
             api_listener: Some(ApiListener {
                 api_listener: Some(Any {
                     type_url: TYPE_HCM.to_string(),
-                    value: hcm.encode_to_vec().into(),
+                    value: hcm.encode_to_vec(),
                 }),
             }),
             ..Default::default()

--- a/tonic-xds/src/xds/cert_provider/verifier.rs
+++ b/tonic-xds/src/xds/cert_provider/verifier.rs
@@ -97,10 +97,10 @@ impl XdsServerCertVerifier {
     /// parse unless the provider has rotated to a new `Arc`.
     fn root_store(&self, data: &Arc<CertificateData>) -> Result<Arc<RootCertStore>, RustlsError> {
         let cached = self.roots_cache.load();
-        if let Some(cached) = cached.as_ref() {
-            if Arc::ptr_eq(&cached.data, data) {
-                return Ok(Arc::clone(&cached.store));
-            }
+        if let Some(cached) = cached.as_ref()
+            && Arc::ptr_eq(&cached.data, data)
+        {
+            return Ok(Arc::clone(&cached.store));
         }
 
         let roots_pem = data

--- a/tonic-xds/src/xds/resource/cluster.rs
+++ b/tonic-xds/src/xds/resource/cluster.rs
@@ -111,8 +111,9 @@ impl ClusterResource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use envoy_types::pb::envoy::config::cluster::v3::cluster::EdsClusterConfig;
+
+    use super::*;
 
     fn make_cluster(name: &str) -> Cluster {
         Cluster {
@@ -184,11 +185,6 @@ mod tests {
         let cluster = make_cluster("");
         let err = ClusterResource::validate(cluster).unwrap_err();
         assert!(err.to_string().contains("cluster name is empty"));
-    }
-
-    #[test]
-    fn test_all_resources_required() {
-        assert!(ClusterResource::ALL_RESOURCES_REQUIRED_IN_SOTW);
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/endpoints.rs
+++ b/tonic-xds/src/xds/resource/endpoints.rs
@@ -211,10 +211,11 @@ impl EndpointsResource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use envoy_types::pb::envoy::config::core::v3::{Address, SocketAddress};
     use envoy_types::pb::envoy::config::endpoint::v3::{Endpoint, LocalityLbEndpoints};
     use envoy_types::pb::google::protobuf::UInt32Value;
+
+    use super::*;
 
     fn make_lb_endpoint(ip: &str, port: u32, health: i32) -> LbEndpoint {
         LbEndpoint {
@@ -277,13 +278,6 @@ mod tests {
         };
         let err = EndpointsResource::validate(cla).unwrap_err();
         assert!(err.to_string().contains("cluster_name"));
-    }
-
-    #[test]
-    fn test_eds_allows_partial_responses_in_sotw() {
-        // EDS resources are per-cluster, so SotW responses may contain only a subset.
-        // Unlike LDS/CDS which require all resources in every SotW response.
-        assert!(!EndpointsResource::ALL_RESOURCES_REQUIRED_IN_SOTW);
     }
 
     #[test]

--- a/tonic-xds/src/xds/resource/listener.rs
+++ b/tonic-xds/src/xds/resource/listener.rs
@@ -126,10 +126,11 @@ impl ListenerResource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use envoy_types::pb::envoy::config::listener::v3::ApiListener;
     use envoy_types::pb::envoy::extensions::filters::network::http_connection_manager::v3::Rds;
     use envoy_types::pb::google::protobuf::Any;
+
+    use super::*;
 
     fn make_rds_listener(name: &str, route_config_name: &str) -> Listener {
         let rds = Rds {
@@ -142,7 +143,7 @@ mod tests {
         };
         let hcm_any = Any {
             type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager".to_string(),
-            value: hcm.encode_to_vec().into(),
+            value: hcm.encode_to_vec(),
         };
         Listener {
             name: name.to_string(),
@@ -205,11 +206,6 @@ mod tests {
     }
 
     #[test]
-    fn test_all_resources_required() {
-        assert!(ListenerResource::ALL_RESOURCES_REQUIRED_IN_SOTW);
-    }
-
-    #[test]
     fn test_validate_inline_route_config() {
         use envoy_types::pb::envoy::config::route::v3::route_match::PathSpecifier;
         use envoy_types::pb::envoy::config::route::v3::{
@@ -247,7 +243,7 @@ mod tests {
         };
         let hcm_any = Any {
             type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager".to_string(),
-            value: hcm.encode_to_vec().into(),
+            value: hcm.encode_to_vec(),
         };
         let listener = Listener {
             name: "inline-listener".to_string(),

--- a/tonic-xds/src/xds/resource/route_config.rs
+++ b/tonic-xds/src/xds/resource/route_config.rs
@@ -607,12 +607,13 @@ impl RouteConfigResource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use envoy_types::pb::envoy::config::route::v3::{
         RetryPolicy, RouteAction, VirtualHost, retry_policy::RetryBackOff, route::Action,
         route_action::ClusterSpecifier,
     };
     use envoy_types::pb::google::protobuf::{Duration as ProtoDuration, UInt32Value};
+
+    use super::*;
 
     fn make_route(prefix: &str, cluster: &str) -> envoy_types::pb::envoy::config::route::v3::Route {
         envoy_types::pb::envoy::config::route::v3::Route {
@@ -833,11 +834,6 @@ mod tests {
         assert_eq!(clusters.len(), 2);
         assert!(clusters.contains("c1"));
         assert!(clusters.contains("c2"));
-    }
-
-    #[test]
-    fn test_not_all_resources_required() {
-        assert!(!RouteConfigResource::ALL_RESOURCES_REQUIRED_IN_SOTW);
     }
 
     #[test]

--- a/tonic/src/codec/decode.rs
+++ b/tonic/src/codec/decode.rs
@@ -318,13 +318,13 @@ impl StreamingInner {
     }
 
     fn response(&mut self) -> Result<(), Status> {
-        if let Direction::Response(status) = self.direction {
-            if let Err(Some(e)) = crate::status::infer_grpc_status(self.trailers.as_ref(), status) {
-                // If the trailers contain a grpc-status, then we should return that as the error
-                // and otherwise stop the stream (by taking the error state)
-                self.trailers.take();
-                return Err(e);
-            }
+        if let Direction::Response(status) = self.direction
+            && let Err(Some(e)) = crate::status::infer_grpc_status(self.trailers.as_ref(), status)
+        {
+            // If the trailers contain a grpc-status, then we should return that as the error
+            // and otherwise stop the stream (by taking the error state)
+            self.trailers.take();
+            return Err(e);
         }
         Ok(())
     }

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -803,13 +803,13 @@ pub(crate) fn infer_grpc_status(
     trailers: Option<&HeaderMap>,
     status_code: http::StatusCode,
 ) -> Result<(), Option<Status>> {
-    if let Some(trailers) = trailers {
-        if let Some(status) = Status::from_header_map(trailers) {
-            if status.code() == Code::Ok {
-                return Ok(());
-            } else {
-                return Err(status.into());
-            }
+    if let Some(trailers) = trailers
+        && let Some(status) = Status::from_header_map(trailers)
+    {
+        if status.code() == Code::Ok {
+            return Ok(());
+        } else {
+            return Err(status.into());
         }
     }
     trace!("trailers missing grpc-status");

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -93,10 +93,11 @@ impl Endpoint {
     {
         let me = dst.try_into().map_err(|e| Error::from_source(e.into()))?;
         #[cfg(feature = "_tls-any")]
-        if let EndpointType::Uri(uri) = &me.uri {
-            if me.tls.is_none() && uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
-                return me.tls_config(ClientTlsConfig::new().with_enabled_roots());
-            }
+        if let EndpointType::Uri(uri) = &me.uri
+            && me.tls.is_none()
+            && uri.scheme() == Some(&http::uri::Scheme::HTTPS)
+        {
+            return me.tls_config(ClientTlsConfig::new().with_enabled_roots());
         }
         Ok(me)
     }

--- a/tonic/src/transport/server/incoming.rs
+++ b/tonic/src/transport/server/incoming.rs
@@ -170,10 +170,10 @@ fn set_accepted_socket_options(
     nodelay: Option<bool>,
     keepalive: &Option<TcpKeepalive>,
 ) {
-    if let Some(nodelay) = nodelay {
-        if let Err(e) = stream.set_nodelay(nodelay) {
-            warn!("error trying to set TCP_NODELAY: {e}");
-        }
+    if let Some(nodelay) = nodelay
+        && let Err(e) = stream.set_nodelay(nodelay)
+    {
+        warn!("error trying to set TCP_NODELAY: {e}");
     }
 
     if let Some(keepalive) = keepalive {

--- a/tonic/src/transport/server/io_stream.rs
+++ b/tonic/src/transport/server/io_stream.rs
@@ -150,8 +150,8 @@ where
 fn handle_tcp_accept_error(e: impl Into<crate::BoxError>) -> ControlFlow<crate::BoxError> {
     let e = e.into();
     tracing::debug!(error = %e, "accept loop error");
-    if let Some(e) = e.downcast_ref::<io::Error>() {
-        if matches!(
+    if let Some(e) = e.downcast_ref::<io::Error>()
+        && matches!(
             e.kind(),
             io::ErrorKind::ConnectionAborted
                 | io::ErrorKind::ConnectionReset
@@ -159,9 +159,9 @@ fn handle_tcp_accept_error(e: impl Into<crate::BoxError>) -> ControlFlow<crate::
                 | io::ErrorKind::Interrupted
                 | io::ErrorKind::WouldBlock
                 | io::ErrorKind::TimedOut
-        ) {
-            return ControlFlow::Continue(());
-        }
+        )
+    {
+        return ControlFlow::Continue(());
     }
 
     ControlFlow::Break(e)


### PR DESCRIPTION
cc @YutaoMa in this PR I deleted the tonic-xds tests that were assertions of constants, as that also causes clippy to be unhappy, and it felt unnecessary to keep the tests and silence the warnings.  Let me know if you feel strongly otherwise and I can bring them back with a `#[allow(clippy::...)]`.