### PR TITLE
github: run tests at crate level instead of workspace level

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -239,7 +239,7 @@ jobs:
       with:
         # Windows is the long pole of a build. Caching it avoids adding ~4 minutes of build time
         cache-targets: ${{ matrix.os == 'windows-latest' }}
-    - run: cargo nextest run --workspace --all-features
+    - run: cargo hack nextest run --all-features --no-tests pass
       env:
         QUICKCHECK_TESTS: 1000  # run a lot of quickcheck iterations
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -339,6 +339,6 @@ protobuf-well-known-types = { version = "4.35.1-release", optional = true }
 
 [build-dependencies]
 tonic-prost-build = { path = "../tonic-prost-build" }
-grpc-protobuf-build = { path = "../grpc-protobuf-build", default-features = false }
+grpc-protobuf-build = { path = "../grpc-protobuf-build" }
 protoc-gen-rust-grpc = { path = "../protoc-gen-rust-grpc", optional = true }
 protobuf-well-known-types = { version = "4.35.1-release" }

--- a/tonic-reflection/Cargo.toml
+++ b/tonic-reflection/Cargo.toml
@@ -34,7 +34,7 @@ tonic-prost = { version = "0.14.6", path = "../tonic-prost", default-features = 
 
 [dev-dependencies]
 tokio-stream = {version = "0.1", default-features = false, features = ["net"]}
-tonic = { version = "0.14.6", path = "../tonic", default-features = false, features = ["transport"] }
+tonic = { version = "0.14.6", path = "../tonic", default-features = false, features = ["transport", "router"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Running `cargo nextest` at the workspace level triggers Cargo's feature unification. While building each dependency once with the union of all active workspace features saves compile time, it introduces a blind spot: tests can pass even if individual crates are missing required feature flags, as long as another crate in the workspace enables them.

To address this, this change uses `cargo hack` to run tests for each crate individually, ensuring strict feature-gate correctness. It also fixes the workspace crates that were missing required dependency features.


## NOTE
This increases the test workflow run time significantly:

| Operating System | Before | After |
|---|---|---|
| **Ubuntu** | 4.5 min | 9.5 min |
| **macOS** | 7 min | 9.5 min |
| **Windows** | 6.5 min | 10.5 min |