### PR TITLE
grpc/server: fork client call options

### DIFF
--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -235,7 +235,7 @@ impl ServerTransport for InMemoryServerCall {
     ) -> InMemoryServingConnection {
         let mut send = InMemoryServerSendStream { tx: self.resp_tx };
         let recv = BoxedRecvStream(Box::new(InMemoryServerRecvStream { rx: self.req_rx }));
-        let options = crate::client::CallOptions::default();
+        let options = crate::server::CallOptions::default();
         let trailers_tx = self.trailer_tx;
 
         let inner = Box::pin(async move {
@@ -576,7 +576,7 @@ mod tests {
         use std::sync::atomic::AtomicBool;
         use std::sync::atomic::Ordering;
 
-        use crate::client::CallOptions;
+        use crate::server::CallOptions;
         use crate::server::RecvStream;
         use crate::server::RequestHeaders;
         use crate::server::SendStream;

--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -22,7 +22,7 @@
  *
  */
 
-use crate::client::CallOptions;
+use crate::server::CallOptions;
 use crate::server::Handle;
 use crate::server::RecvStream;
 use crate::server::RequestHeaders;
@@ -96,7 +96,6 @@ mod test {
     use tokio::sync::Mutex;
 
     use super::*;
-    use crate::client::CallOptions;
     use crate::core::RecvMessage;
     use crate::server::RequestHeaders;
     use crate::server::ResponseStreamItem;

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -51,13 +51,27 @@ use std::sync::Arc;
 
 use tonic::async_trait;
 
-use crate::client::CallOptions;
 use crate::core::RecvMessage;
 use crate::core::SendMessage;
 use crate::metadata::MetadataMap;
 use crate::rt::GrpcRuntime;
 
 pub(crate) mod interceptor;
+
+/// Settings to configure RPCs sent using the [`Handle`] trait.
+///
+/// Most applications will not need this type, and will set options via the
+/// generated (e.g. protobuf) APIs instead.
+#[derive(Default, Clone)]
+#[non_exhaustive]
+pub struct CallOptions {}
+
+impl CallOptions {
+    /// Constructs a new [`CallOptions`] with the default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 /// A serving connection that supports graceful shutdown.
 ///
@@ -977,7 +991,6 @@ mod tests {
 
     #[tokio::test]
     async fn listener_dropped_immediately_while_connections_drain() {
-        use crate::client::CallOptions;
         use crate::server::RecvStream;
         use crate::server::RequestHeaders;
         use crate::server::SendStream;


### PR DESCRIPTION
Currently, the `server::Handle::handle()` method accepts `client::CallOptions`. However, server-side options are distinct from client-side options and should not share the same struct. This PR introduces a dedicated `server::CallOptions` struct for the server APIs.