### PR TITLE
grpc: implement Display and Error for StatusError

### DIFF
--- a/grpc/src/status.rs
+++ b/grpc/src/status.rs
@@ -78,6 +78,18 @@ impl StatusError {
     }
 }
 
+impl std::fmt::Display for StatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.message.is_empty() {
+            write!(f, "{:?}", self.code)
+        } else {
+            write!(f, "{:?}: {}", self.code, self.message)
+        }
+    }
+}
+
+impl std::error::Error for StatusError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,5 +108,14 @@ mod tests {
         assert!(debug.contains("Status"));
         assert!(debug.contains("Cancelled"));
         assert!(debug.contains("not ok"));
+    }
+
+    #[test]
+    fn test_status_display() {
+        let status = StatusError::new(StatusCodeError::NotFound, "not ok");
+        assert_eq!(format!("{status}"), "NotFound: not ok");
+
+        let status = StatusError::new(StatusCodeError::Cancelled, "");
+        assert_eq!(format!("{status}"), "Cancelled");
     }
 }


### PR DESCRIPTION
Since 4d8f56b9b we now expect to put StatusError in Result long-term, so we should follow standard practice and implement Error.