### PR TITLE
Add dead-code ignore annotation to codegen.

### DIFF
--- a/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
+++ b/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
@@ -392,11 +392,9 @@ static void GenerateClient(const Service &service, Printer &printer,
       /// Generated client implementations.
       pub mod $client_mod$ {
           #![allow(
-              unused_variables,
               dead_code,
               missing_docs,
               clippy::wildcard_imports,
-              unused_imports,
           )]
           use grpc::client::*;
           use grpc_protobuf::*;

--- a/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
+++ b/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
@@ -391,6 +391,13 @@ static void GenerateClient(const Service &service, Printer &printer,
       R"rs(
       /// Generated client implementations.
       pub mod $client_mod$ {
+          #![allow(
+              unused_variables,
+              dead_code,
+              missing_docs,
+              clippy::wildcard_imports,
+              unused_imports,
+          )]
           use grpc::client::*;
           use grpc_protobuf::*;
 


### PR DESCRIPTION
## Motivation

When building a client with `grpc-rust` and a server with `tonic`, the un-ignored client code generates a warning:  `unused import: grpc::client::*`.

This is because Tonic's build process deals with these warnings later, but `grpc-rust` build process has not put anything in place for that yet. 

## Solution

Add the same annotations to the generated client code that exists on the generated server code (see lines 713-720 in the same file), during code generation.  We may want to revisit this later, but this is the most straightforward solution for the moment. 