### PR TITLE
transport: drop listener before draining connections

### DIFF
--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -24,9 +24,12 @@
 
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
 use std::io;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::{net::TcpListener, net::TcpStream, sync::oneshot};
+use tokio_stream::Stream;
 use tonic::{
     transport::{server::TcpIncoming, Endpoint, Server},
     Code, Request, Response, Status,
@@ -160,14 +163,37 @@ impl test_server::Test for HoldSvc {
     }
 }
 
-/// The listen socket must close when the shutdown signal fires, *before*
-/// in-flight RPCs finish. Otherwise new clients SYN-ACK into a dead backlog
-/// and hang until their own deadline.
+/// Forwards `S` and sends on `on_drop` when the wrapper is dropped.
+struct NotifyOnDrop<S> {
+    inner: S,
+    on_drop: Option<oneshot::Sender<()>>,
+}
+
+impl<S> Drop for NotifyOnDrop<S> {
+    fn drop(&mut self) {
+        if let Some(tx) = self.on_drop.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+impl<S: Stream + Unpin> Stream for NotifyOnDrop<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// The incoming stream must be dropped when the shutdown signal fires,
+/// before in-flight RPCs finish. Otherwise a TCP listener stays bound
+/// and new clients SYN-ACK into a backlog that is never accepted.
 #[tokio::test]
 async fn shutdown_closes_listener_before_drain() {
     let (started_tx, started_rx) = oneshot::channel();
     let (hold_tx, hold_rx) = oneshot::channel();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (dropped_tx, dropped_rx) = oneshot::channel();
 
     let svc = test_server::TestServer::new(HoldSvc {
         started: Mutex::new(Some(started_tx)),
@@ -176,7 +202,10 @@ async fn shutdown_closes_listener_before_drain() {
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+    let incoming = NotifyOnDrop {
+        inner: TcpIncoming::from(listener).with_nodelay(Some(true)),
+        on_drop: Some(dropped_tx),
+    };
 
     let jh = tokio::spawn(async move {
         Server::builder()
@@ -192,22 +221,23 @@ async fn shutdown_closes_listener_before_drain() {
 
     shutdown_tx.send(()).unwrap();
 
-    let kind = tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            match TcpStream::connect(addr).await {
-                Ok(_) => tokio::task::yield_now().await,
-                Err(e) => return e.kind(),
-            }
-        }
-    })
-    .await
-    .expect("new connect must fail promptly after shutdown, while drain is still in progress");
+    // Wait for the accept stream to be dropped. Do not connect in a loop
+    // while waiting: that keeps accept ready and can starve the shutdown
+    // branch of `select!` (seen on Windows CI).
+    dropped_rx
+        .await
+        .expect("incoming must be dropped on shutdown, before drain finishes");
+
+    let err = TcpStream::connect(addr)
+        .await
+        .expect_err("listen socket must be closed after incoming is dropped");
     assert!(
         matches!(
-            kind,
+            err.kind(),
             io::ErrorKind::ConnectionRefused | io::ErrorKind::ConnectionReset
         ),
-        "expected refused/reset after listen drop, got {kind:?}"
+        "expected refused/reset after listen drop, got {:?}",
+        err.kind()
     );
 
     hold_tx.send(()).unwrap();

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -224,9 +224,12 @@ async fn shutdown_closes_listener_before_drain() {
     // Do not call connect in a loop before that.
     // A connect loop can make `incoming.next()` ready.
     // Then `select!` can accept the connection and ignore shutdown.
-    dropped_rx
+    // The timeout is only a hang guard. On an unfixed server, drop
+    // waits for drain, and drain waits for `hold`.
+    tokio::time::timeout(Duration::from_secs(1), dropped_rx)
         .await
-        .expect("incoming was not dropped before drain");
+        .expect("incoming was not dropped before drain")
+        .unwrap();
 
     let err = TcpStream::connect(addr)
         .await

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -23,9 +23,10 @@
  */
 
 use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::{net::TcpListener, sync::oneshot};
+use tokio::{net::TcpListener, net::TcpStream, sync::oneshot};
 use tonic::{
     transport::{server::TcpIncoming, Endpoint, Server},
     Code, Request, Response, Status,
@@ -135,5 +136,81 @@ async fn connect_lazy_reconnects_after_first_failure() {
 
     assert_eq!(err.code(), Code::Unavailable);
 
+    jh.await.unwrap();
+}
+
+/// A unary call that does not return until `hold` is signaled.
+struct HoldSvc {
+    started: Mutex<Option<oneshot::Sender<()>>>,
+    hold: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+#[tonic::async_trait]
+impl test_server::Test for HoldSvc {
+    async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+        let started = self.started.lock().unwrap().take();
+        if let Some(tx) = started {
+            let _ = tx.send(());
+        }
+        let hold = self.hold.lock().unwrap().take();
+        if let Some(rx) = hold {
+            let _ = rx.await;
+        }
+        Ok(Response::new(Output {}))
+    }
+}
+
+/// The listen socket must close when the shutdown signal fires, *before*
+/// in-flight RPCs finish. Otherwise new clients SYN-ACK into a dead backlog
+/// and hang until their own deadline.
+#[tokio::test]
+async fn shutdown_closes_listener_before_drain() {
+    let (started_tx, started_rx) = oneshot::channel();
+    let (hold_tx, hold_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let svc = test_server::TestServer::new(HoldSvc {
+        started: Mutex::new(Some(started_tx)),
+        hold: Mutex::new(Some(hold_rx)),
+    });
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(incoming, async { drop(shutdown_rx.await) })
+            .await
+            .unwrap();
+    });
+
+    let mut client = TestClient::connect(format!("http://{addr}")).await.unwrap();
+    let call = tokio::spawn(async move { client.unary_call(Request::new(Input {})).await });
+    started_rx.await.unwrap();
+
+    shutdown_tx.send(()).unwrap();
+
+    let kind = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            match TcpStream::connect(addr).await {
+                Ok(_) => tokio::task::yield_now().await,
+                Err(e) => return e.kind(),
+            }
+        }
+    })
+    .await
+    .expect("new connect must fail promptly after shutdown, while drain is still in progress");
+    assert!(
+        matches!(
+            kind,
+            io::ErrorKind::ConnectionRefused | io::ErrorKind::ConnectionReset
+        ),
+        "expected refused/reset after listen drop, got {kind:?}"
+    );
+
+    hold_tx.send(()).unwrap();
+    call.await.unwrap().unwrap();
     jh.await.unwrap();
 }

--- a/tests/integration_tests/tests/connection.rs
+++ b/tests/integration_tests/tests/connection.rs
@@ -142,7 +142,7 @@ async fn connect_lazy_reconnects_after_first_failure() {
     jh.await.unwrap();
 }
 
-/// A unary call that does not return until `hold` is signaled.
+/// A unary handler. The call waits until `hold` is received.
 struct HoldSvc {
     started: Mutex<Option<oneshot::Sender<()>>>,
     hold: Mutex<Option<oneshot::Receiver<()>>>,
@@ -163,7 +163,7 @@ impl test_server::Test for HoldSvc {
     }
 }
 
-/// Forwards `S` and sends on `on_drop` when the wrapper is dropped.
+/// Forwards polls to `inner`. Sends on `on_drop` when this value is dropped.
 struct NotifyOnDrop<S> {
     inner: S,
     on_drop: Option<oneshot::Sender<()>>,
@@ -185,9 +185,8 @@ impl<S: Stream + Unpin> Stream for NotifyOnDrop<S> {
     }
 }
 
-/// The incoming stream must be dropped when the shutdown signal fires,
-/// before in-flight RPCs finish. Otherwise a TCP listener stays bound
-/// and new clients SYN-ACK into a backlog that is never accepted.
+/// Shutdown must drop `incoming` before in-flight RPCs complete.
+/// If `incoming` is a `TcpIncoming`, drop closes the listen socket.
 #[tokio::test]
 async fn shutdown_closes_listener_before_drain() {
     let (started_tx, started_rx) = oneshot::channel();
@@ -221,22 +220,23 @@ async fn shutdown_closes_listener_before_drain() {
 
     shutdown_tx.send(()).unwrap();
 
-    // Wait for the accept stream to be dropped. Do not connect in a loop
-    // while waiting: that keeps accept ready and can starve the shutdown
-    // branch of `select!` (seen on Windows CI).
+    // Wait until `incoming` is dropped.
+    // Do not call connect in a loop before that.
+    // A connect loop can make `incoming.next()` ready.
+    // Then `select!` can accept the connection and ignore shutdown.
     dropped_rx
         .await
-        .expect("incoming must be dropped on shutdown, before drain finishes");
+        .expect("incoming was not dropped before drain");
 
     let err = TcpStream::connect(addr)
         .await
-        .expect_err("listen socket must be closed after incoming is dropped");
+        .expect_err("connect succeeded after incoming drop");
     assert!(
         matches!(
             err.kind(),
             io::ErrorKind::ConnectionRefused | io::ErrorKind::ConnectionReset
         ),
-        "expected refused/reset after listen drop, got {:?}",
+        "connect error was {:?}, not refused or reset",
         err.kind()
     );
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -745,6 +745,9 @@ impl<L> Server<L> {
     }
 
     /// Serve the service with the signal on the provided incoming stream.
+    ///
+    /// When `signal` completes, `incoming` is dropped immediately (closing a
+    /// TCP listener) and already-accepted connections are then drained.
     pub async fn serve_with_incoming_shutdown<S, I, F, IO, IE, ResBody>(
         self,
         svc: S,
@@ -853,37 +856,44 @@ impl<L> Server<L> {
 
         let graceful = signal.is_some();
         let mut sig = pin!(Fuse { inner: signal });
-        let mut incoming = pin!(incoming);
 
-        loop {
-            tokio::select! {
-                _ = &mut sig => {
-                    trace!("signal received, shutting down");
-                    break;
-                },
-                io = incoming.next() => {
-                    let io = match io {
-                        Some(Ok(io)) => io,
-                        Some(Err(e)) => {
-                            trace!("error accepting connection: {}", DisplayErrorStack(&*e));
-                            continue;
-                        },
-                        None => {
-                            break
-                        },
-                    };
+        // Scope the accept loop so `incoming` is dropped as soon as we stop
+        // accepting. For `TcpIncoming` that closes the listen socket immediately
+        // (kernel stops SYN-ACKing). Holding it until after drain leaves the
+        // port bound: new clients complete TCP, then hang until their deadline.
+        {
+            let mut incoming = pin!(incoming);
 
-                    trace!("connection accepted");
+            loop {
+                tokio::select! {
+                    _ = &mut sig => {
+                        trace!("signal received, shutting down");
+                        break;
+                    },
+                    io = incoming.next() => {
+                        let io = match io {
+                            Some(Ok(io)) => io,
+                            Some(Err(e)) => {
+                                trace!("error accepting connection: {}", DisplayErrorStack(&*e));
+                                continue;
+                            },
+                            None => {
+                                break
+                            },
+                        };
 
-                    let req_svc = svc
-                        .call(&io)
-                        .await
-                        .map_err(super::Error::from_source)?;
+                        trace!("connection accepted");
 
-                    let hyper_io = TokioIo::new(io);
-                    let hyper_svc = TowerToHyperService::new(req_svc.map_request(|req: Request<Incoming>| req.map(Body::new)));
+                        let req_svc = svc
+                            .call(&io)
+                            .await
+                            .map_err(super::Error::from_source)?;
 
-                    serve_connection(hyper_io, hyper_svc, server.clone(), graceful.then(|| signal_rx.clone()), max_connection_age, max_connection_age_grace);
+                        let hyper_io = TokioIo::new(io);
+                        let hyper_svc = TowerToHyperService::new(req_svc.map_request(|req: Request<Incoming>| req.map(Body::new)));
+
+                        serve_connection(hyper_io, hyper_svc, server.clone(), graceful.then(|| signal_rx.clone()), max_connection_age, max_connection_age_grace);
+                    }
                 }
             }
         }
@@ -1113,6 +1123,9 @@ impl<L> Router<L> {
     /// on the provided incoming stream of `AsyncRead + AsyncWrite`. Similar to
     /// `serve_with_shutdown` this method will also take a signal future to
     /// gracefully shutdown the server.
+    ///
+    /// When `signal` completes, `incoming` is dropped immediately (closing a
+    /// TCP listener) and already-accepted connections are then drained.
     ///
     /// This method discards any provided [`Server`] TCP configuration.
     ///

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -858,10 +858,10 @@ impl<L> Server<L> {
         let graceful = signal.is_some();
         let mut sig = pin!(Fuse { inner: signal });
 
-        // This block ends the life of `incoming` when accept stops.
-        // Drop of a `TcpIncoming` closes the listen socket.
-        // If `incoming` lives until after drain, the listen socket stays open.
-        // New TCP connections can complete. The server does not read them.
+        // Scope the accept loop so `incoming` is dropped as soon as we stop
+        // accepting. For `TcpIncoming` that closes the listen socket immediately
+        // (kernel stops SYN-ACKing). Holding it until after drain leaves the
+        // port bound: new clients complete TCP, then hang until their deadline.
         {
             let mut incoming = pin!(incoming);
 

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -746,8 +746,9 @@ impl<L> Server<L> {
 
     /// Serve the service with the signal on the provided incoming stream.
     ///
-    /// When `signal` completes, `incoming` is dropped immediately (closing a
-    /// TCP listener) and already-accepted connections are then drained.
+    /// When `signal` completes, this function drops `incoming`.
+    /// If `incoming` is a [`TcpIncoming`], drop closes the listen socket.
+    /// The function then waits for accepted connections to close.
     pub async fn serve_with_incoming_shutdown<S, I, F, IO, IE, ResBody>(
         self,
         svc: S,
@@ -857,10 +858,10 @@ impl<L> Server<L> {
         let graceful = signal.is_some();
         let mut sig = pin!(Fuse { inner: signal });
 
-        // Scope the accept loop so `incoming` is dropped as soon as we stop
-        // accepting. For `TcpIncoming` that closes the listen socket immediately
-        // (kernel stops SYN-ACKing). Holding it until after drain leaves the
-        // port bound: new clients complete TCP, then hang until their deadline.
+        // This block ends the life of `incoming` when accept stops.
+        // Drop of a `TcpIncoming` closes the listen socket.
+        // If `incoming` lives until after drain, the listen socket stays open.
+        // New TCP connections can complete. The server does not read them.
         {
             let mut incoming = pin!(incoming);
 


### PR DESCRIPTION
## Motivation

`Server::serve_with_incoming_shutdown` stops polling the accept stream when the shutdown signal completes. It then waits for already-accepted connections to drain. The incoming stream itself was not dropped until that drain finished.

For `TcpIncoming`, keeping the stream alive keeps the listen socket open. The kernel continues to accept TCP handshakes into the backlog. Those connections are never passed to the HTTP/2 or TLS stack. A new client completes TCP, then waits until its own request deadline.

`shutdown_closes_listener_before_drain` fails on current `master` with:

```
new connect must fail promptly after shutdown, while drain is still in progress: Elapsed(())
```

A new `TcpStream::connect` still succeeds for the full 500 ms after shutdown while an in-flight RPC is held. grpc-go `GracefulStop` closes every listener first, then drains transports. `net/http.Server.Shutdown` does the same.

## Solution

Scope the accept loop so `incoming` is dropped as soon as the shutdown signal fires. `TcpIncoming`'s `Drop` closes the listen socket. Already-accepted connections are then drained as before.

`serve_with_incoming_shutdown` docs now state this order.

The integration test starts a unary RPC, holds it, signals shutdown, and asserts that a new TCP connect fails with `ConnectionRefused` or `ConnectionReset` before the held RPC is released.

This change was drafted with AI. I reviewed the code, ran `shutdown_closes_listener_before_drain` on this branch (pass) and on `master` with the same test added (fail).