### PR TITLE
fix(client): validate response content-type

### DIFF
--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -309,15 +309,9 @@ async fn status_from_server_stream_with_inferred_status() {
         .await
         .unwrap();
 
-    let error = client
-        .stream_call(InputStream {})
-        .await
-        .unwrap_err();
+    let error = client.stream_call(InputStream {}).await.unwrap_err();
 
-    assert_eq!(
-        error.code(),
-        Code::Unavailable
-    );
+    assert_eq!(error.code(), Code::Unavailable);
 }
 
 #[tokio::test]

--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -309,18 +309,15 @@ async fn status_from_server_stream_with_inferred_status() {
         .await
         .unwrap();
 
-    let mut stream = client
+    let error = client
         .stream_call(InputStream {})
         .await
-        .unwrap()
-        .into_inner();
+        .unwrap_err();
 
     assert_eq!(
-        stream.message().await.unwrap_err().code(),
+        error.code(),
         Code::Unavailable
     );
-
-    assert_eq!(stream.message().await.unwrap(), None);
 }
 
 #[tokio::test]

--- a/tests/integration_tests/tests/status.rs
+++ b/tests/integration_tests/tests/status.rs
@@ -471,3 +471,79 @@ async fn missing_grpc_status_trailer_is_unknown_error() {
         err.message()
     );
 }
+
+#[tokio::test]
+async fn trailers_only_response_without_content_type() {
+    integration_tests::trace_init();
+
+    struct Svc;
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+            Ok(Response::new(Output {}))
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestLayer;
+
+    impl<S> tower::Layer<S> for TestLayer {
+        type Service = TestService;
+
+        fn layer(&self, _: S) -> Self::Service {
+            TestService
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestService;
+
+    impl tower::Service<http::Request<Body>> for TestService {
+        type Response = http::Response<Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: http::Request<Body>) -> Self::Future {
+            Box::pin(async {
+                // A Trailers-Only response: grpc-status in headers, no content-type header.
+                Ok(http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .header("grpc-status", "3")
+                    .header("grpc-message", "custom trailers-only error")
+                    .body(Body::empty())
+                    .unwrap())
+            })
+        }
+    }
+
+    let svc = test_server::TestServer::new(Svc);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .layer(TestLayer)
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut client = test_client::TestClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let error = client.unary_call(Input {}).await.unwrap_err();
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert_eq!(error.message(), "custom trailers-only error");
+}

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -363,31 +363,6 @@ impl<T> Grpc<T> {
         )?;
 
         let status_code = response.status();
-
-        let is_valid_content_type = response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .map(|val| val.as_bytes().starts_with(b"application/grpc"))
-            .unwrap_or(false);
-
-        if !is_valid_content_type {
-            let error_msg = format!(
-                "invalid content-type: {:?} (expected application/grpc)",
-                response
-                    .headers()
-                    .get(http::header::CONTENT_TYPE)
-                    .map(|v| v.to_str().unwrap_or("<invalid utf-8>"))
-                    .unwrap_or("<missing>")
-            );
-
-            if let Err(Some(status)) = crate::status::infer_grpc_status(None, status_code) {
-                // Return the mapped status code but with the custom error message.
-                return Err(Status::new(status.code(), error_msg));
-            } else {
-                return Err(Status::unknown(error_msg));
-            }
-        }
-
         let trailers_only_status = Status::from_header_map(response.headers());
 
         // We do not need to check for trailers if the `grpc-status` header is present
@@ -399,6 +374,28 @@ impl<T> Grpc<T> {
 
             false
         } else {
+            // When a gRPC server returns an immediate error via a Trailers-Only response,
+            // the server often omits content-type since there is no body payload.
+            // If no grpc-status header is present, ensure the content-type is valid
+            // before attempting to decode the stream.
+            if !is_grpc_content_type(response.headers()) {
+                let error_msg = format!(
+                    "invalid content-type: {:?} (expected application/grpc)",
+                    response
+                        .headers()
+                        .get(CONTENT_TYPE)
+                        .map(|v| v.to_str().unwrap_or("<invalid utf-8>"))
+                        .unwrap_or("<missing>")
+                );
+
+                if let Err(Some(status)) = crate::status::infer_grpc_status(None, status_code) {
+                    // Return the mapped status code but with the custom error message.
+                    return Err(Status::new(status.code(), error_msg));
+                } else {
+                    return Err(Status::unknown(error_msg));
+                }
+            }
+
             true
         };
 
@@ -515,5 +512,81 @@ impl<T: fmt::Debug> fmt::Debug for Grpc<T> {
                 &self.config.max_encoding_message_size,
             )
             .finish()
+    }
+}
+
+fn is_grpc_content_type(headers: &http::HeaderMap) -> bool {
+    if let Some(val) = headers.get(CONTENT_TYPE) {
+        let bytes = val.as_bytes();
+        if bytes.len() >= 16 && bytes[..16].eq_ignore_ascii_case(b"application/grpc") {
+            return bytes.len() == 16 || matches!(bytes[16], b'+' | b';' | b'-' | b' ' | b'\t');
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::header::CONTENT_TYPE;
+    use http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn test_is_grpc_content_type() {
+        let mut headers = HeaderMap::new();
+
+        assert!(!is_grpc_content_type(&headers));
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("Application/grpc"));
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("APPLICATION/GRPC"));
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpc+proto"),
+        );
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpc+json"),
+        );
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpc; charset=utf-8"),
+        );
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpc-web"),
+        );
+        assert!(is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpc-web+proto"),
+        );
+        assert!(is_grpc_content_type(&headers));
+
+        // Invalid content types
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/html"));
+        assert!(!is_grpc_content_type(&headers));
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        assert!(!is_grpc_content_type(&headers));
+
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/grpcextra"),
+        );
+        assert!(!is_grpc_content_type(&headers));
     }
 }

