### PR TITLE
feat(tonic-xds): add public bootstrap config builder & release alpha.3

### DIFF
--- a/grpc-xds/Cargo.toml
+++ b/grpc-xds/Cargo.toml
@@ -21,7 +21,7 @@ allowed_external_types = []
 protobuf = "4.35.1-release"
 protobuf-well-known-types = "4.35.1-release"
 bytes = "1.11.0"
-xds-client = { version = "0.1.0-alpha.2", path = "../xds-client", default-features = false }
+xds-client = { version = "0.1.0-alpha.3", path = "../xds-client", default-features = false }
 regex = "1"
 
 [build-dependencies]

--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-xds"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 rust-version.workspace = true
 homepage = "https://github.com/hyperium/tonic"
@@ -33,7 +33,7 @@ url = "2.5.8"
 futures-core = "0.3.31"
 futures-util = "0.3"
 bytes = "1"
-xds-client = { version = "0.1.0-alpha.2", path = "../xds-client" }
+xds-client = { version = "0.1.0-alpha.3", path = "../xds-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 envoy-types = "0.7"
@@ -56,13 +56,13 @@ rustls = { version = "0.23", default-features = false, features = ["std", "tls12
 rustls-pemfile = { version = "2", optional = true }
 x509-parser = { version = "0.17", optional = true }
 opentelemetry = { version = "0.32", optional = true, default-features = false, features = ["metrics"] }
-xds-client-opentelemetry = { version = "0.1.0-alpha.2", path = "../xds-client-opentelemetry", optional = true }
+xds-client-opentelemetry = { version = "0.1.0-alpha.3", path = "../xds-client-opentelemetry", optional = true }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-xds-client = { version = "0.1.0-alpha.2", path = "../xds-client", features = ["test-util"] }
+xds-client = { version = "0.1.0-alpha.3", path = "../xds-client", features = ["test-util"] }
 xds-test-util = { path = "../xds-test-util" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "test-util"] }
 tonic = { version = "0.14", features = [ "server", "channel", "tls-ring" ] }
@@ -123,5 +123,6 @@ allowed_external_types = [
     "tower::util::boxed_clone_sync::BoxCloneSyncService",
     "url::parser::ParseError",
     "serde_core::de::Deserialize",
+    "serde_core::ser::Serialize",
     "serde_json::error::Error",
 ]

--- a/tonic-xds/examples/channel.rs
+++ b/tonic-xds/examples/channel.rs
@@ -46,7 +46,7 @@
 //! cargo run -p tonic-xds --example xds_server
 //!
 //! # Terminal 3: xDS client
-//! GRPC_XDS_BOOTSTRAP_CONFIG='{"xds_servers":[{"server_uri":"http://localhost:18000"}],"node":{"id":"test"}}' \
+//! GRPC_XDS_BOOTSTRAP_CONFIG='{"xds_servers":[{"server_uri":"http://localhost:18000","channel_creds":[{"type":"insecure"}]}],"node":{"id":"test"}}' \
 //!     cargo run -p tonic-xds --example channel --features testutil
 //! ```
 //!

--- a/tonic-xds/examples/run_xds_example.sh
+++ b/tonic-xds/examples/run_xds_example.sh
@@ -25,5 +25,5 @@ XDS_PID=$!
 sleep 2
 
 # 3. Run xDS-aware client
-GRPC_XDS_BOOTSTRAP_CONFIG='{"xds_servers":[{"server_uri":"http://localhost:18000"}],"node":{"id":"test"}}' \
+GRPC_XDS_BOOTSTRAP_CONFIG='{"xds_servers":[{"server_uri":"http://localhost:18000","channel_creds":[{"type":"insecure"}]}],"node":{"id":"test"}}' \
     cargo run -p tonic-xds --example channel --features testutil 2>&1 | prefix "client"

--- a/tonic-xds/src/client/xds_e2e.rs
+++ b/tonic-xds/src/client/xds_e2e.rs
@@ -63,7 +63,7 @@ mod test {
     /// target resolves the listener `listener_name`.
     fn build_channel(cp_addr: SocketAddr, listener_name: &str) -> XdsChannelGrpc {
         let bootstrap_json = format!(
-            r#"{{"xds_servers":[{{"server_uri":"http://{cp_addr}"}}],"node":{{"id":"test"}}}}"#
+            r#"{{"xds_servers":[{{"server_uri":"http://{cp_addr}","channel_creds":[{{"type":"insecure"}}]}}],"node":{{"id":"test"}}}}"#
         );
         let bootstrap = BootstrapConfig::from_json(&bootstrap_json).expect("parse bootstrap");
         let target = XdsUri::parse(&format!("xds:///{listener_name}")).expect("parse target");

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -38,8 +38,9 @@
 //!
 //! 1. **Provide a bootstrap configuration** that tells the client where
 //!    the xDS management server lives and what node identity to present.
-//!    The format matches [gRFC A27] — a JSON object with `xds_servers`
-//!    and an optional `node`.
+//!    The format matches [gRFC A27] — a JSON object with `xds_servers`,
+//!    each entry carrying a `server_uri` and the `channel_creds` types the
+//!    client may offer, plus an optional `node`.
 //!
 //! 2. **Build the channel** with [`XdsChannelBuilder`], pointing it at
 //!    an `xds:///` target URI.
@@ -67,7 +68,10 @@
 //!
 //! ```json
 //! {
-//!   "xds_servers": [{"server_uri": "xds.example.com:443"}],
+//!   "xds_servers": [{
+//!     "server_uri": "xds.example.com:443",
+//!     "channel_creds": [{"type": "tls"}]
+//!   }],
 //!   "node": {"id": "my-node"}
 //! }
 //! ```
@@ -94,7 +98,10 @@
 //! use tonic_xds::{BootstrapConfig, XdsChannelBuilder, XdsChannelConfig, XdsUri};
 //!
 //! let bootstrap = BootstrapConfig::from_json(r#"{
-//!     "xds_servers": [{"server_uri": "xds.example.com:443"}],
+//!     "xds_servers": [{
+//!         "server_uri": "xds.example.com:443",
+//!         "channel_creds": [{"type": "tls"}]
+//!     }],
 //!     "node": {"id": "my-node", "cluster": "my-cluster"}
 //! }"#).unwrap();
 //!
@@ -142,7 +149,10 @@
 //!
 //! ```json
 //! {
-//!   "xds_servers": [{"server_uri": "xds.example.com:443"}],
+//!   "xds_servers": [{
+//!     "server_uri": "xds.example.com:443",
+//!     "channel_creds": [{"type": "tls"}]
+//!   }],
 //!   "certificate_providers": {
 //!     "root_ca":  { "plugin_name": "file_watcher", "config": {
 //!       "ca_certificate_file": "/etc/certs/ca.pem"

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -54,7 +54,8 @@
 //!
 //! | Method | How |
 //! |--------|-----|
-//! | Programmatic | [`BootstrapConfig::from_json`] then [`XdsChannelConfig::with_bootstrap`] |
+//! | Programmatic (builder) | [`BootstrapConfig::builder`] then [`XdsChannelConfig::with_bootstrap`] |
+//! | Programmatic (JSON) | [`BootstrapConfig::from_json`] then [`XdsChannelConfig::with_bootstrap`] |
 //! | Environment (explicit) | [`XdsChannelConfig::with_bootstrap_from_env`] |
 //! | Environment (implicit) | Omit bootstrap; the builder loads from env vars automatically |
 //!
@@ -96,6 +97,26 @@
 //!     "xds_servers": [{"server_uri": "xds.example.com:443"}],
 //!     "node": {"id": "my-node", "cluster": "my-cluster"}
 //! }"#).unwrap();
+//!
+//! let target = XdsUri::parse("xds:///myservice:50051").unwrap();
+//! let channel = XdsChannelBuilder::new(
+//!     XdsChannelConfig::new(target).with_bootstrap(bootstrap),
+//! ).build_grpc_channel().unwrap();
+//!
+//! // let client = MyServiceClient::new(channel);
+//! ```
+//!
+//! ### Using the builder
+//!
+//! ```rust,no_run
+//! use tonic_xds::{BootstrapConfig, ChannelCredentialType, XdsChannelBuilder, XdsChannelConfig, XdsUri};
+//!
+//! let bootstrap = BootstrapConfig::builder("xds.example.com:443")
+//!     .channel_creds([ChannelCredentialType::Tls])
+//!     .node_id("my-node")
+//!     .node_cluster("my-cluster")
+//!     .build()
+//!     .unwrap();
 //!
 //! let target = XdsUri::parse("xds:///myservice:50051").unwrap();
 //! let channel = XdsChannelBuilder::new(
@@ -182,7 +203,9 @@ pub use client::retry::{
 pub use client::route::PreRouteInterceptor;
 pub use common::async_util::BoxFuture;
 pub use shared_http_body::SharedBody;
-pub use xds::bootstrap::{BootstrapConfig, BootstrapError};
+pub use xds::bootstrap::{
+    BootstrapConfig, BootstrapConfigBuilder, BootstrapError, ChannelCredentialType,
+};
 pub use xds::resource::route_config::{RouteConfigMetadata, TypedMetadata};
 pub use xds::uri::{XdsUri, XdsUriError};
 pub use xds_client::TonicCallCredentials;

--- a/tonic-xds/src/xds/bootstrap.rs
+++ b/tonic-xds/src/xds/bootstrap.rs
@@ -57,18 +57,52 @@ const ENV_BOOTSTRAP_CONFIG: &str = "GRPC_XDS_BOOTSTRAP_CONFIG";
 /// let config = BootstrapConfig::from_json(json).unwrap();
 /// ```
 ///
+/// # Inspecting
+///
+/// The fields are private so new bootstrap keys can be added without breaking
+/// changes. The accessors below report what a loaded config will act on.
+///
+/// ```rust
+/// use tonic_xds::BootstrapConfig;
+///
+/// let json = r#"{
+///   "xds_servers": [{"server_uri": "xds.example.com:443"}],
+///   "node": {"id": "node-1"}
+/// }"#;
+/// let config = BootstrapConfig::from_json(json).unwrap();
+/// assert_eq!(config.server_uri(), "xds.example.com:443");
+/// assert_eq!(config.node_id(), "node-1");
+/// ```
+///
+/// # Building programmatically
+///
+/// [`BootstrapConfig::builder`] constructs a config from typed values,
+/// without needing a JSON string. It covers the
+/// same bootstrap keys [`from_json`] acts on, per gRFC A27.
+///
+/// ```rust
+/// use tonic_xds::{BootstrapConfig, ChannelCredentialType};
+///
+/// let config = BootstrapConfig::builder("xds.example.com:443")
+///     .channel_creds([ChannelCredentialType::Tls])
+///     .node_id("node-1")
+///     .build()
+///     .unwrap();
+///
+/// assert_eq!(config.server_uri(), "xds.example.com:443");
+/// assert!(config.use_tls());
+/// ```
+///
+/// [`from_env`]: BootstrapConfig::from_env
+/// [`from_json`]: BootstrapConfig::from_json
 /// [gRFC A27]: https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
-// TODO: Design a public builder API for constructing BootstrapConfig
-// programmatically (not just from JSON). The current `new()` is pub(crate);
-// a public API should use the builder pattern to accommodate future fields
-// without breaking changes.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(try_from = "BootstrapConfigDe")]
 #[non_exhaustive]
 pub struct BootstrapConfig {
     /// xDS management servers to connect to.
     pub(crate) xds_servers: Vec<XdsServerConfig>,
     /// Node identity sent to the xDS server.
-    #[serde(default)]
     pub(crate) node: NodeConfig,
     /// Certificate provider plugin instances, keyed by instance name.
     ///
@@ -77,15 +111,42 @@ pub struct BootstrapConfig {
     /// See gRFC A29 for details.
     ///
     /// [`CertificateProviderPluginInstance`]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/transport_sockets/tls/v3/common.proto
-    #[serde(default)]
     // Consumed by `CertProviderRegistry::from_bootstrap` only under TLS
     // features; parsed regardless so non-TLS builds accept the same JSON.
     #[cfg_attr(not(feature = "_tls-any"), allow(dead_code))]
     pub(crate) certificate_providers: HashMap<String, CertProviderPluginConfig>,
 }
 
+/// Wire form of [`BootstrapConfig`].
+///
+/// [`BootstrapConfig`] deserializes through this type via `serde(try_from)`,
+/// so a config a caller obtains by embedding it in their own config struct
+/// goes through [`validate`](BootstrapConfig::validate) too.
+#[derive(Deserialize)]
+pub(crate) struct BootstrapConfigDe {
+    xds_servers: Vec<XdsServerConfig>,
+    #[serde(default)]
+    node: NodeConfig,
+    #[serde(default)]
+    certificate_providers: HashMap<String, CertProviderPluginConfig>,
+}
+
+impl TryFrom<BootstrapConfigDe> for BootstrapConfig {
+    type Error = BootstrapError;
+
+    fn try_from(de: BootstrapConfigDe) -> Result<Self, Self::Error> {
+        let config = Self {
+            xds_servers: de.xds_servers,
+            node: de.node,
+            certificate_providers: de.certificate_providers,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+}
+
 /// Configuration for a single xDS management server.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub(crate) struct XdsServerConfig {
     /// URI of the xDS server (e.g., `"xds.example.com:443"`).
     pub server_uri: String,
@@ -100,24 +161,42 @@ pub(crate) struct XdsServerConfig {
 }
 
 /// A channel credential entry from the bootstrap config.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub(crate) struct ChannelCredentialConfig {
     /// Credential type (e.g., `"insecure"`, `"tls"`, `"google_default"`).
     #[serde(rename = "type")]
     pub cred_type: ChannelCredentialType,
 }
 
-/// Channel credential type from the bootstrap config.
+/// Channel credential type offered to the xDS management server.
 ///
-/// Known types are deserialized into specific variants; unrecognized types
-/// are captured as `Unsupported(String)` so they can be skipped gracefully.
+/// The client uses the first type it supports, per [gRFC A27]. This is the
+/// bootstrap's `xds_servers[].channel_creds[].type`, and is what
+/// [`BootstrapConfigBuilder::channel_creds`] accepts.
+///
+/// [gRFC A27]: https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum ChannelCredentialType {
+#[non_exhaustive]
+pub enum ChannelCredentialType {
+    /// Plaintext connection to the xDS server.
     Insecure,
+    /// TLS with the platform's default trust roots.
     Tls,
+    /// Google default credentials (ALTS or TLS plus call credentials).
     GoogleDefault,
+    /// A credential type this client does not implement.
+    ///
+    /// Produced when parsing a bootstrap written for a newer or different
+    /// client; such entries are skipped when selecting a credential, so a
+    /// bootstrap can list types this version does not know about.
+    ///
+    /// `#[non_exhaustive]` reserves the variant for the parser: downstream
+    /// code can neither construct it nor match its payload. [`Deserialize`]
+    /// still yields one for an unknown type, so
+    /// [`BootstrapConfigBuilder::build`] rejects it.
     #[serde(untagged)]
+    #[non_exhaustive]
     Unsupported(String),
 }
 
@@ -131,7 +210,7 @@ pub(crate) enum ChannelCredentialType {
 /// fields. See [gRFC A29].
 ///
 /// [gRFC A29]: https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 // In non-TLS builds `cert_provider` is gated out, so nothing reads these
 // fields after serde populates them.
 #[cfg_attr(not(feature = "_tls-any"), allow(dead_code))]
@@ -142,7 +221,7 @@ pub(crate) struct CertProviderPluginConfig {
 }
 
 /// Node identity configuration from bootstrap JSON.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub(crate) struct NodeConfig {
     /// Opaque node identifier.
     #[serde(default)]
@@ -184,7 +263,7 @@ fn json_to_metadata(value: serde_json::Value) -> Result<MetadataValue, Bootstrap
 }
 
 /// Locality configuration from bootstrap JSON.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub(crate) struct LocalityConfig {
     #[serde(default)]
     pub region: String,
@@ -196,6 +275,7 @@ pub(crate) struct LocalityConfig {
 
 /// Errors that can occur when loading bootstrap configuration.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum BootstrapError {
     /// Neither `GRPC_XDS_BOOTSTRAP` nor `GRPC_XDS_BOOTSTRAP_CONFIG` is set.
     #[error("neither {ENV_BOOTSTRAP_FILE} nor {ENV_BOOTSTRAP_CONFIG} environment variable is set")]
@@ -214,24 +294,22 @@ pub enum BootstrapError {
     /// The parsed config failed validation (e.g., empty `xds_servers`).
     #[error("bootstrap config validation failed: {0}")]
     Validation(String),
+    /// A value passed to [`BootstrapConfigBuilder`] could not be serialized to
+    /// JSON.
+    ///
+    /// Setters take `impl Serialize` for free-form fields such as
+    /// `node.metadata`; [`build`](BootstrapConfigBuilder::build) reports the
+    /// first one that failed.
+    #[error("failed to serialize bootstrap {field}: {source}")]
+    Serialization {
+        /// Field whose value could not be serialized (e.g. `node.metadata`).
+        field: &'static str,
+        /// Underlying serialization error.
+        source: serde_json::Error,
+    },
 }
 
 impl BootstrapConfig {
-    /// Create a bootstrap configuration directly from struct fields.
-    #[allow(dead_code)] // Used by callers constructing config programmatically.
-    pub(crate) fn new(
-        xds_servers: Vec<XdsServerConfig>,
-        node: NodeConfig,
-    ) -> Result<Self, BootstrapError> {
-        let config = Self {
-            xds_servers,
-            node,
-            certificate_providers: HashMap::new(),
-        };
-        config.validate()?;
-        Ok(config)
-    }
-
     /// Load bootstrap configuration from environment variables.
     ///
     /// Checks `GRPC_XDS_BOOTSTRAP` (file path) first, then falls back to
@@ -252,11 +330,22 @@ impl BootstrapConfig {
 
     /// Parse bootstrap configuration from a JSON string.
     pub fn from_json(json: &str) -> Result<Self, BootstrapError> {
-        let config: BootstrapConfig = serde_json::from_str(json)?;
-        config.validate()?;
-        Ok(config)
+        // The wire form reports validation failures as
+        // `BootstrapError::Validation`; `Self` reports them as a serde error.
+        let de: BootstrapConfigDe = serde_json::from_str(json)?;
+        Self::try_from(de)
     }
 
+    /// Checks the invariants every constructor upholds.
+    ///
+    /// Runs on both construction paths — `TryFrom<BootstrapConfigDe>`, which
+    /// covers [`from_json`], [`from_env`] and `Deserialize`, and
+    /// [`BootstrapConfigBuilder::build`] — so [`server_uri`] can index
+    /// `xds_servers` directly.
+    ///
+    /// [`from_json`]: BootstrapConfig::from_json
+    /// [`from_env`]: BootstrapConfig::from_env
+    /// [`server_uri`]: BootstrapConfig::server_uri
     fn validate(&self) -> Result<(), BootstrapError> {
         if self.xds_servers.is_empty() {
             return Err(BootstrapError::Validation(
@@ -273,12 +362,22 @@ impl BootstrapConfig {
         Ok(())
     }
 
-    /// Returns the URI of the first xDS server.
-    pub(crate) fn server_uri(&self) -> &str {
+    /// Returns the URI of the xDS server this config connects to.
+    ///
+    /// Only the first entry is used; further `xds_servers` are parsed but not
+    /// yet connected to.
+    pub fn server_uri(&self) -> &str {
         self.xds_servers
             .first()
             .map(|s| s.server_uri.as_str())
             .expect("xds_servers validated non-empty")
+    }
+
+    /// Returns the node identifier presented to the xDS server.
+    ///
+    /// Empty when the bootstrap omits `node.id`.
+    pub fn node_id(&self) -> &str {
+        &self.node.id
     }
 
     /// Select the first supported channel credential type from the first server's config.
@@ -301,12 +400,250 @@ impl BootstrapConfig {
             })
     }
 
-    /// Returns `true` if the first server's selected credential is TLS.
-    pub(crate) fn use_tls(&self) -> bool {
+    /// Returns `true` if the connection to the xDS server uses TLS.
+    pub fn use_tls(&self) -> bool {
         matches!(
             self.selected_credential(),
             Some(ChannelCredentialType::Tls | ChannelCredentialType::GoogleDefault)
         )
+    }
+
+    /// Starts building a bootstrap config for the given xDS server URI.
+    ///
+    /// Use this when the process already holds the configuration, so it can
+    /// build the config directly. [`from_json`] remains the full-fidelity
+    /// path and the only one that accepts a gRFC A27 document verbatim.
+    ///
+    /// ```rust
+    /// use tonic_xds::{BootstrapConfig, ChannelCredentialType};
+    ///
+    /// let config = BootstrapConfig::builder("xds.example.com:443")
+    ///     .channel_creds([ChannelCredentialType::Tls])
+    ///     .node_id("my-node")
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// assert_eq!(config.server_uri(), "xds.example.com:443");
+    /// assert_eq!(config.node_id(), "my-node");
+    /// assert!(config.use_tls());
+    /// ```
+    ///
+    /// [`from_json`]: BootstrapConfig::from_json
+    pub fn builder(server_uri: impl Into<String>) -> BootstrapConfigBuilder {
+        BootstrapConfigBuilder::new(server_uri)
+    }
+}
+
+/// Builds a [`BootstrapConfig`] without going through JSON.
+///
+/// Created by [`BootstrapConfig::builder`]. Every setter is optional except
+/// the server URI, which [`BootstrapConfig::builder`] takes up front because
+/// the config is invalid without it.
+///
+/// The builder covers the bootstrap keys the client acts on. A bootstrap that
+/// needs keys outside that set — additional `xds_servers` entries, which are
+/// parsed but not yet connected to — must still come from [`from_json`].
+///
+/// ```rust
+/// use tonic_xds::{BootstrapConfig, ChannelCredentialType};
+///
+/// let config = BootstrapConfig::builder("xds.example.com:443")
+///     .channel_creds([ChannelCredentialType::Tls, ChannelCredentialType::Insecure])
+///     .node_id("projects/123/nodes/456")
+///     .node_cluster("my-cluster")
+///     .node_locality("us-east1", "us-east1-b", "rack1")
+///     .node_metadata("GENERATOR", "grpc")
+///     .build()
+///     .unwrap();
+///
+/// assert!(config.use_tls());
+/// ```
+///
+/// [`from_json`]: BootstrapConfig::from_json
+#[derive(Debug)]
+pub struct BootstrapConfigBuilder {
+    server_uri: String,
+    channel_creds: Vec<ChannelCredentialConfig>,
+    node_id: String,
+    node_cluster: Option<String>,
+    node_locality: Option<LocalityConfig>,
+    node_metadata: HashMap<String, serde_json::Value>,
+    certificate_providers: HashMap<String, CertProviderPluginConfig>,
+    error: Option<BootstrapError>,
+}
+
+impl BootstrapConfigBuilder {
+    fn new(server_uri: impl Into<String>) -> Self {
+        Self {
+            server_uri: server_uri.into(),
+            channel_creds: Vec::new(),
+            node_id: String::new(),
+            node_cluster: None,
+            node_locality: None,
+            node_metadata: HashMap::new(),
+            certificate_providers: HashMap::new(),
+            error: None,
+        }
+    }
+
+    /// Sets the credentials offered to the xDS server, in preference order.
+    ///
+    /// Replaces any previously set credentials. Unset, the client connects to
+    /// the management server in plaintext, matching a bootstrap with no
+    /// `channel_creds`; pass [`ChannelCredentialType::Tls`] for a secured
+    /// server.
+    #[must_use]
+    pub fn channel_creds(mut self, creds: impl IntoIterator<Item = ChannelCredentialType>) -> Self {
+        self.channel_creds = creds
+            .into_iter()
+            .map(|cred_type| ChannelCredentialConfig { cred_type })
+            .collect();
+        self
+    }
+
+    /// Sets the opaque node identifier presented to the xDS server.
+    #[must_use]
+    pub fn node_id(mut self, id: impl Into<String>) -> Self {
+        self.node_id = id.into();
+        self
+    }
+
+    /// Sets the cluster the node belongs to.
+    #[must_use]
+    pub fn node_cluster(mut self, cluster: impl Into<String>) -> Self {
+        self.node_cluster = Some(cluster.into());
+        self
+    }
+
+    /// Sets the locality the node is running in.
+    #[must_use]
+    pub fn node_locality(
+        mut self,
+        region: impl Into<String>,
+        zone: impl Into<String>,
+        sub_zone: impl Into<String>,
+    ) -> Self {
+        self.node_locality = Some(LocalityConfig {
+            region: region.into(),
+            zone: zone.into(),
+            sub_zone: sub_zone.into(),
+        });
+        self
+    }
+
+    /// Adds one free-form node metadata entry, replacing any entry with the
+    /// same key.
+    ///
+    /// Accepts anything [`Serialize`], so a string, a number, or a nested
+    /// struct all work. Some control planes vary the served config based on
+    /// metadata — e.g. Istio's istiod gates proxyless gRPC config behind
+    /// `GENERATOR = "grpc"`.
+    ///
+    /// [`build`] reports a value with no JSON form as
+    /// [`BootstrapError::Serialization`].
+    ///
+    /// [`Serialize`]: serde::Serialize
+    /// [`build`]: BootstrapConfigBuilder::build
+    #[must_use]
+    pub fn node_metadata(mut self, key: impl Into<String>, value: impl serde::Serialize) -> Self {
+        let key = key.into();
+        match serde_json::to_value(value) {
+            Ok(value) => {
+                self.node_metadata.insert(key, value);
+            }
+            Err(source) => self.record_error("node.metadata", source),
+        }
+        self
+    }
+
+    /// Registers a certificate provider instance, replacing any instance with
+    /// the same name.
+    ///
+    /// `instance_name` is what CDS/LDS resources reference by
+    /// `CertificateProviderPluginInstance`; `config` is the opaque
+    /// plugin-specific blob, accepted as anything [`Serialize`]. See [gRFC A29].
+    ///
+    /// [`build`] reports a config with no JSON form as
+    /// [`BootstrapError::Serialization`].
+    ///
+    /// [`Serialize`]: serde::Serialize
+    /// [`build`]: BootstrapConfigBuilder::build
+    /// [gRFC A29]: https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md
+    #[must_use]
+    pub fn certificate_provider(
+        mut self,
+        instance_name: impl Into<String>,
+        plugin_name: impl Into<String>,
+        config: impl serde::Serialize,
+    ) -> Self {
+        let instance_name = instance_name.into();
+        match serde_json::to_value(config) {
+            Ok(config) => {
+                self.certificate_providers.insert(
+                    instance_name,
+                    CertProviderPluginConfig {
+                        plugin_name: plugin_name.into(),
+                        config,
+                    },
+                );
+            }
+            Err(source) => self.record_error("certificate_providers", source),
+        }
+        self
+    }
+
+    /// Keeps the first error so the chain can continue and report at `build`.
+    fn record_error(&mut self, field: &'static str, source: serde_json::Error) {
+        if self.error.is_none() {
+            self.error = Some(BootstrapError::Serialization { field, source });
+        }
+    }
+
+    /// Validates the accumulated settings and returns the config.
+    ///
+    /// # Errors
+    ///
+    /// - [`BootstrapError::Serialization`] if a metadata or certificate
+    ///   provider value could not be serialized to JSON; the first failing
+    ///   setter wins.
+    /// - [`BootstrapError::Validation`] if the server URI is empty — the same
+    ///   validation configs parsed from JSON go through — or if the
+    ///   credentials include [`ChannelCredentialType::Unsupported`].
+    pub fn build(self) -> Result<BootstrapConfig, BootstrapError> {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        // Parsing skips `Unsupported` for forward compatibility; building
+        // treats it as a caller mistake. `Deserialize` is the only source of
+        // one, since the constructor is sealed.
+        if let Some(ChannelCredentialType::Unsupported(name)) = self
+            .channel_creds
+            .iter()
+            .map(|c| &c.cred_type)
+            .find(|t| matches!(t, ChannelCredentialType::Unsupported(_)))
+        {
+            return Err(BootstrapError::Validation(format!(
+                "channel credential type '{name}' is not supported by this client"
+            )));
+        }
+        let config = BootstrapConfig {
+            xds_servers: vec![XdsServerConfig {
+                server_uri: self.server_uri,
+                channel_creds: self.channel_creds,
+                // The client acts on no server feature yet, so the builder
+                // omits a setter.
+                server_features: Vec::new(),
+            }],
+            node: NodeConfig {
+                id: self.node_id,
+                cluster: self.node_cluster,
+                locality: self.node_locality,
+                metadata: self.node_metadata,
+            },
+            certificate_providers: self.certificate_providers,
+        };
+        config.validate()?;
+        Ok(config)
     }
 }
 
@@ -511,6 +848,227 @@ mod tests {
         let config = BootstrapConfig::from_json(json).unwrap();
         let node = Node::try_from(config.node).unwrap();
         assert!(node.id.is_none());
+    }
+
+    #[test]
+    fn public_accessors_report_what_the_client_will_use() {
+        let json = r#"{
+            "xds_servers": [
+                {"server_uri": "primary:443", "channel_creds": [{"type": "tls"}]},
+                {"server_uri": "fallback:443"}
+            ],
+            "node": {"id": "node-1"}
+        }"#;
+        let config = BootstrapConfig::from_json(json).unwrap();
+
+        assert_eq!(config.server_uri(), "primary:443");
+        assert_eq!(config.node_id(), "node-1");
+        assert!(config.use_tls());
+    }
+
+    #[test]
+    fn public_accessors_report_absent_optional_fields() {
+        let json = r#"{"xds_servers": [{"server_uri": "localhost:5000"}]}"#;
+        let config = BootstrapConfig::from_json(json).unwrap();
+
+        assert_eq!(config.node_id(), "");
+        assert!(!config.use_tls());
+    }
+
+    #[test]
+    fn equal_configs_compare_equal_regardless_of_json_formatting() {
+        let compact = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node":{"id":"n1"}}"#;
+        let spaced = r#"{
+            "node": {"id": "n1"},
+            "xds_servers": [{"server_uri": "xds:443"}]
+        }"#;
+
+        assert_eq!(
+            BootstrapConfig::from_json(compact).unwrap(),
+            BootstrapConfig::from_json(spaced).unwrap(),
+        );
+    }
+
+    #[test]
+    fn misplaced_keys_are_dropped_and_compare_unequal() {
+        let intended = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node":{"id":"n1"}}"#;
+        let misplaced = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node_id":"n1"}"#;
+
+        let misparsed = BootstrapConfig::from_json(misplaced).unwrap();
+        assert_eq!(misparsed.node_id(), "");
+        assert_ne!(BootstrapConfig::from_json(intended).unwrap(), misparsed);
+    }
+
+    #[test]
+    fn builder_matches_the_equivalent_json() {
+        let built = BootstrapConfig::builder("xds.example.com:443")
+            .channel_creds([
+                ChannelCredentialType::GoogleDefault,
+                ChannelCredentialType::Tls,
+                ChannelCredentialType::Insecure,
+            ])
+            .node_id("projects/123/nodes/456")
+            .node_cluster("test-cluster")
+            .node_locality("us-east1", "us-east1-b", "rack1")
+            .build()
+            .unwrap();
+
+        // `full_json` also carries `server_features`; the client ignores it,
+        // so the builder omits it.
+        let parsed = BootstrapConfig::from_json(full_json()).unwrap();
+        assert_eq!(parsed.xds_servers[0].server_features, vec!["xds_v3"]);
+        assert!(built.xds_servers[0].server_features.is_empty());
+
+        let mut parsed_without_features = parsed;
+        parsed_without_features.xds_servers[0]
+            .server_features
+            .clear();
+        assert_eq!(parsed_without_features, built);
+    }
+
+    #[test]
+    fn builder_defaults_omit_optional_fields() {
+        let built = BootstrapConfig::builder("xds.example.com:443")
+            .node_id("test-node")
+            .build()
+            .unwrap();
+
+        assert_eq!(BootstrapConfig::from_json(minimal_json()).unwrap(), built);
+        assert!(!built.use_tls());
+    }
+
+    #[test]
+    fn builder_carries_metadata_and_cert_providers() {
+        let built = BootstrapConfig::builder("localhost:5000")
+            .node_metadata("GENERATOR", "grpc")
+            .certificate_provider(
+                "google_cloud_private_spiffe",
+                "file_watcher",
+                serde_json::json!({"certificate_file": "/etc/certs/cert.pem"}),
+            )
+            .build()
+            .unwrap();
+
+        let equivalent = BootstrapConfig::from_json(
+            r#"{
+                "xds_servers": [{"server_uri": "localhost:5000"}],
+                "node": {"metadata": {"GENERATOR": "grpc"}},
+                "certificate_providers": {
+                    "google_cloud_private_spiffe": {
+                        "plugin_name": "file_watcher",
+                        "config": {"certificate_file": "/etc/certs/cert.pem"}
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(equivalent, built);
+    }
+
+    #[test]
+    fn builder_runs_the_same_validation_as_json() {
+        let err = BootstrapConfig::builder("").build().unwrap_err();
+        assert!(matches!(err, BootstrapError::Validation(_)));
+        assert!(err.to_string().contains("server_uri must not be empty"));
+    }
+
+    #[test]
+    fn builder_reports_unrepresentable_metadata_at_build() {
+        // JSON object keys must be strings, so a tuple-keyed map has no JSON
+        // form and `build` reports it.
+        let unrepresentable = HashMap::from([((1u8, 2u8), "v")]);
+        let err = BootstrapConfig::builder("xds:443")
+            .node_metadata("bad", unrepresentable)
+            .build()
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BootstrapError::Serialization {
+                field: "node.metadata",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn builder_reports_only_the_first_serialization_error() {
+        let unrepresentable = HashMap::from([((1u8, 2u8), "v")]);
+        let err = BootstrapConfig::builder("xds:443")
+            .node_metadata("bad", unrepresentable.clone())
+            .certificate_provider("bad", "file_watcher", unrepresentable)
+            .build()
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BootstrapError::Serialization {
+                field: "node.metadata",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parsed_unsupported_creds_are_skipped_but_rejected_by_the_builder() {
+        // Parsing keeps forward compatibility: an unknown type is skipped and
+        // the next supported one wins.
+        let parsed = BootstrapConfig::from_json(
+            r#"{
+                "xds_servers": [{
+                    "server_uri": "xds:443",
+                    "channel_creds": [{"type": "future_creds"}, {"type": "tls"}]
+                }]
+            }"#,
+        )
+        .unwrap();
+        assert!(parsed.use_tls());
+
+        // Building states what this client should use, so `build` rejects the
+        // same value parsing skips. `Deserialize` is the only way to name one.
+        let err = BootstrapConfig::builder("xds:443")
+            .channel_creds(
+                parsed.xds_servers[0]
+                    .channel_creds
+                    .iter()
+                    .map(|c| c.cred_type.clone()),
+            )
+            .build()
+            .unwrap_err();
+
+        assert!(matches!(err, BootstrapError::Validation(_)));
+        assert!(err.to_string().contains("future_creds"));
+    }
+
+    #[test]
+    fn deserializing_a_config_directly_runs_validation() {
+        // `BootstrapConfig` derives `Deserialize` so callers can embed it in
+        // their own config structs; that path validates too, keeping
+        // `server_uri` total.
+        let err =
+            serde_json::from_str::<BootstrapConfig>(r#"{"xds_servers": []}"#).expect_err("empty");
+        assert!(err.to_string().contains("xds_servers must not be empty"));
+
+        let ok = serde_json::from_str::<BootstrapConfig>(
+            r#"{"xds_servers": [{"server_uri": "xds:443"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(ok.server_uri(), "xds:443");
+    }
+
+    #[test]
+    fn builder_setters_replace_rather_than_accumulate() {
+        let built = BootstrapConfig::builder("xds:443")
+            .channel_creds([ChannelCredentialType::Insecure])
+            .channel_creds([ChannelCredentialType::Tls])
+            .node_metadata("k", "first")
+            .node_metadata("k", "second")
+            .build()
+            .unwrap();
+
+        assert!(built.use_tls());
+        assert_eq!(built.node.metadata["k"], serde_json::json!("second"));
     }
 
     #[test]

--- a/tonic-xds/src/xds/bootstrap.rs
+++ b/tonic-xds/src/xds/bootstrap.rs
@@ -53,7 +53,12 @@ const ENV_BOOTSTRAP_CONFIG: &str = "GRPC_XDS_BOOTSTRAP_CONFIG";
 /// let config = BootstrapConfig::from_env().unwrap();
 ///
 /// // From a JSON string:
-/// let json = r#"{"xds_servers":[{"server_uri":"xds.example.com:443"}]}"#;
+/// let json = r#"{
+///   "xds_servers": [{
+///     "server_uri": "xds.example.com:443",
+///     "channel_creds": [{"type": "tls"}]
+///   }]
+/// }"#;
 /// let config = BootstrapConfig::from_json(json).unwrap();
 /// ```
 ///
@@ -66,12 +71,16 @@ const ENV_BOOTSTRAP_CONFIG: &str = "GRPC_XDS_BOOTSTRAP_CONFIG";
 /// use tonic_xds::BootstrapConfig;
 ///
 /// let json = r#"{
-///   "xds_servers": [{"server_uri": "xds.example.com:443"}],
+///   "xds_servers": [{
+///     "server_uri": "xds.example.com:443",
+///     "channel_creds": [{"type": "tls"}]
+///   }],
 ///   "node": {"id": "node-1"}
 /// }"#;
 /// let config = BootstrapConfig::from_json(json).unwrap();
 /// assert_eq!(config.server_uri(), "xds.example.com:443");
 /// assert_eq!(config.node_id(), "node-1");
+/// assert!(config.use_tls());
 /// ```
 ///
 /// # Building programmatically
@@ -151,6 +160,10 @@ pub(crate) struct XdsServerConfig {
     /// URI of the xDS server (e.g., `"xds.example.com:443"`).
     pub server_uri: String,
     /// Ordered list of channel credentials. The client uses the first supported type.
+    ///
+    /// gRFC A27 requires the key. `#[serde(default)]` routes a missing list to
+    /// [`BootstrapConfig::validate`], which reports it with the same message it
+    /// gives an empty or unknown-only one.
     #[serde(default)]
     pub channel_creds: Vec<ChannelCredentialConfig>,
     /// Server features (e.g., `["xds_v3"]`).
@@ -158,6 +171,24 @@ pub(crate) struct XdsServerConfig {
     #[allow(dead_code)]
     // Parsed for completeness; used when server feature negotiation is added.
     pub server_features: Vec<String>,
+}
+
+impl XdsServerConfig {
+    /// First credential type this client supports, per gRFC A27.
+    ///
+    /// Skips unknown types so a bootstrap written for a newer client still
+    /// resolves. Returns `None` for a config still awaiting
+    /// [`BootstrapConfig::validate`], which requires a match.
+    fn selected_credential(&self) -> Option<&ChannelCredentialType> {
+        self.channel_creds.iter().map(|c| &c.cred_type).find(|t| {
+            matches!(
+                t,
+                ChannelCredentialType::Insecure
+                    | ChannelCredentialType::Tls
+                    | ChannelCredentialType::GoogleDefault
+            )
+        })
+    }
 }
 
 /// A channel credential entry from the bootstrap config.
@@ -198,6 +229,24 @@ pub enum ChannelCredentialType {
     #[serde(untagged)]
     #[non_exhaustive]
     Unsupported(String),
+}
+
+impl ChannelCredentialType {
+    /// The bootstrap JSON spelling, so errors name what the caller wrote.
+    fn as_json_name(&self) -> &str {
+        match self {
+            Self::Insecure => "insecure",
+            Self::Tls => "tls",
+            Self::GoogleDefault => "google_default",
+            Self::Unsupported(name) => name,
+        }
+    }
+
+    /// Whether this type expects a TLS handshake. `google_default` counts:
+    /// it negotiates TLS outside its ALTS environments.
+    fn is_tls(&self) -> bool {
+        matches!(self, Self::Tls | Self::GoogleDefault)
+    }
 }
 
 /// A certificate provider plugin entry from the bootstrap config.
@@ -341,11 +390,13 @@ impl BootstrapConfig {
     /// Runs on both construction paths — `TryFrom<BootstrapConfigDe>`, which
     /// covers [`from_json`], [`from_env`] and `Deserialize`, and
     /// [`BootstrapConfigBuilder::build`] — so [`server_uri`] can index
-    /// `xds_servers` directly.
+    /// `xds_servers` directly and [`use_tls`] reports a credential the client
+    /// actually selected.
     ///
     /// [`from_json`]: BootstrapConfig::from_json
     /// [`from_env`]: BootstrapConfig::from_env
     /// [`server_uri`]: BootstrapConfig::server_uri
+    /// [`use_tls`]: BootstrapConfig::use_tls
     fn validate(&self) -> Result<(), BootstrapError> {
         if self.xds_servers.is_empty() {
             return Err(BootstrapError::Validation(
@@ -358,6 +409,68 @@ impl BootstrapConfig {
                     "xds_servers[{i}].server_uri must not be empty"
                 )));
             }
+            // gRFC A27 requires `channel_creds` to name at least one type the
+            // client supports. Enforcing it makes the control plane's security
+            // level an explicit choice, so a missing, empty or unknown-only
+            // list fails here.
+            let Some(selected) = server.selected_credential() else {
+                let listed = server
+                    .channel_creds
+                    .iter()
+                    .map(|c| c.cred_type.as_json_name())
+                    .collect::<Vec<_>>();
+                let found = if listed.is_empty() {
+                    "it is missing or empty".to_string()
+                } else {
+                    format!("found only [{}]", listed.join(", "))
+                };
+                return Err(BootstrapError::Validation(format!(
+                    "xds_servers[{i}].channel_creds must list at least one credential type this \
+                     client supports (insecure, tls, google_default); {found}"
+                )));
+            };
+            Self::validate_uri_scheme(i, &server.server_uri, selected)?;
+        }
+        Ok(())
+    }
+
+    /// Requires the `server_uri` and the selected credential to agree on TLS.
+    ///
+    /// The scheme drives the handshake: the transport upgrades a scheme-less
+    /// URI to `https` when the bootstrap selects TLS, keeps any explicit scheme
+    /// as written, and handshakes for `https` alone. TLS therefore holds on
+    /// exactly those two forms. Any other scheme — `http://`, `unix://`,
+    /// anything unrecognised — connects in the clear while the client reports a
+    /// secure channel and attaches call credentials to it.
+    ///
+    /// `https://` with `insecure` states the same conflict from the other side
+    /// and fails at connect time, so this catches it up front.
+    fn validate_uri_scheme(
+        index: usize,
+        server_uri: &str,
+        credential: &ChannelCredentialType,
+    ) -> Result<(), BootstrapError> {
+        // Mirrors the transport, which parses with `http::Uri` as well: it
+        // reports no scheme for the bare authority form (`xds.example.com:443`)
+        // it upgrades, and errors on the forms it hands to its own connectors
+        // (`unix://...`). A parse error therefore counts as plaintext.
+        let parsed = server_uri.parse::<http::Uri>();
+        let upgraded_to_tls = matches!(&parsed, Ok(uri) if uri.scheme_str().is_none());
+        let is_https = matches!(&parsed, Ok(uri) if uri.scheme_str() == Some("https"));
+        let cred = credential.as_json_name();
+
+        if credential.is_tls() && !(upgraded_to_tls || is_https) {
+            return Err(BootstrapError::Validation(format!(
+                "xds_servers[{index}].server_uri '{server_uri}' connects in plaintext but \
+                 channel_creds selects '{cred}'; use an 'https://' or scheme-less URI, or \
+                 select 'insecure'"
+            )));
+        }
+        if !credential.is_tls() && is_https {
+            return Err(BootstrapError::Validation(format!(
+                "xds_servers[{index}].server_uri '{server_uri}' requires TLS but channel_creds \
+                 selects '{cred}'; list 'tls' or 'google_default', or drop the 'https://' scheme"
+            )));
         }
         Ok(())
     }
@@ -382,30 +495,20 @@ impl BootstrapConfig {
 
     /// Select the first supported channel credential type from the first server's config.
     ///
-    /// Per gRFC A27, the client stops at the first credential type it supports.
-    /// Returns `None` if no supported credential type is found.
+    /// [`validate`](Self::validate) guarantees one exists, so a validated
+    /// config always returns `Some`.
     pub(crate) fn selected_credential(&self) -> Option<&ChannelCredentialType> {
-        self.xds_servers
-            .first()?
-            .channel_creds
-            .iter()
-            .map(|c| &c.cred_type)
-            .find(|t| {
-                matches!(
-                    t,
-                    ChannelCredentialType::Insecure
-                        | ChannelCredentialType::Tls
-                        | ChannelCredentialType::GoogleDefault
-                )
-            })
+        self.xds_servers.first()?.selected_credential()
     }
 
     /// Returns `true` if the connection to the xDS server uses TLS.
+    ///
+    /// [`validate`](Self::validate) requires the `server_uri` scheme to agree
+    /// with the selected credential, so a `true` here means the transport
+    /// really does handshake.
     pub fn use_tls(&self) -> bool {
-        matches!(
-            self.selected_credential(),
-            Some(ChannelCredentialType::Tls | ChannelCredentialType::GoogleDefault)
-        )
+        self.selected_credential()
+            .is_some_and(ChannelCredentialType::is_tls)
     }
 
     /// Starts building a bootstrap config for the given xDS server URI.
@@ -436,9 +539,9 @@ impl BootstrapConfig {
 
 /// Builds a [`BootstrapConfig`] without going through JSON.
 ///
-/// Created by [`BootstrapConfig::builder`]. Every setter is optional except
-/// the server URI, which [`BootstrapConfig::builder`] takes up front because
-/// the config is invalid without it.
+/// Created by [`BootstrapConfig::builder`], which takes the required server URI
+/// up front. gRFC A27 also requires [`channel_creds`], which [`build`] checks.
+/// Every other setter is optional.
 ///
 /// The builder covers the bootstrap keys the client acts on. A bootstrap that
 /// needs keys outside that set — additional `xds_servers` entries, which are
@@ -459,6 +562,8 @@ impl BootstrapConfig {
 /// assert!(config.use_tls());
 /// ```
 ///
+/// [`channel_creds`]: BootstrapConfigBuilder::channel_creds
+/// [`build`]: BootstrapConfigBuilder::build
 /// [`from_json`]: BootstrapConfig::from_json
 #[derive(Debug)]
 pub struct BootstrapConfigBuilder {
@@ -488,10 +593,12 @@ impl BootstrapConfigBuilder {
 
     /// Sets the credentials offered to the xDS server, in preference order.
     ///
-    /// Replaces any previously set credentials. Unset, the client connects to
-    /// the management server in plaintext, matching a bootstrap with no
-    /// `channel_creds`; pass [`ChannelCredentialType::Tls`] for a secured
-    /// server.
+    /// Replaces any previously set credentials. Calling this is required: gRFC
+    /// A27 asks for at least one type the client supports, and [`build`]
+    /// enforces it. Pass [`ChannelCredentialType::Tls`] for a secured server,
+    /// or [`ChannelCredentialType::Insecure`] to state plaintext explicitly.
+    ///
+    /// [`build`]: BootstrapConfigBuilder::build
     #[must_use]
     pub fn channel_creds(mut self, creds: impl IntoIterator<Item = ChannelCredentialType>) -> Self {
         self.channel_creds = creds
@@ -604,11 +711,15 @@ impl BootstrapConfigBuilder {
     /// # Errors
     ///
     /// - [`BootstrapError::Serialization`] if a metadata or certificate
-    ///   provider value could not be serialized to JSON; the first failing
-    ///   setter wins.
-    /// - [`BootstrapError::Validation`] if the server URI is empty — the same
-    ///   validation configs parsed from JSON go through — or if the
-    ///   credentials include [`ChannelCredentialType::Unsupported`].
+    ///   provider value failed to serialize to JSON; the first failing setter
+    ///   wins.
+    /// - [`BootstrapError::Validation`] if the credentials include
+    ///   [`ChannelCredentialType::Unsupported`], or if the config fails the
+    ///   same validation JSON-parsed configs go through: an empty server URI,
+    ///   no supported [`channel_creds`], or a URI scheme that disagrees with
+    ///   the selected credential.
+    ///
+    /// [`channel_creds`]: BootstrapConfigBuilder::channel_creds
     pub fn build(self) -> Result<BootstrapConfig, BootstrapError> {
         if let Some(error) = self.error {
             return Err(error);
@@ -630,7 +741,7 @@ impl BootstrapConfigBuilder {
             xds_servers: vec![XdsServerConfig {
                 server_uri: self.server_uri,
                 channel_creds: self.channel_creds,
-                // The client acts on no server feature yet, so the builder
+                // Server feature negotiation is still to come, so the builder
                 // omits a setter.
                 server_features: Vec::new(),
             }],
@@ -685,7 +796,10 @@ mod tests {
 
     fn minimal_json() -> &'static str {
         r#"{
-            "xds_servers": [{"server_uri": "xds.example.com:443"}],
+            "xds_servers": [{
+                "server_uri": "xds.example.com:443",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "node": {"id": "test-node"}
         }"#
     }
@@ -791,7 +905,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_credential_none_supported() {
+    fn unknown_only_channel_creds_fail() {
         let json = r#"{
             "xds_servers": [{
                 "server_uri": "localhost:5000",
@@ -799,18 +913,129 @@ mod tests {
             }],
             "node": {"id": "n1"}
         }"#;
-        let config = BootstrapConfig::from_json(json).unwrap();
-        assert!(matches!(
-            config.xds_servers[0].channel_creds[0].cred_type,
-            ChannelCredentialType::Unsupported(_)
-        ));
-        assert_eq!(config.selected_credential(), None);
+        // gRFC A27 requires a type the client supports; an unknown-only list
+        // otherwise falls through to a plaintext control-plane connection.
+        let err = BootstrapConfig::from_json(json).unwrap_err();
+        assert!(matches!(err, BootstrapError::Validation(_)));
+        assert!(
+            err.to_string()
+                .contains("channel_creds must list at least one")
+        );
+        assert!(err.to_string().contains("some_future_type"));
     }
 
     #[test]
-    fn selected_credential_empty_creds() {
-        let config = BootstrapConfig::from_json(minimal_json()).unwrap();
-        assert_eq!(config.selected_credential(), None);
+    fn missing_channel_creds_fail() {
+        let json = r#"{
+            "xds_servers": [{"server_uri": "xds.example.com:443"}],
+            "node": {"id": "n1"}
+        }"#;
+        let err = BootstrapConfig::from_json(json).unwrap_err();
+        assert!(err.to_string().contains("is missing or empty"));
+    }
+
+    #[test]
+    fn empty_channel_creds_fail() {
+        let json = r#"{
+            "xds_servers": [{"server_uri": "localhost:5000", "channel_creds": []}],
+            "node": {"id": "n1"}
+        }"#;
+        let err = BootstrapConfig::from_json(json).unwrap_err();
+        assert!(err.to_string().contains("is missing or empty"));
+    }
+
+    #[test]
+    fn a_uri_that_cannot_carry_tls_with_tls_creds_fails() {
+        // The transport upgrades the scheme-less form alone and handshakes for
+        // `https` alone, so each of these connects in the clear while `use_tls`
+        // reports a secure channel.
+        for uri in [
+            "http://xds.example.com:443",
+            // Parses, and tonic treats an unrecognised scheme as plaintext.
+            "foo://xds.example.com:443",
+            "dns://xds.example.com:443",
+            // Fails `http::Uri`; the transport routes it to a plaintext connector.
+            "unix:///etc/istio/proxy/XDS",
+            "unix:/etc/istio/proxy/XDS",
+        ] {
+            for cred in ["tls", "google_default"] {
+                let json = format!(
+                    r#"{{
+                        "xds_servers": [{{
+                            "server_uri": "{uri}",
+                            "channel_creds": [{{"type": "{cred}"}}]
+                        }}]
+                    }}"#
+                );
+                let err = BootstrapConfig::from_json(&json)
+                    .expect_err(&format!("{uri} with {cred} should be rejected"));
+                assert!(err.to_string().contains("connects in plaintext"), "{uri}");
+                assert!(err.to_string().contains(cred), "{uri}");
+            }
+        }
+    }
+
+    #[test]
+    fn tls_uri_with_insecure_creds_fails() {
+        let json = r#"{
+            "xds_servers": [{
+                "server_uri": "https://xds.example.com:443",
+                "channel_creds": [{"type": "insecure"}]
+            }]
+        }"#;
+        let err = BootstrapConfig::from_json(json).unwrap_err();
+        assert!(err.to_string().contains("requires TLS but channel_creds"));
+    }
+
+    #[test]
+    fn explicit_schemes_matching_their_creds_are_accepted() {
+        for (uri, cred, tls) in [
+            ("https://xds.example.com:443", "tls", true),
+            ("http://localhost:18000", "insecure", false),
+            // No scheme: the transport picks one from the credential.
+            ("xds.example.com:443", "google_default", true),
+            // Fails `http::Uri`; the transport routes it to its UDS connector.
+            ("unix:///etc/istio/proxy/XDS", "insecure", false),
+            // An unrecognised scheme stays plaintext, which `insecure` agrees with.
+            ("dns://xds.example.com:443", "insecure", false),
+        ] {
+            let json = format!(
+                r#"{{"xds_servers": [{{"server_uri": "{uri}", "channel_creds": [{{"type": "{cred}"}}]}}]}}"#
+            );
+            let config = BootstrapConfig::from_json(&json)
+                .unwrap_or_else(|e| panic!("{uri} with {cred} should parse: {e}"));
+            assert_eq!(config.use_tls(), tls, "{uri} with {cred}");
+        }
+    }
+
+    #[test]
+    fn a_later_server_is_validated_too() {
+        let json = r#"{
+            "xds_servers": [
+                {"server_uri": "primary:443", "channel_creds": [{"type": "tls"}]},
+                {"server_uri": "fallback:443"}
+            ]
+        }"#;
+        let err = BootstrapConfig::from_json(json).unwrap_err();
+        assert!(err.to_string().contains("xds_servers[1].channel_creds"));
+    }
+
+    #[test]
+    fn builder_rejects_a_plaintext_uri_with_tls_creds() {
+        let err = BootstrapConfig::builder("http://xds.example.com:443")
+            .channel_creds([ChannelCredentialType::Tls])
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("connects in plaintext"));
+    }
+
+    #[test]
+    fn builder_requires_channel_creds() {
+        let err = BootstrapConfig::builder("xds.example.com:443")
+            .node_id("n1")
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("is missing or empty"));
     }
 
     #[test]
@@ -843,7 +1068,10 @@ mod tests {
     #[test]
     fn node_without_id() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}]
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }]
         }"#;
         let config = BootstrapConfig::from_json(json).unwrap();
         let node = Node::try_from(config.node).unwrap();
@@ -855,7 +1083,7 @@ mod tests {
         let json = r#"{
             "xds_servers": [
                 {"server_uri": "primary:443", "channel_creds": [{"type": "tls"}]},
-                {"server_uri": "fallback:443"}
+                {"server_uri": "fallback:443", "channel_creds": [{"type": "tls"}]}
             ],
             "node": {"id": "node-1"}
         }"#;
@@ -868,7 +1096,7 @@ mod tests {
 
     #[test]
     fn public_accessors_report_absent_optional_fields() {
-        let json = r#"{"xds_servers": [{"server_uri": "localhost:5000"}]}"#;
+        let json = r#"{"xds_servers": [{"server_uri": "localhost:5000", "channel_creds": [{"type": "insecure"}]}]}"#;
         let config = BootstrapConfig::from_json(json).unwrap();
 
         assert_eq!(config.node_id(), "");
@@ -877,10 +1105,13 @@ mod tests {
 
     #[test]
     fn equal_configs_compare_equal_regardless_of_json_formatting() {
-        let compact = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node":{"id":"n1"}}"#;
+        let compact = r#"{"xds_servers":[{"server_uri":"xds:443","channel_creds":[{"type":"insecure"}]}],"node":{"id":"n1"}}"#;
         let spaced = r#"{
             "node": {"id": "n1"},
-            "xds_servers": [{"server_uri": "xds:443"}]
+            "xds_servers": [{
+                "server_uri": "xds:443",
+                "channel_creds": [{"type": "insecure"}]
+            }]
         }"#;
 
         assert_eq!(
@@ -891,12 +1122,16 @@ mod tests {
 
     #[test]
     fn misplaced_keys_are_dropped_and_compare_unequal() {
-        let intended = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node":{"id":"n1"}}"#;
-        let misplaced = r#"{"xds_servers":[{"server_uri":"xds:443"}],"node_id":"n1"}"#;
+        let creds = r#""channel_creds":[{"type":"insecure"}]"#;
+        let intended = format!(
+            r#"{{"xds_servers":[{{"server_uri":"xds:443",{creds}}}],"node":{{"id":"n1"}}}}"#
+        );
+        let misplaced =
+            format!(r#"{{"xds_servers":[{{"server_uri":"xds:443",{creds}}}],"node_id":"n1"}}"#);
 
-        let misparsed = BootstrapConfig::from_json(misplaced).unwrap();
+        let misparsed = BootstrapConfig::from_json(&misplaced).unwrap();
         assert_eq!(misparsed.node_id(), "");
-        assert_ne!(BootstrapConfig::from_json(intended).unwrap(), misparsed);
+        assert_ne!(BootstrapConfig::from_json(&intended).unwrap(), misparsed);
     }
 
     #[test]
@@ -929,6 +1164,7 @@ mod tests {
     #[test]
     fn builder_defaults_omit_optional_fields() {
         let built = BootstrapConfig::builder("xds.example.com:443")
+            .channel_creds([ChannelCredentialType::Insecure])
             .node_id("test-node")
             .build()
             .unwrap();
@@ -940,6 +1176,7 @@ mod tests {
     #[test]
     fn builder_carries_metadata_and_cert_providers() {
         let built = BootstrapConfig::builder("localhost:5000")
+            .channel_creds([ChannelCredentialType::Insecure])
             .node_metadata("GENERATOR", "grpc")
             .certificate_provider(
                 "google_cloud_private_spiffe",
@@ -951,7 +1188,10 @@ mod tests {
 
         let equivalent = BootstrapConfig::from_json(
             r#"{
-                "xds_servers": [{"server_uri": "localhost:5000"}],
+                "xds_servers": [{
+                    "server_uri": "localhost:5000",
+                    "channel_creds": [{"type": "insecure"}]
+                }],
                 "node": {"metadata": {"GENERATOR": "grpc"}},
                 "certificate_providers": {
                     "google_cloud_private_spiffe": {
@@ -1051,7 +1291,7 @@ mod tests {
         assert!(err.to_string().contains("xds_servers must not be empty"));
 
         let ok = serde_json::from_str::<BootstrapConfig>(
-            r#"{"xds_servers": [{"server_uri": "xds:443"}]}"#,
+            r#"{"xds_servers": [{"server_uri": "xds:443", "channel_creds": [{"type": "tls"}]}]}"#,
         )
         .unwrap();
         assert_eq!(ok.server_uri(), "xds:443");
@@ -1074,7 +1314,10 @@ mod tests {
     #[test]
     fn parse_node_metadata() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "node": {
                 "id": "n1",
                 "metadata": {
@@ -1097,7 +1340,10 @@ mod tests {
     #[test]
     fn node_from_config_propagates_metadata() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "node": {
                 "id": "n1",
                 "metadata": {"GENERATOR": "grpc"}
@@ -1115,7 +1361,10 @@ mod tests {
     fn parse_istio_style_metadata() {
         // Real-world Istio bootstrap shape: nested objects, numbers, arrays.
         let json = r#"{
-            "xds_servers": [{"server_uri": "unix:///etc/istio/proxy/XDS"}],
+            "xds_servers": [{
+                "server_uri": "unix:///etc/istio/proxy/XDS",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "node": {
                 "id": "sidecar~10.0.0.1~pod.ns~ns.svc.cluster.local",
                 "metadata": {
@@ -1175,7 +1424,10 @@ mod tests {
     #[test]
     fn parse_certificate_providers() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "certificate_providers": {
                 "google_cloud_private_spiffe": {
                     "plugin_name": "file_watcher",
@@ -1234,7 +1486,10 @@ mod tests {
     #[test]
     fn multiple_certificate_provider_instances() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "certificate_providers": {
                 "identity": {
                     "plugin_name": "file_watcher",

--- a/tonic-xds/src/xds/bootstrap.rs
+++ b/tonic-xds/src/xds/bootstrap.rs
@@ -495,17 +495,17 @@ impl BootstrapConfig {
 
     /// Select the first supported channel credential type from the first server's config.
     ///
-    /// [`validate`](Self::validate) guarantees one exists, so a validated
-    /// config always returns `Some`.
+    /// Validation guarantees one exists, so a validated config always returns
+    /// `Some`.
     pub(crate) fn selected_credential(&self) -> Option<&ChannelCredentialType> {
         self.xds_servers.first()?.selected_credential()
     }
 
     /// Returns `true` if the connection to the xDS server uses TLS.
     ///
-    /// [`validate`](Self::validate) requires the `server_uri` scheme to agree
-    /// with the selected credential, so a `true` here means the transport
-    /// really does handshake.
+    /// Every constructor requires the `server_uri` scheme to agree with the
+    /// selected credential, so a `true` here means the transport really does
+    /// handshake.
     pub fn use_tls(&self) -> bool {
         self.selected_credential()
             .is_some_and(ChannelCredentialType::is_tls)

--- a/tonic-xds/src/xds/cert_provider/mod.rs
+++ b/tonic-xds/src/xds/cert_provider/mod.rs
@@ -281,7 +281,10 @@ mod tests {
     #[test]
     fn unknown_plugin_rejected_at_registry_build() {
         let json = r#"{
-            "xds_servers": [{"server_uri": "localhost:5000"}],
+            "xds_servers": [{
+                "server_uri": "localhost:5000",
+                "channel_creds": [{"type": "insecure"}]
+            }],
             "certificate_providers": {
                 "test": {
                     "plugin_name": "unknown_plugin",

--- a/xds-client-opentelemetry/Cargo.toml
+++ b/xds-client-opentelemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xds-client-opentelemetry"
 description = "OpenTelemetry metrics recorder for xds-client (gRFC A78 XdsClient metrics)"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 homepage = "https://github.com/grpc/grpc-rust"
 repository = "https://github.com/grpc/grpc-rust"
@@ -13,7 +13,7 @@ publish = true
 workspace = true
 
 [dependencies]
-xds-client = { version = "0.1.0-alpha.2", path = "../xds-client" }
+xds-client = { version = "0.1.0-alpha.3", path = "../xds-client" }
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
 
 [dev-dependencies]

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xds-client"
 description = "An xDS client implementation in Rust"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 homepage = "https://github.com/hyperium/tonic"
 repository = "https://github.com/hyperium/tonic"

--- a/xds-client/src/transport/tonic.rs
+++ b/xds-client/src/transport/tonic.rs
@@ -308,14 +308,36 @@ impl TransportBuilder for TonicTransportBuilder {
     type Transport = TonicTransport;
 
     async fn build(&self, server: &ServerConfig) -> Result<Self::Transport> {
-        // The channel is secure only when TLS is configured; with no TLS backend
-        // compiled in, it can never be secure.
+        // With no TLS backend compiled in, `tls_configured` stays false.
         #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
-        let secure = self.tls_config.is_some();
+        let tls_configured = self.tls_config.is_some();
         #[cfg(not(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc")))]
-        let secure = false;
+        let tls_configured = false;
 
-        // Refuse before connecting: never send credentials over an insecure channel.
+        let uri = Self::ensure_secure_server_uri(server.uri(), tls_configured);
+
+        // tonic handshakes for an `https` URI alone, so the scheme decides
+        // whether the channel is encrypted.
+        let secure = uri
+            .parse::<http::Uri>()
+            .is_ok_and(|uri| uri.scheme_str() == Some("https"));
+
+        // Require the scheme and the TLS config to agree, so the caller gets
+        // the channel they asked for. `ensure_secure_server_uri` has already
+        // upgraded the scheme-less form, leaving only real conflicts here.
+        if tls_configured && !secure {
+            return Err(Error::Connection(format!(
+                "TLS is configured but server URI '{uri}' connects in plaintext; \
+                 use an `https://` or scheme-less URI"
+            )));
+        }
+        if secure && !tls_configured {
+            return Err(Error::Connection(format!(
+                "server URI '{uri}' requires TLS but no TLS config is set"
+            )));
+        }
+
+        // Fail before connecting, so credentials stay off an insecure channel.
         if let Some(creds) = &self.call_creds
             && creds.requires_secure_transport()
             && !secure
@@ -327,8 +349,7 @@ impl TransportBuilder for TonicTransportBuilder {
 
         // `Endpoint::from_shared` routes `unix://` URIs to tonic's UDS connector.
         // Required for control planes like Istio's grpc-agent that ship `unix:///etc/istio/proxy/XDS`.
-        let endpoint = Endpoint::from_shared(Self::ensure_secure_server_uri(server.uri(), secure))
-            .map_err(|e| Error::Connection(e.to_string()))?;
+        let endpoint = Endpoint::from_shared(uri).map_err(|e| Error::Connection(e.to_string()))?;
 
         let mut endpoint = endpoint.connect_timeout(self.connect_timeout);
         if let Some(interval) = self.keep_alive_interval {
@@ -598,6 +619,42 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, Error::CallCredentials(_)));
+    }
+
+    #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
+    #[tokio::test]
+    async fn tls_config_and_plaintext_uri_are_rejected() {
+        // A URI that keeps a non-`https` scheme stays plaintext despite the TLS
+        // config, so the build fails and the call credentials below stay put.
+        for uri in [
+            "http://127.0.0.1:1",
+            "unix:///etc/istio/proxy/XDS",
+            "foo://127.0.0.1:1",
+        ] {
+            let err = TonicTransportBuilder::new()
+                .with_tls_config(tonic::transport::ClientTlsConfig::new())
+                .with_call_credentials(Arc::new(MockCreds {
+                    pairs: vec![],
+                    requires_secure: true,
+                }))
+                .build(&ServerConfig::new(uri))
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("connects in plaintext"), "{uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn tls_uri_without_a_tls_config_is_rejected() {
+        // Without a TLS backend tonic connects to this in the clear.
+        let err = TonicTransportBuilder::new()
+            .build(&ServerConfig::new("https://127.0.0.1:1"))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("requires TLS but no TLS config is set")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Releasing alpha.3 to include the recent custom transport API additions, in order to test in other crates.

## Solution

One gap identified while assessing the API production readiness: currently the only way to construct a bootstrap config to instantiate an xDS channel from is to go through a A27-formatted JSON string. This is more error prone than a typed builder, which is now introduced in this PR. We acknowledge that other gRPC implementations such as grpc-go explicitly marked its typed config builder as test only / experimental in anticipation of needing to change the config shapes, so here we marked relevant enums and fields as `#[non_exhaustive]` and guarded them with checks to ensure forward compatibility.