### PR TITLE
grpc-protobuf: disable grpc default features

### DIFF
--- a/grpc-protobuf/Cargo.toml
+++ b/grpc-protobuf/Cargo.toml
@@ -22,7 +22,7 @@ allowed_external_types = [
 
 [dependencies]
 bytes = "1.11.1"
-grpc = { version = "0.10.0", path = "../grpc" }
+grpc = { version = "0.10.0", path = "../grpc", default-features = false }
 protobuf = "4.35.1-release"
 protobuf-well-known-types = "4.35.1-release"
 


### PR DESCRIPTION
## Motivation

`grpc-protobuf` crate depends on `grpc` without disabling default features.

I don't want to bring the entire Hickory Resolver into my project since i don't even need DNS resolution, so i add grpc as `--no-default-features -F _runtime-tokio`.
But then i add grpc-protobuf, and Hickory's dependency tree appears again, because it requires the default features of grpc including `dns`, which i specifically wanted to opt-out from.

## Solution

Set `default_features = false` for grpc dependency in grpc-protobuf, so this utility crate doesn't opt-in for possibly undesired grpc crate features.

By the way, the same thing is already done in grpc-google (though i don't know if the reason was the same):

https://github.com/grpc/grpc-rust/blob/38c7e6159c5571d79acec9bf55d484940d100c4a/grpc-google/Cargo.toml#L17