### PR TITLE
fix(ci): exclude grpc crates from automated releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -54,6 +54,19 @@ release = false
 name = "xds-client-opentelemetry"
 release = false
 
-# grpc group (single crate)
-#[[package]]
-#name = "grpc"
+# grpc crates: published manually for now
+[[package]]
+name = "grpc"
+release = false
+
+[[package]]
+name = "grpc-protobuf"
+release = false
+
+[[package]]
+name = "grpc-protobuf-build"
+release = false
+
+[[package]]
+name = "protoc-gen-rust-grpc"
+release = false


### PR DESCRIPTION
## Motivation

The tonic release PR currently includes the publishable gRPC crates because release-plz manages publishable workspace members by default. These crates need to remain manually publishable without being included in automated tonic releases.

## Solution

Configure `grpc`, `grpc-protobuf`, `grpc-protobuf-build`, and `protoc-gen-rust-grpc` with `release = false`. This disables release-plz processing while preserving Cargo's default manual publishing behavior.

## Test plan

- [x] Run `git diff --check`
- [x] Verify every publishable gRPC-family crate has an explicit release-plz exclusion
- [ ] Confirm the next release-plz refresh removes the gRPC crates from the release PR

Made with [Cursor](https://cursor.com)