--- a/tonic/src/client/grpc.rs
+++ b/tonic/src/client/grpc.rs
@@ -363,6 +363,31 @@ impl<T> Grpc<T> {
         )?;
 
         let status_code = response.status();
+
+        let is_valid_content_type = response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .map(|val| val.as_bytes().starts_with(b"application/grpc"))
+            .unwrap_or(false);
+
+        if !is_valid_content_type {
+            let error_msg = format!(
+                "invalid content-type: {:?} (expected application/grpc)",
+                response
+                    .headers()
+                    .get(http::header::CONTENT_TYPE)
+                    .map(|v| v.to_str().unwrap_or("<invalid utf-8>"))
+                    .unwrap_or("<missing>")
+            );
+
+            if let Err(Some(status)) = crate::status::infer_grpc_status(None, status_code) {
+                // Return the mapped status code but with the custom error message.
+                return Err(Status::new(status.code(), error_msg));
+            } else {
+                return Err(Status::unknown(error_msg));
+            }
+        }
+
         let trailers_only_status = Status::from_header_map(response.headers());
 
         // We do not need to check for trailers if the `grpc-status` header is present


### PR DESCRIPTION


Fixes #2365.

Currently, if the gRPC client receives a response with an incorrect `Content-Type` (for instance, `text/html` from a proxy like Envoy returning a `502 Bad Gateway`), it ignores the content type and proceeds to attempt decoding the HTML body as if it were a valid gRPC binary stream. This leads to confusing stream parsing errors, such as `invalid compression flag: 60 ... while receiving response with status: 502 Bad Gateway`.

According to the gRPC specification: "If the Content-Type does not begin with `application/grpc`, the client SHOULD NOT assume that the body contains gRPC messages, and MUST fail the RPC with a status of UNKNOWN (or the equivalent status code translated from the HTTP status code, if one is present)."

## Solution

This PR adds a `Content-Type` validation step in `tonic/src/client/grpc.rs` during the initial `create_response` call. 

We now check if the `Content-Type` header starts with `application/grpc` (which also properly accommodates `application/grpc-web` and `application/grpc+proto`). If it is missing or invalid, we immediately return an error. If there is a recognizable HTTP error code (e.g., `502`), we utilize `crate::status::infer_grpc_status` to convert it to the appropriate gRPC status, but with a clear, custom error message stating that the `Content-Type` was invalid.
