### PR TITLE
grpc-protobuf: remove redundant trait bounds

### DIFF
--- a/grpc-protobuf/src/client/bidi.rs
+++ b/grpc-protobuf/src/client/bidi.rs
@@ -28,10 +28,7 @@ use std::pin::Pin;
 use grpc::client::CallOptions;
 use grpc::client::InvokeOnce;
 use grpc::client::RequestHeaders;
-use protobuf::ClearAndParse;
 use protobuf::Message;
-use protobuf::MessageMut;
-use protobuf::MessageView;
 
 use crate::CallBuilder;
 use crate::GrpcStreamingRequest;
@@ -64,16 +61,8 @@ impl<'a, C, Req, Res> BidiCallBuilder<'a, C, Req, Res> {
 impl<'a, C, Req, Res> IntoFuture for BidiCallBuilder<'a, C, Req, Res>
 where
     C: InvokeOnce + 'a,
-    // Req is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
     Req: Message,
-    for<'b> Req::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
-    Res: Message + ClearAndParse,
-    for<'b> Res::Mut<'b>: MessageMut<'b>,
+    Res: Message,
 {
     type Output = (
         GrpcStreamingRequest<Req, C::SendStream>,

--- a/grpc-protobuf/src/client/client_streaming.rs
+++ b/grpc-protobuf/src/client/client_streaming.rs
@@ -35,10 +35,7 @@ use grpc::client::SendStream;
 use grpc::client::stream_util::RecvStreamValidator;
 use protobuf::AsMut;
 use protobuf::AsView;
-use protobuf::ClearAndParse;
 use protobuf::Message;
-use protobuf::MessageMut;
-use protobuf::MessageView;
 
 use crate::CallBuilder;
 use crate::ProtoRecvMessage;
@@ -77,16 +74,8 @@ where
 impl<'a, C, Req, Res> IntoFuture for ClientStreamingCallBuilder<'a, C, Req, Res>
 where
     C: InvokeOnce + 'a,
-    // Req is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
     Req: Message,
-    for<'b> Req::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
-    Res: Message + ClearAndParse,
-    for<'b> Res::Mut<'b>: MessageMut<'b>,
+    Res: Message,
 {
     type Output = ClientStreamingCall<'a, C, Req, Res>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
@@ -136,16 +125,8 @@ pub struct ClientStreamingCall<'a, C: InvokeOnce, Req, Res> {
 impl<'a, C, Req, Res> ClientStreamingCall<'a, C, Req, Res>
 where
     C: InvokeOnce + 'a,
-    // Req is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
     Req: Message,
-    for<'b> Req::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
     Res: Message,
-    for<'b> Res::Mut<'b>: MessageMut<'b>,
 {
     /// Sends `message` on the stream.  Will block if flow control does not
     /// allow for sending the request message.  Returns an error if the stream

--- a/grpc-protobuf/src/client/mod.rs
+++ b/grpc-protobuf/src/client/mod.rs
@@ -42,8 +42,6 @@ use grpc::client::stream_util::RecvStreamValidator;
 use grpc::core::RecvMessage;
 use protobuf::AsMut;
 use protobuf::Message;
-use protobuf::MessageMut;
-use protobuf::MessageView;
 
 use crate::ProtoRecvMessage;
 use crate::ProtoSendMessage;
@@ -70,7 +68,6 @@ impl<M, Tx> GrpcStreamingRequest<M, Tx>
 where
     Tx: SendStream,
     M: Message,
-    for<'b> M::View<'b>: MessageView<'b>,
 {
     fn new(tx: Tx) -> Self {
         Self {
@@ -117,7 +114,6 @@ impl<M, Rx> GrpcStreamingResponse<M, Rx>
 where
     Rx: ClientRecvStream,
     M: Message,
-    for<'b> M::Mut<'b>: MessageMut<'b>,
 {
     fn new(rx: Rx) -> Self {
         Self {

--- a/grpc-protobuf/src/client/server_streaming.rs
+++ b/grpc-protobuf/src/client/server_streaming.rs
@@ -31,11 +31,7 @@ use grpc::client::RequestHeaders;
 use grpc::client::SendOptions;
 use grpc::client::SendStream as _;
 use protobuf::AsView;
-use protobuf::ClearAndParse;
 use protobuf::Message;
-use protobuf::MessageMut;
-use protobuf::MessageView;
-use protobuf::Proxied;
 
 use crate::CallBuilder;
 use crate::GrpcStreamingResponse;
@@ -74,11 +70,7 @@ where
     // "AsView" and protobuf would automatically include the rest.)
     ReqMsgView: AsView + Send + Sync + 'a,
     <ReqMsgView as AsView>::Proxied: Message,
-    for<'b> <<ReqMsgView as AsView>::Proxied as Proxied>::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.)
-    Res: Message + ClearAndParse,
-    for<'b> Res::Mut<'b>: MessageMut<'b>,
+    Res: Message,
 {
     type Output = GrpcStreamingResponse<Res, C::RecvStream>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;

--- a/grpc-protobuf/src/client/server_streaming.rs
+++ b/grpc-protobuf/src/client/server_streaming.rs
@@ -66,10 +66,7 @@ impl<'a, C, ReqMsgView, Res> ServerStreamingCallBuilder<'a, C, ReqMsgView, Res> 
 impl<'a, C, ReqMsgView, Res> IntoFuture for ServerStreamingCallBuilder<'a, C, ReqMsgView, Res>
 where
     C: InvokeOnce + 'a,
-    // ReqMsgView is a proto message view. (Ideally we could just require
-    // "AsView" and protobuf would automatically include the rest.)
-    ReqMsgView: AsView + Send + Sync + 'a,
-    <ReqMsgView as AsView>::Proxied: Message,
+    ReqMsgView: AsView<Proxied: Message> + Send + Sync + 'a,
     Res: Message,
 {
     type Output = GrpcStreamingResponse<Res, C::RecvStream>;

--- a/grpc-protobuf/src/client/unary.rs
+++ b/grpc-protobuf/src/client/unary.rs
@@ -75,10 +75,7 @@ where
     /// and returning the status of the call.
     pub async fn with_response_message(self, res: &mut impl AsMut<MutProxied = Res>) -> Status
     where
-        // ReqMsgView is a proto message view. (Ideally we could just require
-        // "AsView" and protobuf would automatically include the rest.)
-        ReqMsgView: AsView + Send + Sync + 'a,
-        <ReqMsgView as AsView>::Proxied: Message,
+        ReqMsgView: AsView<Proxied: Message> + Send + Sync + 'a,
         Res: Message,
     {
         let headers = RequestHeaders::new().with_method_name(self.method);
@@ -99,11 +96,7 @@ where
 impl<'a, C, ReqMsgView, Res> IntoFuture for UnaryCallBuilder<'a, C, ReqMsgView, Res>
 where
     C: InvokeOnce + 'a,
-    // ReqMsgView is a proto message view. (Ideally we could just require
-    // "AsView" and protobuf would automatically include the rest.  For now we
-    // need the HRTBs.)
-    ReqMsgView: AsView + Send + Sync + 'a,
-    <ReqMsgView as AsView>::Proxied: Message,
+    ReqMsgView: AsView<Proxied: Message> + Send + Sync + 'a,
     Res: Message,
 {
     type Output = Result<Res, StatusError>;

--- a/grpc-protobuf/src/client/unary.rs
+++ b/grpc-protobuf/src/client/unary.rs
@@ -35,10 +35,7 @@ use grpc::client::SendStream as _;
 use grpc::client::stream_util::RecvStreamValidator;
 use protobuf::AsMut;
 use protobuf::AsView;
-use protobuf::ClearAndParse;
 use protobuf::Message;
-use protobuf::MessageView;
-use protobuf::Proxied;
 
 use crate::CallBuilder;
 use crate::ProtoRecvMessage;
@@ -82,11 +79,7 @@ where
         // "AsView" and protobuf would automatically include the rest.)
         ReqMsgView: AsView + Send + Sync + 'a,
         <ReqMsgView as AsView>::Proxied: Message,
-        for<'b> <<ReqMsgView as AsView>::Proxied as Proxied>::View<'b>: MessageView<'b>,
-        // Res is a proto message. (Ideally we could just require "Message" and
-        // protobuf would automatically include the rest.)
         Res: Message,
-        for<'b> Res::Mut<'b>: ClearAndParse + Send + Sync,
     {
         let headers = RequestHeaders::new().with_method_name(self.method);
         let (mut tx, rx) = self.channel.invoke_once(headers, self.args).await;
@@ -111,12 +104,7 @@ where
     // need the HRTBs.)
     ReqMsgView: AsView + Send + Sync + 'a,
     <ReqMsgView as AsView>::Proxied: Message,
-    for<'b> <<ReqMsgView as AsView>::Proxied as Proxied>::View<'b>: MessageView<'b>,
-    // Res is a proto message. (Ideally we could just require "Message" and
-    // protobuf would automatically include the rest.  For now we need the
-    // HRTBs.)
     Res: Message,
-    for<'b> Res::Mut<'b>: ClearAndParse + Send + Sync,
 {
     type Output = Result<Res, StatusError>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/commit/be1292fbe2fc84ad59b6365a7620625e30114181 introduced supertraits that make several generic bounds redundant. This PR removes those redundant bounds.