### PR TITLE
feat(tonic-xds): make retry classifier + RDS compilation transport-neutral

### DIFF
--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -46,7 +46,7 @@ use xds_client::{
     ClientConfig, MetricsRecorder, Node, ProstCodec, TokioRuntime, TonicTransportBuilder, XdsClient,
 };
 
-use crate::client::retry::{GrpcRetrySharedConfig, RetryLayer};
+use crate::client::retry::{RetryClassifierFactory, RetryLayer, RetrySharedConfig};
 
 /// Configuration for building [`XdsChannel`] / [`XdsChannelGrpc`].
 #[derive(Clone, Debug)]
@@ -195,6 +195,7 @@ pub struct XdsChannelBuilder {
     config: Arc<XdsChannelConfig>,
     recorder: Option<Arc<dyn MetricsRecorder>>,
     pre_route: Option<Arc<dyn PreRouteInterceptor>>,
+    retry_classifier_factory: Option<Arc<dyn RetryClassifierFactory>>,
     #[cfg(feature = "_tls-any")]
     cert_providers: HashMap<String, Arc<dyn CertificateProvider>>,
 }
@@ -216,6 +217,13 @@ impl Debug for XdsChannelBuilder {
                     .pre_route
                     .as_deref()
                     .map_or("None", |i| std::any::type_name_of_val(i)),
+            )
+            .field(
+                "retry_classifier_factory",
+                &self
+                    .retry_classifier_factory
+                    .as_deref()
+                    .map_or("None", |f| std::any::type_name_of_val(f)),
             );
         #[cfg(feature = "_tls-any")]
         s.field(
@@ -234,6 +242,7 @@ impl XdsChannelBuilder {
             config: Arc::new(config),
             recorder: None,
             pre_route: None,
+            retry_classifier_factory: None,
             #[cfg(feature = "_tls-any")]
             cert_providers: HashMap::new(),
         }
@@ -263,6 +272,22 @@ impl XdsChannelBuilder {
     #[must_use]
     pub fn with_pre_route_interceptor(mut self, interceptor: Arc<dyn PreRouteInterceptor>) -> Self {
         self.pre_route = Some(interceptor);
+        self
+    }
+
+    /// Overrides the [`RetryClassifierFactory`] used to compile per-route retry
+    /// policies from RDS. By default (`None`) the gRPC
+    /// [`GrpcRetryClassifierFactory`](crate::GrpcRetryClassifierFactory) is used.
+    ///
+    /// A non-gRPC transport supplies its own factory so a route's Envoy
+    /// `retry_on` conditions are interpreted for that transport and produce the
+    /// matching [`RetryClassifier`](crate::RetryClassifier).
+    #[must_use]
+    pub fn with_retry_classifier_factory(
+        mut self,
+        factory: Arc<dyn RetryClassifierFactory>,
+    ) -> Self {
+        self.retry_classifier_factory = Some(factory);
         self
     }
 
@@ -366,12 +391,15 @@ impl XdsChannelBuilder {
         xds_client: XdsClient,
         resource_manager: XdsResourceManager,
     ) -> XdsChannelGrpc {
-        let router: Arc<dyn Router> = Arc::new(XdsRouter::new(&cache));
+        let router: Arc<dyn Router> = Arc::new(match self.retry_classifier_factory.clone() {
+            Some(factory) => XdsRouter::with_retry_factory(&cache, factory),
+            None => XdsRouter::new(&cache),
+        });
 
         // Fallback retry config for requests that carry no per-route config
         // (non-xDS callers, or a route with no retry policy). Per-route configs
         // come from RDS via the request's `RouteDecision`; see `RetryLayer`.
-        let retry_layer = RetryLayer::new(Arc::new(GrpcRetrySharedConfig::default()));
+        let retry_layer = RetryLayer::new(Arc::new(RetrySharedConfig::grpc_default()));
 
         #[cfg(feature = "_tls-any")]
         let discovery: Arc<
@@ -422,7 +450,7 @@ impl XdsChannelBuilder {
         &self,
         router: Arc<dyn Router>,
         discovery: Arc<dyn ClusterDiscovery<EndpointAddress, EndpointChannel<Channel>>>,
-        retry: Arc<GrpcRetrySharedConfig>,
+        retry: Arc<RetrySharedConfig>,
         interceptor: Option<Arc<dyn PreRouteInterceptor>>,
     ) -> XdsChannelGrpc {
         let routing_layer = XdsRoutingLayer::new(router, interceptor, self.authority());
@@ -462,7 +490,7 @@ mod tests {
         XdsChannelConfig::new(XdsUri::parse("xds:///test-service").unwrap())
     }
     use crate::client::lb::{BoxDiscover, ClusterDiscovery};
-    use crate::client::retry::GrpcRetrySharedConfig;
+    use crate::client::retry::RetrySharedConfig;
     use crate::client::route::RouteDecision;
     use crate::client::route::RouteInput;
     use crate::client::route::Router;
@@ -614,7 +642,7 @@ mod tests {
         let xds_channel = xds_channel_builder.build_grpc_channel_from_parts(
             xds_manager.clone(),
             xds_manager.clone(),
-            Arc::new(GrpcRetrySharedConfig::default()),
+            Arc::new(RetrySharedConfig::grpc_default()),
             None,
         );
 
@@ -683,9 +711,9 @@ mod tests {
         let servers = vec![server];
         let xds_manager = Arc::new(MockXdsManager::from_test_servers(&servers));
 
-        let retry = Arc::new(GrpcRetrySharedConfig::new(
+        let retry = Arc::new(RetrySharedConfig::new(
             RetryConfig::new().num_retries(1),
-            GrpcRetryClassifier::new(vec![tonic::Code::Unavailable]),
+            Arc::new(GrpcRetryClassifier::new(vec![tonic::Code::Unavailable])),
         ));
 
         let xds_channel = XdsChannelBuilder::new(test_config()).build_grpc_channel_from_parts(
@@ -797,7 +825,7 @@ mod tests {
         builder.build_grpc_channel_from_parts(
             router,
             discovery,
-            Arc::new(GrpcRetrySharedConfig::default()),
+            Arc::new(RetrySharedConfig::grpc_default()),
             None,
         )
     }

--- a/tonic-xds/src/client/circuit_breaking.rs
+++ b/tonic-xds/src/client/circuit_breaking.rs
@@ -718,7 +718,7 @@ mod tests {
     use tower::service_fn;
 
     use crate::client::retry::{
-        GrpcRetryClassifier, GrpcRetryPolicy, RetryBackoffConfig, RetryConfig, RetryLayer,
+        GrpcRetryClassifier, RetryBackoffConfig, RetryConfig, RetryLayer, RetryPolicy,
     };
 
     use super::*;
@@ -980,12 +980,12 @@ mod tests {
     #[tokio::test]
     async fn limit_responses_do_not_enter_retry_policy() {
         let breakers = configured_breakers(0);
-        let policy = GrpcRetryPolicy::new(
+        let policy = RetryPolicy::new(
             RetryConfig::new().num_retries(4).retry_backoff(
                 RetryBackoffConfig::new(Duration::from_millis(1))
                     .max_interval(Duration::from_millis(1)),
             ),
-            GrpcRetryClassifier::new(vec![Code::Unavailable]),
+            Arc::new(GrpcRetryClassifier::new(vec![Code::Unavailable])),
         );
         let calls = Arc::new(AtomicU32::new(0));
         let call_counter = calls.clone();

--- a/tonic-xds/src/client/retry.rs
+++ b/tonic-xds/src/client/retry.rs
@@ -24,11 +24,17 @@
 
 //! Transport-agnostic retry utilities.
 //!
-//! The retry *decision* state (attempt cap, backoff, body cloning) lives in the
-//! generic [`RetryPolicy`], while transport-specific decisions (which responses
-//! are retryable, and any per-retry request mutation) live behind the
-//! [`RetryClassifier`] seam. [`GrpcRetryClassifier`] is the default gRPC
-//! implementation; [`GrpcRetryPolicy`] is the gRPC policy alias.
+//! The retry *decision* state (attempt cap, backoff, body cloning) lives in
+//! [`RetryPolicy`], while transport-specific decisions (which outcomes are
+//! retryable, and any per-retry request mutation) live behind the object-safe
+//! [`RetryClassifier`] seam, which inspects a [`RetryOutcome`]. The classifier is
+//! type-erased (`Arc<dyn RetryClassifier>`) so one engine serves any transport;
+//! [`GrpcRetryClassifier`] is the default gRPC implementation.
+//!
+//! RDS-driven per-route policies are compiled through the [`RetryClassifierFactory`]
+//! seam, which maps a route's Envoy `retry_on` conditions to a classifier;
+//! [`GrpcRetryClassifierFactory`] is the gRPC default, and a non-gRPC transport
+//! supplies its own to interpret `retry_on` for that transport.
 
 use std::fmt::Debug;
 use std::io;
@@ -53,7 +59,7 @@ use crate::xds::resource::route_config::RouteRetryConfig;
 ///
 /// These are errors where the request was definitely **not** sent, making it safe to retry.
 /// Walks the full error source chain via [`std::error::Error::source`].
-pub(crate) fn is_retryable_connection_error(err: &(dyn std::error::Error + 'static)) -> bool {
+pub fn is_retryable_connection_error(err: &(dyn std::error::Error + 'static)) -> bool {
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
     while let Some(e) = current {
         if let Some(io_err) = e.downcast_ref::<io::Error>() {
@@ -78,27 +84,77 @@ pub(crate) fn is_retryable_grpc_status_code(
     code != tonic::Code::Ok && retryable_codes.contains(&code)
 }
 
-/// Transport-specific retry decisions. [`RetryPolicy`] owns everything else
-/// (attempt cap, backoff, body cloning), so a classifier only decides *whether*
-/// a response is retryable and optionally mutates the request before each retry.
-///
-/// This is the seam that lets non-gRPC transports (e.g. plain HTTP) reuse the
-/// shared retry engine by supplying their own retryable-status logic without
-/// duplicating any retry state machine.
-pub(crate) trait RetryClassifier: Clone {
-    /// Whether the request should be retried, given either the transport response
-    /// or a connection-level error. Implementations typically retry on a retryable
-    /// connection error (see [`is_retryable_connection_error`]) or a retryable
-    /// transport status.
-    fn is_retryable<Res>(&self, res: &Result<http::Response<Res>, tower::BoxError>) -> bool;
-
-    /// Optional per-retry request mutation (e.g. stamping a retry-attempt header),
-    /// called with the 1-based attempt number just before the retry is issued.
-    /// Default: no-op.
-    fn prepare_retry<Req>(&self, _req: &mut http::Request<Req>, _attempt: u32) {}
+/// The outcome of a single transport attempt, handed to
+/// [`RetryClassifier::is_retryable`]. Borrows from the response or error so the
+/// hot path builds it without cloning.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum RetryOutcome<'a> {
+    /// The transport produced a response; inspect `status`/`headers` to decide.
+    Response {
+        /// The response status.
+        status: http::StatusCode,
+        /// The response headers (e.g. gRPC's trailers-only `grpc-status`).
+        headers: &'a http::HeaderMap,
+    },
+    /// The transport failed before producing a usable response (e.g. a
+    /// connection-level error); see [`is_retryable_connection_error`].
+    Error(&'a tower::BoxError),
 }
 
-/// Maximum number of retry attempts allowed by the gRPC retry spec.
+impl<'a> RetryOutcome<'a> {
+    /// Borrow an outcome from a transport result without cloning.
+    pub(crate) fn from_result<B>(result: &'a Result<http::Response<B>, tower::BoxError>) -> Self {
+        match result {
+            Ok(response) => RetryOutcome::Response {
+                status: response.status(),
+                headers: response.headers(),
+            },
+            Err(err) => RetryOutcome::Error(err),
+        }
+    }
+}
+
+/// Transport-specific retry decisions. The retry engine (`RetryPolicy`) owns
+/// everything else (attempt cap, backoff, body cloning), so a classifier only
+/// decides *whether* an outcome is retryable and optionally mutates the request
+/// headers before each retry.
+///
+/// The seam is object-safe and type-erased (`Arc<dyn RetryClassifier>`) so a
+/// non-gRPC transport (e.g. plain HTTP) can plug its own retryable-outcome logic
+/// into the shared retry engine without duplicating any retry state machine.
+/// Local circuit-breaker drops are never retried by the engine, so classifiers
+/// need not handle them.
+pub trait RetryClassifier: Debug + Send + Sync + 'static {
+    /// Whether the request should be retried given the transport [`RetryOutcome`].
+    /// Implementations typically retry on a retryable connection error (see
+    /// [`is_retryable_connection_error`]) or a retryable transport status.
+    fn is_retryable(&self, outcome: RetryOutcome<'_>) -> bool;
+
+    /// Optional per-retry request-header mutation (e.g. stamping a retry-attempt
+    /// header), called with the 1-based attempt number just before the retry is
+    /// issued. Default: no-op.
+    fn prepare_retry(&self, _headers: &mut http::HeaderMap, _attempt: u32) {}
+}
+
+/// Compiles a route's Envoy `retry_on` conditions into a [`RetryClassifier`].
+///
+/// This is the transport seam for RDS-driven retry: the shared routing layer
+/// compiles each route's retry policy once by asking the factory for a
+/// classifier (the generic knobs — attempt cap and backoff — are handled by
+/// `RetrySharedConfig::from_route_retry`). gRPC uses
+/// [`GrpcRetryClassifierFactory`]; a non-gRPC transport (e.g. plain HTTP)
+/// supplies its own so it can interpret `retry_on` (e.g. `5xx`, `gateway-error`)
+/// and return an HTTP classifier without touching the retry engine.
+pub trait RetryClassifierFactory: Send + Sync + 'static {
+    /// Classifier for a route's comma-separated `retry_on` conditions, or `None`
+    /// when none apply to this transport so the route falls back to the layer
+    /// default (connection-error retries only; see
+    /// [`is_retryable_connection_error`]).
+    fn classifier_for(&self, retry_on: &str) -> Option<Arc<dyn RetryClassifier>>;
+}
+
+/// Maximum number of retry attempts, matching gRPC's retry design.
 /// Any `num_retries` value that would result in more than 5 total attempts
 /// is capped to `MAX_ATTEMPTS - 1 = 4`.
 const MAX_ATTEMPTS: u32 = 5;
@@ -230,22 +286,39 @@ impl Default for GrpcRetryClassifier {
 }
 
 impl RetryClassifier for GrpcRetryClassifier {
-    fn is_retryable<Res>(&self, res: &Result<http::Response<Res>, tower::BoxError>) -> bool {
-        match res {
-            Err(err) => is_retryable_connection_error(err.as_ref()),
-            Ok(response) if is_local_circuit_breaker_drop(response) => false,
-            Ok(response) => match tonic::Status::from_header_map(response.headers()) {
-                Some(status) => is_retryable_grpc_status_code(status.code(), &self.retry_on),
-                // No grpc-status header means success.
-                None => false,
-            },
+    fn is_retryable(&self, outcome: RetryOutcome<'_>) -> bool {
+        match outcome {
+            RetryOutcome::Error(err) => is_retryable_connection_error(err.as_ref()),
+            RetryOutcome::Response { headers, .. } => {
+                match tonic::Status::from_header_map(headers) {
+                    Some(status) => is_retryable_grpc_status_code(status.code(), &self.retry_on),
+                    // No grpc-status header means success.
+                    None => false,
+                }
+            }
         }
     }
 
-    fn prepare_retry<Req>(&self, req: &mut http::Request<Req>, attempt: u32) {
+    fn prepare_retry(&self, headers: &mut http::HeaderMap, attempt: u32) {
         // Per gRPC spec: advertise the number of previous attempts.
-        req.headers_mut()
-            .insert(GRPC_PREVIOUS_RPC_ATTEMPTS, http::HeaderValue::from(attempt));
+        headers.insert(GRPC_PREVIOUS_RPC_ATTEMPTS, http::HeaderValue::from(attempt));
+    }
+}
+
+/// Default [`RetryClassifierFactory`] for gRPC: maps `retry_on` to retryable
+/// [`tonic::Code`]s and builds a `GrpcRetryClassifier`. Returns `None` when no
+/// condition maps to a gRPC code, so the route falls back to the layer default
+/// instead of masking connection retries (gRFC A44).
+#[derive(Debug, Default, Clone)]
+pub struct GrpcRetryClassifierFactory;
+
+impl RetryClassifierFactory for GrpcRetryClassifierFactory {
+    fn classifier_for(&self, retry_on: &str) -> Option<Arc<dyn RetryClassifier>> {
+        let codes = grpc_retry_on_codes(retry_on);
+        if codes.is_empty() {
+            return None;
+        }
+        Some(Arc::new(GrpcRetryClassifier::new(codes)))
     }
 }
 
@@ -264,31 +337,35 @@ fn make_backoff(config: &RetryBackoffConfig) -> backoff::ExponentialBackoff {
 }
 
 /// Immutable, shared retry configuration: the transport-agnostic knobs (attempt
-/// cap, backoff) plus the transport-specific classifier `C`. Built once when a
-/// `RouteConfiguration` is validated (see
-/// [`GrpcRetrySharedConfig::from_route_retry`]) and shared across matching
-/// requests via an [`Arc`].
+/// cap, backoff) plus the type-erased [`RetryClassifier`]. Built once when a
+/// `RouteConfiguration` is validated (see [`RetrySharedConfig::from_route_retry`])
+/// and shared across matching requests via an [`Arc`].
 ///
 /// Kept separate from the per-request retry state ([`RetryPolicy`]) so that
 /// instantiating a policy is an `Arc` clone plus a zero-field init.
 #[derive(Debug)]
-pub(crate) struct RetrySharedConfig<C> {
+pub(crate) struct RetrySharedConfig {
     /// Attempt cap and backoff schedule.
     config: RetryConfig,
     /// Decides retryability and per-retry request mutation for the transport.
-    classifier: C,
+    classifier: Arc<dyn RetryClassifier>,
 }
 
-impl<C> RetrySharedConfig<C> {
-    /// Create a shared retry config from a [`RetryConfig`] and a classifier.
-    pub(crate) fn new(config: RetryConfig, classifier: C) -> Self {
+impl RetrySharedConfig {
+    /// Create a shared retry config from a [`RetryConfig`] and a type-erased
+    /// [`RetryClassifier`].
+    pub(crate) fn new(config: RetryConfig, classifier: Arc<dyn RetryClassifier>) -> Self {
         Self { config, classifier }
     }
-}
 
-impl<C: Default> Default for RetrySharedConfig<C> {
-    fn default() -> Self {
-        Self::new(RetryConfig::default(), C::default())
+    /// Shared config with default knobs and a default [`GrpcRetryClassifier`]
+    /// (empty `retry_on`: status-code retries inactive, connection retries still
+    /// apply). Used as the gRPC layer fallback.
+    pub(crate) fn grpc_default() -> Self {
+        Self::new(
+            RetryConfig::default(),
+            Arc::new(GrpcRetryClassifier::default()),
+        )
     }
 }
 
@@ -298,25 +375,25 @@ impl<C: Default> Default for RetrySharedConfig<C> {
 /// clones it per request, so the state is per-request while the config stays
 /// shared behind the `Arc`.
 #[derive(Clone, Debug)]
-pub(crate) struct RetryPolicy<C> {
+pub(crate) struct RetryPolicy {
     /// Immutable config shared across all requests on this route.
-    shared: Arc<RetrySharedConfig<C>>,
+    shared: Arc<RetrySharedConfig>,
     /// Backoff state for the current request, created from config on first retry.
     backoff: Option<backoff::ExponentialBackoff>,
     /// Number of retry attempts made so far for the current request.
     attempts: u32,
 }
 
-impl<C> RetryPolicy<C> {
-    /// Create a policy from a config and classifier, allocating the shared `Arc`.
-    /// Prefer [`from_shared`](Self::from_shared) on the hot path.
-    pub(crate) fn new(config: RetryConfig, classifier: C) -> Self {
+impl RetryPolicy {
+    /// Create a policy from a config and a type-erased classifier, allocating the
+    /// shared `Arc`. Prefer [`from_shared`](Self::from_shared) on the hot path.
+    pub(crate) fn new(config: RetryConfig, classifier: Arc<dyn RetryClassifier>) -> Self {
         Self::from_shared(Arc::new(RetrySharedConfig::new(config, classifier)))
     }
 
     /// Instantiate per-request state from a shared config: a pointer clone plus
     /// a zero-field init.
-    pub(crate) fn from_shared(shared: Arc<RetrySharedConfig<C>>) -> Self {
+    pub(crate) fn from_shared(shared: Arc<RetrySharedConfig>) -> Self {
         Self {
             shared,
             backoff: None,
@@ -325,7 +402,7 @@ impl<C> RetryPolicy<C> {
     }
 
     /// Consume the policy and return its shared config.
-    pub(crate) fn into_shared(self) -> Arc<RetrySharedConfig<C>> {
+    pub(crate) fn into_shared(self) -> Arc<RetrySharedConfig> {
         self.shared
     }
 
@@ -342,23 +419,17 @@ impl<C> RetryPolicy<C> {
     }
 }
 
-impl<C: Default> Default for RetryPolicy<C> {
-    fn default() -> Self {
-        Self::from_shared(Arc::new(RetrySharedConfig::default()))
-    }
-}
-
-impl RetrySharedConfig<GrpcRetryClassifier> {
-    /// Build a shared gRPC config from a route's [`RouteRetryConfig`], mapping
-    /// `retry_on` to [`tonic::Code`]s; unset Envoy fields use [`RetryConfig`]
-    /// defaults. Returns `None` when no condition maps to a gRPC code, so the
-    /// route falls back to the layer default instead of masking connection
-    /// retries (gRFC A44).
-    pub(crate) fn from_route_retry(retry: &RouteRetryConfig) -> Option<Self> {
-        let retry_on = grpc_retry_on_codes(&retry.retry_on);
-        if retry_on.is_empty() {
-            return None;
-        }
+impl RetrySharedConfig {
+    /// Build a shared config from a route's [`RouteRetryConfig`]: the generic
+    /// knobs (`num_retries`, backoff) map to [`RetryConfig`], and `factory`
+    /// supplies the transport classifier from `retry_on`. Returns `None` when the
+    /// factory finds no applicable condition, so the route falls back to the
+    /// layer default instead of masking connection retries (gRFC A44).
+    pub(crate) fn from_route_retry(
+        retry: &RouteRetryConfig,
+        factory: &dyn RetryClassifierFactory,
+    ) -> Option<Self> {
+        let classifier = factory.classifier_for(&retry.retry_on)?;
         let mut config = RetryConfig::new();
         if let Some(num_retries) = retry.num_retries {
             config = config.num_retries(num_retries);
@@ -370,7 +441,7 @@ impl RetrySharedConfig<GrpcRetryClassifier> {
             }
             config = config.retry_backoff(backoff);
         }
-        Some(Self::new(config, GrpcRetryClassifier::new(retry_on)))
+        Some(Self::new(config, classifier))
     }
 }
 
@@ -395,9 +466,8 @@ pub(crate) fn grpc_retry_on_codes(retry_on: &str) -> Vec<tonic::Code> {
         .collect()
 }
 
-impl<C, Req, Res> Policy<Request<Req>, Response<Res>, tower::BoxError> for RetryPolicy<C>
+impl<Req, Res> Policy<Request<Req>, Response<Res>, tower::BoxError> for RetryPolicy
 where
-    C: RetryClassifier,
     Req: Clone,
 {
     type Future = tokio::time::Sleep;
@@ -411,16 +481,30 @@ where
             return None;
         }
 
-        if !self.shared.classifier.is_retryable(result) {
+        // A local circuit-breaker drop is a deliberate client-side drop and is
+        // never retried, regardless of the transport classifier.
+        if let Ok(response) = result.as_ref()
+            && is_local_circuit_breaker_drop(response)
+        {
+            return None;
+        }
+
+        if !self
+            .shared
+            .classifier
+            .is_retryable(RetryOutcome::from_result(result))
+        {
             return None;
         }
 
         let delay = self.backoff_next();
         self.attempts += 1;
 
-        // Let the classifier stamp any per-retry request state (e.g. gRPC's
-        // grpc-previous-rpc-attempts header).
-        self.shared.classifier.prepare_retry(req, self.attempts);
+        // Let the classifier stamp any per-retry request headers (e.g. gRPC's
+        // grpc-previous-rpc-attempts).
+        self.shared
+            .classifier
+            .prepare_retry(req.headers_mut(), self.attempts);
 
         Some(tokio::time::sleep(delay))
     }
@@ -430,15 +514,7 @@ where
     }
 }
 
-/// Non-breaking alias: existing gRPC callers keep the same name and behavior.
-pub(crate) type GrpcRetryPolicy = RetryPolicy<GrpcRetryClassifier>;
-
-/// Shared, immutable gRPC retry config (attempt cap, backoff, retryable
-/// [`tonic::Code`] set); the [`GrpcRetryClassifier`] specialization of
-/// [`RetrySharedConfig`].
-pub(crate) type GrpcRetrySharedConfig = RetrySharedConfig<GrpcRetryClassifier>;
-
-/// Tower [`Layer`] that wraps a gRPC service with retry support.
+/// Tower [`Layer`] that wraps a service with retry support.
 ///
 /// Builds a fresh [`tower::retry::Retry`] per request, selecting the config from
 /// the matched route's [`RouteDecision`] (stamped by the routing layer just
@@ -447,12 +523,12 @@ pub(crate) type GrpcRetrySharedConfig = RetrySharedConfig<GrpcRetryClassifier>;
 #[derive(Clone)]
 pub(crate) struct RetryLayer {
     /// Config used when a request carries no per-route retry config.
-    fallback: Arc<GrpcRetrySharedConfig>,
+    fallback: Arc<RetrySharedConfig>,
 }
 
 impl RetryLayer {
     /// Create a layer with the given `fallback` config.
-    pub(crate) fn new(fallback: Arc<GrpcRetrySharedConfig>) -> Self {
+    pub(crate) fn new(fallback: Arc<RetrySharedConfig>) -> Self {
         Self { fallback }
     }
 }
@@ -475,13 +551,13 @@ impl<S> Layer<S> for RetryLayer {
 pub(crate) struct RetryService<S> {
     inner: S,
     /// Config used when a request carries no per-route retry config.
-    fallback: Arc<GrpcRetrySharedConfig>,
+    fallback: Arc<RetrySharedConfig>,
 }
 
 impl<S, B, Res> Service<Request<B>> for RetryService<S>
 where
-    GrpcRetryPolicy: Policy<Request<SharedBody<B>>, Response<Res>, S::Error>,
-    <GrpcRetryPolicy as Policy<Request<SharedBody<B>>, Response<Res>, S::Error>>::Future: Send,
+    RetryPolicy: Policy<Request<SharedBody<B>>, Response<Res>, S::Error>,
+    <RetryPolicy as Policy<Request<SharedBody<B>>, Response<Res>, S::Error>>::Future: Send,
     S: Service<Request<SharedBody<B>>, Response = Response<Res>> + Clone + Send + 'static,
     S::Error: Debug + Send + 'static,
     S::Response: Send + 'static,
@@ -620,7 +696,7 @@ mod tests {
         let err: tower::BoxError =
             Box::new(io::Error::new(io::ErrorKind::ConnectionRefused, "refused"));
         let result: Result<http::Response<()>, tower::BoxError> = Err(err);
-        assert!(classifier.is_retryable(&result));
+        assert!(classifier.is_retryable(RetryOutcome::from_result(&result)));
     }
 
     #[test]
@@ -631,7 +707,7 @@ mod tests {
             .body(())
             .unwrap();
         let result: Result<http::Response<()>, tower::BoxError> = Ok(response);
-        assert!(classifier.is_retryable(&result));
+        assert!(classifier.is_retryable(RetryOutcome::from_result(&result)));
     }
 
     #[test]
@@ -642,7 +718,7 @@ mod tests {
             .body(())
             .unwrap();
         let result: Result<http::Response<()>, tower::BoxError> = Ok(response);
-        assert!(!classifier.is_retryable(&result));
+        assert!(!classifier.is_retryable(RetryOutcome::from_result(&result)));
     }
 
     #[test]
@@ -650,7 +726,7 @@ mod tests {
         let classifier = GrpcRetryClassifier::new(vec![tonic::Code::Unavailable]);
         let response = http::Response::builder().body(()).unwrap();
         let result: Result<http::Response<()>, tower::BoxError> = Ok(response);
-        assert!(!classifier.is_retryable(&result));
+        assert!(!classifier.is_retryable(RetryOutcome::from_result(&result)));
     }
 
     // --- RetryBackoffConfig tests ---
@@ -754,7 +830,8 @@ mod tests {
             base_interval: Some(Duration::from_millis(100)),
             max_interval: Some(Duration::from_millis(1000)),
         };
-        let shared = GrpcRetrySharedConfig::from_route_retry(&retry).expect("codes present");
+        let shared = RetrySharedConfig::from_route_retry(&retry, &GrpcRetryClassifierFactory)
+            .expect("codes present");
         assert_eq!(shared.config.num_retries, 3);
         assert_eq!(
             shared.config.retry_backoff.base_interval,
@@ -764,9 +841,16 @@ mod tests {
             shared.config.retry_backoff.max_interval,
             Duration::from_millis(1000)
         );
-        assert_eq!(
-            shared.classifier.retry_on.as_ref(),
-            [tonic::Code::Unavailable]
+        // The compiled classifier retries UNAVAILABLE (mapped from `retry_on`).
+        let unavailable: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder()
+                .header("grpc-status", "14")
+                .body(())
+                .unwrap());
+        assert!(
+            shared
+                .classifier
+                .is_retryable(RetryOutcome::from_result(&unavailable))
         );
     }
 
@@ -778,12 +862,19 @@ mod tests {
             base_interval: None,
             max_interval: None,
         };
-        let shared = GrpcRetrySharedConfig::from_route_retry(&retry).expect("codes present");
+        let shared = RetrySharedConfig::from_route_retry(&retry, &GrpcRetryClassifierFactory)
+            .expect("codes present");
         assert_eq!(shared.config.num_retries, 1);
         assert_eq!(shared.config.retry_backoff, RetryBackoffConfig::default());
-        assert_eq!(
-            shared.classifier.retry_on.as_ref(),
-            [tonic::Code::Cancelled]
+        // The compiled classifier retries CANCELLED (mapped from `retry_on`).
+        let cancelled: Result<http::Response<()>, tower::BoxError> = Ok(http::Response::builder()
+            .header("grpc-status", "1")
+            .body(())
+            .unwrap());
+        assert!(
+            shared
+                .classifier
+                .is_retryable(RetryOutcome::from_result(&cancelled))
         );
     }
 
@@ -797,7 +888,7 @@ mod tests {
             base_interval: None,
             max_interval: None,
         };
-        assert!(GrpcRetrySharedConfig::from_route_retry(&retry).is_none());
+        assert!(RetrySharedConfig::from_route_retry(&retry, &GrpcRetryClassifierFactory).is_none());
     }
 
     // --- from_shared tests ---
@@ -805,12 +896,15 @@ mod tests {
     #[test]
     fn from_shared_instantiates_zeroed_state_sharing_config() {
         let shared = Arc::new(
-            GrpcRetrySharedConfig::from_route_retry(&RouteRetryConfig {
-                retry_on: "unavailable".into(),
-                num_retries: Some(2),
-                base_interval: None,
-                max_interval: None,
-            })
+            RetrySharedConfig::from_route_retry(
+                &RouteRetryConfig {
+                    retry_on: "unavailable".into(),
+                    num_retries: Some(2),
+                    base_interval: None,
+                    max_interval: None,
+                },
+                &GrpcRetryClassifierFactory,
+            )
             .expect("codes present"),
         );
         let policy = RetryPolicy::from_shared(Arc::clone(&shared));
@@ -829,9 +923,9 @@ mod tests {
     /// the policy per request, so mutations from one request must not leak into another.
     #[tokio::test]
     async fn test_retry_state_is_per_request() {
-        let policy = GrpcRetryPolicy::new(
+        let policy = RetryPolicy::new(
             RetryConfig::new().num_retries(2),
-            GrpcRetryClassifier::new(vec![tonic::Code::Unavailable]),
+            Arc::new(GrpcRetryClassifier::new(vec![tonic::Code::Unavailable])),
         );
 
         // Simulate two independent request sessions by cloning the policy
@@ -897,5 +991,136 @@ mod tests {
             .unwrap());
         let retry2b = policy_req2.retry(&mut req2, &mut result2b);
         assert!(retry2b.is_some(), "req2 should still have retries left");
+    }
+
+    // --- object-safe classifier seam (non-gRPC) ---
+
+    /// A minimal non-gRPC classifier: retries one fixed HTTP status (plus
+    /// connection errors) and stamps a custom retry-attempt header. Proves the
+    /// object-safe [`RetryClassifier`] seam serves a transport other than gRPC
+    /// without any HTTP-specific logic living in this crate.
+    #[derive(Debug)]
+    struct HttpStatusClassifier {
+        retry_status: http::StatusCode,
+    }
+
+    impl RetryClassifier for HttpStatusClassifier {
+        fn is_retryable(&self, outcome: RetryOutcome<'_>) -> bool {
+            match outcome {
+                RetryOutcome::Error(err) => is_retryable_connection_error(err.as_ref()),
+                RetryOutcome::Response { status, .. } => status == self.retry_status,
+            }
+        }
+
+        fn prepare_retry(&self, headers: &mut http::HeaderMap, attempt: u32) {
+            headers.insert("x-retry-attempt", http::HeaderValue::from(attempt));
+        }
+    }
+
+    #[test]
+    fn non_grpc_classifier_decides_by_http_status() {
+        let classifier = HttpStatusClassifier {
+            retry_status: http::StatusCode::SERVICE_UNAVAILABLE,
+        };
+        let retryable: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder().status(503).body(()).unwrap());
+        let not_retryable: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder().status(200).body(()).unwrap());
+        assert!(classifier.is_retryable(RetryOutcome::from_result(&retryable)));
+        assert!(!classifier.is_retryable(RetryOutcome::from_result(&not_retryable)));
+    }
+
+    #[tokio::test]
+    async fn engine_drives_non_grpc_classifier_and_prepares_headers() {
+        let mut policy = RetryPolicy::new(
+            RetryConfig::new().num_retries(1),
+            Arc::new(HttpStatusClassifier {
+                retry_status: http::StatusCode::SERVICE_UNAVAILABLE,
+            }),
+        );
+        let mut req = http::Request::builder().body(()).unwrap();
+        let mut result: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder().status(503).body(()).unwrap());
+
+        assert!(
+            policy.retry(&mut req, &mut result).is_some(),
+            "engine should retry a 503 for the HTTP classifier"
+        );
+        assert_eq!(
+            req.headers().get("x-retry-attempt").unwrap(),
+            "1",
+            "engine should let the classifier stamp per-retry headers"
+        );
+
+        // Exhausted after one retry (num_retries = 1).
+        let mut result2: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder().status(503).body(()).unwrap());
+        assert!(policy.retry(&mut req, &mut result2).is_none());
+    }
+
+    // --- classifier factory seam (RDS compilation) ---
+
+    /// A non-gRPC factory mapping any non-empty `retry_on` to an
+    /// [`HttpStatusClassifier`] (503) and `None` otherwise. Proves the
+    /// [`RetryClassifierFactory`] seam lets RDS compile a non-gRPC classifier
+    /// while the shared OSS code still applies the generic retry knobs.
+    #[derive(Debug)]
+    struct HttpRetryClassifierFactory;
+
+    impl RetryClassifierFactory for HttpRetryClassifierFactory {
+        fn classifier_for(&self, retry_on: &str) -> Option<Arc<dyn RetryClassifier>> {
+            if retry_on.is_empty() {
+                return None;
+            }
+            Some(Arc::new(HttpStatusClassifier {
+                retry_status: http::StatusCode::SERVICE_UNAVAILABLE,
+            }))
+        }
+    }
+
+    #[test]
+    fn factory_compiles_non_grpc_classifier_from_route_retry() {
+        let retry = RouteRetryConfig {
+            retry_on: "5xx".into(),
+            num_retries: Some(2),
+            base_interval: None,
+            max_interval: None,
+        };
+        let shared = RetrySharedConfig::from_route_retry(&retry, &HttpRetryClassifierFactory)
+            .expect("factory produced a classifier");
+        // Generic knobs are still applied by the shared compiler.
+        assert_eq!(shared.config.num_retries, 2);
+        // The compiled classifier is the factory's HTTP one: it retries a 503 and
+        // ignores a gRPC trailers-only status.
+        let http_503: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder().status(503).body(()).unwrap());
+        let grpc_unavailable: Result<http::Response<()>, tower::BoxError> =
+            Ok(http::Response::builder()
+                .header("grpc-status", "14")
+                .body(())
+                .unwrap());
+        assert!(
+            shared
+                .classifier
+                .is_retryable(RetryOutcome::from_result(&http_503))
+        );
+        assert!(
+            !shared
+                .classifier
+                .is_retryable(RetryOutcome::from_result(&grpc_unavailable))
+        );
+    }
+
+    #[test]
+    fn factory_returning_none_yields_no_route_policy() {
+        // Empty `retry_on` -> factory returns None -> the route falls back to the
+        // layer default instead of a route-specific policy.
+        let retry = RouteRetryConfig {
+            retry_on: String::new(),
+            num_retries: Some(3),
+            base_interval: None,
+            max_interval: None,
+        };
+        assert!(RetrySharedConfig::from_route_retry(&retry, &HttpRetryClassifierFactory).is_none());
     }
 }

--- a/tonic-xds/src/client/route.rs
+++ b/tonic-xds/src/client/route.rs
@@ -22,7 +22,7 @@
  *
  */
 
-use crate::client::retry::GrpcRetrySharedConfig;
+use crate::client::retry::{RetryClassifierFactory, RetrySharedConfig};
 use crate::common::async_util::BoxFuture;
 use crate::xds::resource::route_config::{
     RouteConfigMetadata, RouteConfigResource, RouteRetryConfig,
@@ -61,7 +61,7 @@ pub(crate) struct RouteDecision {
     /// or `None` when the route sets no retry. Resolved from the [`RoutingSnapshot`]
     /// this decision was made on, so the retry layer applies the config for exactly
     /// the route the request took.
-    pub retry_config: Option<Arc<GrpcRetrySharedConfig>>,
+    pub retry_config: Option<Arc<RetrySharedConfig>>,
 }
 
 /// A hook that runs before xDS route selection.
@@ -76,32 +76,36 @@ pub trait PreRouteInterceptor: Send + Sync + 'static {
     fn on_request(&self, headers: &mut http::HeaderMap, metadata: &RouteConfigMetadata);
 }
 
-/// The validated [`RouteConfigResource`] bundled with the gRPC retry configs
+/// The validated [`RouteConfigResource`] bundled with the retry configs
 /// compiled from it, one per RDS update.
 ///
 /// Bundling both behind one `Arc` lets routing resolve a route and its retry
 /// config from a single consistent RDS version, and keeps the request path to a
 /// map lookup plus a pointer clone. Compiling here, rather than in the xDS
-/// resource layer, keeps the resource types free of gRPC types.
+/// resource layer, keeps the resource types free of client-side retry types.
 #[derive(Debug, Default)]
 pub(crate) struct RoutingSnapshot {
     resource: Arc<RouteConfigResource>,
     /// Compiled retry config, keyed by the identity (`Arc` address) of the
     /// route's [`RouteRetryConfig`]. Routes that inherit a vhost policy share one
-    /// entry; a route whose `retry_on` maps to no gRPC code has none.
-    retry: HashMap<usize, Arc<GrpcRetrySharedConfig>>,
+    /// entry; a route whose `retry_on` the factory maps to no classifier has none.
+    retry: HashMap<usize, Arc<RetrySharedConfig>>,
 }
 
 impl RoutingSnapshot {
-    /// Compiles each distinct route retry config once.
-    pub(crate) fn new(resource: Arc<RouteConfigResource>) -> Self {
-        let mut retry: HashMap<usize, Arc<GrpcRetrySharedConfig>> = HashMap::new();
+    /// Compiles each distinct route retry config once, using `factory` to build
+    /// the transport classifier for each route's `retry_on`.
+    pub(crate) fn new(
+        resource: Arc<RouteConfigResource>,
+        factory: &dyn RetryClassifierFactory,
+    ) -> Self {
+        let mut retry: HashMap<usize, Arc<RetrySharedConfig>> = HashMap::new();
         for vhost in &resource.virtual_hosts {
             for route in &vhost.routes {
                 if let Some(config) = &route.retry_config {
                     let key = Arc::as_ptr(config) as usize;
                     if let std::collections::hash_map::Entry::Vacant(entry) = retry.entry(key)
-                        && let Some(shared) = GrpcRetrySharedConfig::from_route_retry(config)
+                        && let Some(shared) = RetrySharedConfig::from_route_retry(config, factory)
                     {
                         entry.insert(Arc::new(shared));
                     }
@@ -111,11 +115,11 @@ impl RoutingSnapshot {
         Self { resource, retry }
     }
 
-    /// The compiled gRPC retry config for a route's [`RouteRetryConfig`], if any.
+    /// The compiled retry config for a route's [`RouteRetryConfig`], if any.
     pub(crate) fn retry_for(
         &self,
         config: Option<&Arc<RouteRetryConfig>>,
-    ) -> Option<Arc<GrpcRetrySharedConfig>> {
+    ) -> Option<Arc<RetrySharedConfig>> {
         config.and_then(|config| self.retry.get(&(Arc::as_ptr(config) as usize)).cloned())
     }
 }

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -174,6 +174,10 @@ pub use client::channel::{
 pub use client::endpoint::{
     ClusterConfig, Connector, EndpointAddress, EndpointChannel, MakeConnector,
 };
+pub use client::retry::{
+    GrpcRetryClassifierFactory, RetryClassifier, RetryClassifierFactory, RetryOutcome,
+    is_retryable_connection_error,
+};
 pub use client::route::PreRouteInterceptor;
 pub use common::async_util::BoxFuture;
 pub use xds::bootstrap::{BootstrapConfig, BootstrapError};

--- a/tonic-xds/src/xds/routing.rs
+++ b/tonic-xds/src/xds/routing.rs
@@ -43,6 +43,7 @@ use std::time::Duration;
 use arc_swap::ArcSwapOption;
 use tokio::sync::watch;
 
+use crate::client::retry::{GrpcRetryClassifierFactory, RetryClassifierFactory};
 use crate::client::route::{AcquiredConfig, RouteDecision, RouteInput, Router, RoutingSnapshot};
 use crate::common::async_util::AbortOnDrop;
 use crate::xds::cache::XdsCache;
@@ -72,12 +73,24 @@ pub(crate) struct XdsRouter {
 }
 
 impl XdsRouter {
-    /// Creates a new `XdsRouter` that watches route config from the given cache.
+    /// Creates a new `XdsRouter` that watches route config from the given cache,
+    /// compiling per-route retry policies with the default
+    /// [`GrpcRetryClassifierFactory`].
     ///
     /// Spawns a background task that updates the local route config whenever
     /// the cache publishes a new one. The task is aborted when this router
     /// is dropped.
     pub(crate) fn new(cache: &XdsCache) -> Self {
+        Self::with_retry_factory(cache, Arc::new(GrpcRetryClassifierFactory))
+    }
+
+    /// Like [`new`](Self::new) but compiles per-route retry policies with a custom
+    /// [`RetryClassifierFactory`], letting a non-gRPC transport interpret
+    /// `retry_on` for that transport.
+    pub(crate) fn with_retry_factory(
+        cache: &XdsCache,
+        retry_factory: Arc<dyn RetryClassifierFactory>,
+    ) -> Self {
         let route_config = Arc::new(ArcSwapOption::empty());
         let (ready_tx, ready_rx) = watch::channel(false);
         let rc = route_config.clone();
@@ -85,7 +98,10 @@ impl XdsRouter {
         let handle = tokio::spawn(async move {
             let mut ready_tx = Some(ready_tx);
             while let Some(config) = watcher.next().await {
-                rc.store(Some(Arc::new(RoutingSnapshot::new(config))));
+                rc.store(Some(Arc::new(RoutingSnapshot::new(
+                    config,
+                    retry_factory.as_ref(),
+                ))));
                 // Signal readiness on the first config, then drop the sender.
                 if let Some(tx) = ready_tx.take() {
                     let _ = tx.send(true);


### PR DESCRIPTION
## Motivation

The retry engine was generic over a `RetryClassifier` type parameter but only the gRPC classifier was ever plugged in, the trait was not object-safe, and RDS per-route compilation hard-coded gRPC. Non-gRPC transports (e.g. plain HTTP) could not reuse the shared retry state machine or have their `retry_on` conditions compiled for them.

## Solution

Type-erase the classifier and parameterize RDS compilation so one engine serves any transport. `RetryClassifier` becomes a public, object-safe trait whose `is_retryable` inspects a new public `RetryOutcome` (response status/headers or a connection error); `RetrySharedConfig`/`RetryPolicy`/`RetryLayer`/`RetryService` drop their `<C>` generic and hold `Arc<dyn RetryClassifier>`, and local circuit-breaker drops are skipped in the engine itself. Per-route policies are compiled through a new public `RetryClassifierFactory` that maps a route's `retry_on` to a classifier while the generic knobs stay shared; `GrpcRetryClassifierFactory` is the default and `XdsChannelBuilder::with_retry_classifier_factory` installs a custom one. The gRPC path is behavior-preserving, and the new public types are exported so a non-gRPC transport can plug in its own retry logic without duplicating the engine.
