### PR TITLE
 fix(tonic-xds): evict cluster clients for clusters that leave the ro…

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -343,10 +343,20 @@ impl XdsChannelBuilder {
         let xds_client = client_builder.build();
 
         let cache = Arc::new(XdsCache::new());
-        let resource_manager =
-            XdsResourceManager::new(xds_client.clone(), cache.clone(), listener_name);
+        let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
+        let on_active_clusters: crate::xds::resource_manager::OnActiveClusters = {
+            let registry = cluster_registry.clone();
+            Arc::new(move |active| registry.retain_clusters(active))
+        };
+        let resource_manager = XdsResourceManager::new(
+            xds_client.clone(),
+            cache.clone(),
+            listener_name,
+            on_active_clusters,
+        );
 
         Ok(self.build_from_cache(
+            cluster_registry,
             cache,
             #[cfg(feature = "_tls-any")]
             cert_provider_registry,
@@ -361,6 +371,7 @@ impl XdsChannelBuilder {
     /// disconnected `XdsClient` and pre-populated cache.
     fn build_from_cache(
         &self,
+        cluster_registry: Arc<ClusterClientRegistryGrpc>,
         cache: Arc<XdsCache>,
         #[cfg(feature = "_tls-any")] cert_provider_registry: Arc<CertProviderRegistry>,
         xds_client: XdsClient,
@@ -391,7 +402,6 @@ impl XdsChannelBuilder {
         });
 
         let routing_layer = XdsRoutingLayer::new(router, self.pre_route.clone(), self.authority());
-        let cluster_registry = Arc::new(ClusterClientRegistryGrpc::new());
         let lb_service = XdsLbService::new(cluster_registry, discovery);
         let inner = ServiceBuilder::new()
             .layer(routing_layer)
@@ -913,9 +923,14 @@ mod tests {
         use crate::xds::resource_manager::XdsResourceManager;
 
         let cache = Arc::new(XdsCache::new());
+        let cluster_registry = Arc::new(crate::client::cluster::ClusterClientRegistryGrpc::new());
         let xds_client = xds_client::XdsClient::disconnected();
-        let resource_manager =
-            XdsResourceManager::new(xds_client.clone(), cache.clone(), "test-listener".into());
+        let resource_manager = XdsResourceManager::new(
+            xds_client.clone(),
+            cache.clone(),
+            "test-listener".into(),
+            Arc::new(|_: &std::collections::HashSet<String>| {}),
+        );
 
         let builder = XdsChannelBuilder::new(test_config());
 
@@ -926,10 +941,17 @@ mod tests {
                 CertProviderRegistry::from_bootstrap(&Default::default(), Default::default())
                     .unwrap(),
             );
-            builder.build_from_cache(cache, registry, xds_client, resource_manager)
+            builder.build_from_cache(
+                cluster_registry,
+                cache,
+                registry,
+                xds_client,
+                resource_manager,
+            )
         };
         #[cfg(not(feature = "_tls-any"))]
-        let _channel = builder.build_from_cache(cache, xds_client, resource_manager);
+        let _channel =
+            builder.build_from_cache(cluster_registry, cache, xds_client, resource_manager);
         // Construction should succeed without panicking.
     }
 }

--- a/tonic-xds/src/client/cluster.rs
+++ b/tonic-xds/src/client/cluster.rs
@@ -25,6 +25,7 @@
 use crate::common::async_util::BoxFuture;
 use dashmap::DashMap;
 use http::{Request, Response};
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::Hash;
@@ -252,6 +253,19 @@ where
                 Arc::new(ClusterClient::new(name, discover))
             })
             .clone()
+    }
+
+    /// Drops every client whose cluster is not in `active`, the authoritative
+    /// cluster set from the current route configuration.
+    ///
+    /// In-flight requests keep their clones alive until they complete. This
+    /// takes the full set rather than the removed names because a request
+    /// racing an eviction (e.g. a retry carrying a stale route decision) can
+    /// re-insert a just-removed cluster through `get_cluster`; reconciling
+    /// against the authoritative set on every route update drops such
+    /// entries too, instead of leaking them for the channel's lifetime.
+    pub(crate) fn retain_clusters(&self, active: &HashSet<String>) {
+        self.registry.retain(|name, _| active.contains(name));
     }
 }
 

--- a/tonic-xds/src/xds/resource_manager.rs
+++ b/tonic-xds/src/xds/resource_manager.rs
@@ -84,14 +84,30 @@ impl XdsResourceManager {
     /// * `xds_client` - The xDS client for creating resource watches
     /// * `cache` - The shared cache to write resources into
     /// * `listener_name` - The LDS resource name to watch (from target URI)
-    pub(crate) fn new(xds_client: XdsClient, cache: Arc<XdsCache>, listener_name: String) -> Self {
-        let state = CascadeState::new();
+    /// * `on_active_clusters` - Invoked with the authoritative cluster set on
+    ///   every route-config reconcile, so cached clients for clusters outside
+    ///   that set can be released
+    pub(crate) fn new(
+        xds_client: XdsClient,
+        cache: Arc<XdsCache>,
+        listener_name: String,
+        on_active_clusters: OnActiveClusters,
+    ) -> Self {
+        let state = CascadeState::new(on_active_clusters);
         let handle = tokio::spawn(state.run(xds_client, cache, listener_name));
         Self {
             _task: AbortOnDrop(handle),
         }
     }
 }
+
+/// Callback invoked with the authoritative cluster set on every route-config
+/// reconcile, so per-cluster clients (cached by `ClusterClientRegistry`) for
+/// clusters outside that set can be evicted instead of accumulating for every
+/// cluster name ever routed to. It receives the full set rather than removed
+/// names so that entries re-inserted by requests racing an eviction are also
+/// dropped on the next reconcile.
+pub(crate) type OnActiveClusters = Arc<dyn Fn(&HashSet<String>) + Send + Sync>;
 
 /// Mutable state for the entire LDS -> RDS -> CDS -> EDS cascade.
 ///
@@ -107,16 +123,20 @@ struct CascadeState {
     eds_watchers: StreamMap<String, WatcherStream<EndpointsResource>>,
     /// Current EDS service name per cluster, to detect when the name changes.
     eds_names: HashMap<String, String>,
+    /// Invoked with the authoritative cluster set by
+    /// [`reconcile_clusters`](Self::reconcile_clusters).
+    on_active_clusters: OnActiveClusters,
 }
 
 impl CascadeState {
-    fn new() -> Self {
+    fn new(on_active_clusters: OnActiveClusters) -> Self {
         Self {
             rds_watcher: None,
             rds_name: None,
             cds_watchers: StreamMap::new(),
             eds_watchers: StreamMap::new(),
             eds_names: HashMap::new(),
+            on_active_clusters,
         }
     }
 
@@ -301,6 +321,11 @@ impl CascadeState {
             cache.remove_endpoints(name);
         }
 
+        // Fired on every reconcile (not just when the diff removed something)
+        // so that registry entries re-inserted by requests racing a previous
+        // eviction are dropped as well.
+        (self.on_active_clusters)(&new_clusters);
+
         for name in new_clusters.difference(&old_clusters) {
             let watcher = xds_client.watch::<ClusterResource>(name).await;
             self.cds_watchers
@@ -408,7 +433,7 @@ mod tests {
     async fn reconcile_adds_new_clusters() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc = make_route_config("rc", &["a", "b"]);
         state.reconcile_clusters(&rc, &client, &cache).await;
@@ -422,7 +447,7 @@ mod tests {
     async fn reconcile_removes_old_clusters() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc1 = make_route_config("rc", &["a", "b"]);
         state.reconcile_clusters(&rc1, &client, &cache).await;
@@ -436,11 +461,55 @@ mod tests {
         assert_eq!(state.cds_watchers.keys().count(), 2);
     }
 
+    /// Regression test for cluster resurrection: every reconcile must hand
+    /// the authoritative cluster set to `on_active_clusters` so
+    /// `ClusterClientRegistry` can drop clients outside it — including
+    /// entries re-inserted by requests racing a previous eviction, which a
+    /// removal-diff callback would never see again.
+    #[tokio::test]
+    async fn reconcile_fires_on_active_clusters_with_authoritative_set() {
+        let cache = test_cache();
+        let client = test_client();
+        let calls = Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
+        let mut state = CascadeState::new({
+            let calls = calls.clone();
+            Arc::new(move |active: &HashSet<String>| {
+                let mut names: Vec<String> = active.iter().cloned().collect();
+                names.sort();
+                calls.lock().unwrap().push(names);
+            })
+        });
+
+        let rc1 = make_route_config("rc", &["a", "b"]);
+        state.reconcile_clusters(&rc1, &client, &cache).await;
+
+        let rc2 = make_route_config("rc", &["b"]);
+        state.reconcile_clusters(&rc2, &client, &cache).await;
+
+        // Fires even when nothing was removed: this is what evicts registry
+        // entries resurrected between reconciles.
+        let rc3 = make_route_config("rc", &["b"]);
+        state.reconcile_clusters(&rc3, &client, &cache).await;
+
+        let rc4 = make_route_config("rc", &[]);
+        state.reconcile_clusters(&rc4, &client, &cache).await;
+
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["b".to_string()],
+                vec!["b".to_string()],
+                Vec::<String>::new(),
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn reconcile_to_empty_removes_all() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc1 = make_route_config("rc", &["a"]);
         state.reconcile_clusters(&rc1, &client, &cache).await;
@@ -455,7 +524,7 @@ mod tests {
     async fn handle_rds_ok_updates_cache_and_reconciles() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc = make_route_config("rc-1", &["cluster-a", "cluster-b"]);
         state.handle_rds(ok_event(rc), &client, &cache).await;
@@ -470,7 +539,7 @@ mod tests {
     async fn handle_rds_err_preserves_state() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc = make_route_config("rc", &["c1"]);
         state.handle_rds(ok_event(rc), &client, &cache).await;
@@ -485,7 +554,7 @@ mod tests {
     async fn handle_rds_ambient_error_preserves_state() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         let rc = make_route_config("rc", &["c1"]);
         state.handle_rds(ok_event(rc), &client, &cache).await;
@@ -499,7 +568,7 @@ mod tests {
     async fn handle_lds_inline_writes_route_config() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_inline(&["c1"])), &client, &cache)
@@ -516,7 +585,7 @@ mod tests {
     async fn handle_lds_inline_clears_existing_rds() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_rds("rc-1")), &client, &cache)
@@ -535,7 +604,7 @@ mod tests {
     async fn handle_lds_rds_sets_watcher_and_name() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_rds("my-route")), &client, &cache)
@@ -549,7 +618,7 @@ mod tests {
     async fn handle_lds_rds_same_name_reuses_watcher() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_rds("rc")), &client, &cache)
@@ -568,7 +637,7 @@ mod tests {
     async fn handle_lds_rds_different_name_replaces_watcher() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_rds("rc-1")), &client, &cache)
@@ -585,7 +654,7 @@ mod tests {
     async fn handle_lds_err_preserves_state() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_inline(&["c1"])), &client, &cache)
@@ -608,7 +677,7 @@ mod tests {
     async fn handle_lds_ambient_error_preserves_state() {
         let cache = test_cache();
         let client = test_client();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
 
         state
             .handle_lds(ok_event(make_listener_rds("rc")), &client, &cache)
@@ -674,7 +743,7 @@ mod tests {
             .expect("watcher closed");
 
         let cache = test_cache();
-        let mut state = CascadeState::new();
+        let mut state = CascadeState::new(Arc::new(|_: &HashSet<String>| {}));
         tokio::time::timeout(
             Duration::from_secs(10),
             state.handle_rds(event, &xds_client, &cache),


### PR DESCRIPTION
 ClusterClientRegistry never removed clients, so every cluster that came                                                                                                                                                            
 and went (each canary rollout) leaked its client and background tasks                                                                                                                                                              
 for as long as the channel lived.  