### PR TITLE
xds-client: reset backoff only after first response

### DIFF
--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -772,7 +772,7 @@ where
     async fn run_connected<S: TransportStream>(
         &mut self,
         mut stream: S,
-        &mut healthy: bool,
+        healthy: &mut bool,
     ) -> ConnectedOutcome {
         // Whether at least one response was received on this stream. Per gRFC
         // A78 a stream that fails *after* receiving a response is not counted as
@@ -792,9 +792,9 @@ where
                     match result {
                         Ok(Some(bytes)) => {
                             if !saw_response {
-                                if !healthy {
-                                    worker.recorder.record_connected(true);
-                                    healthy = true;
+                                if !*healthy {
+                                    self.recorder.record_connected(true);
+                                    *healthy = true;
                                 }
                                 saw_response = true;
                             }

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -697,7 +697,12 @@ where
                 }
             };
 
-            match self.run_connected(stream, &mut healthy).await {
+            if !healthy {
+                self.recorder.record_connected(true);
+                healthy = true;
+            }
+
+            match self.run_connected(stream).await {
                 ConnectedOutcome::Shutdown => return,
                 ConnectedOutcome::Failed { saw_response } => {
                     // gRFC A78: a server goes unhealthy (one `server_failure`) on
@@ -769,11 +774,7 @@ where
     /// (command channel closed), or [`ConnectedOutcome::Failed`] if the stream
     /// failed and the worker should reconnect (carrying whether a response was
     /// seen, per gRFC A78).
-    async fn run_connected<S: TransportStream>(
-        &mut self,
-        mut stream: S,
-        healthy: &mut bool,
-    ) -> ConnectedOutcome {
+    async fn run_connected<S: TransportStream>(&mut self, mut stream: S) -> ConnectedOutcome {
         // Whether at least one response was received on this stream. Per gRFC
         // A78 a stream that fails *after* receiving a response is not counted as
         // a server failure.
@@ -791,13 +792,7 @@ where
                 result = stream.recv(), if pending.is_none() => {
                     match result {
                         Ok(Some(bytes)) => {
-                            if !saw_response {
-                                if !*healthy {
-                                    self.recorder.record_connected(true);
-                                    *healthy = true;
-                                }
-                                saw_response = true;
-                            }
+                            saw_response = true;
                             match self.handle_response(&mut stream, bytes).await {
                                 Ok(dispatch) => pending = dispatch,
                                 Err(_) => return ConnectedOutcome::Failed { saw_response },

--- a/xds-client/src/client/worker.rs
+++ b/xds-client/src/client/worker.rs
@@ -686,10 +686,7 @@ where
             };
 
             let stream = match transport.new_stream(self.build_initial_requests()).await {
-                Ok(s) => {
-                    self.backoff.reset();
-                    s
-                }
+                Ok(s) => s,
                 Err(_) => {
                     self.record_unhealthy(&mut healthy);
                     match self.backoff.next_backoff() {
@@ -700,19 +697,16 @@ where
                 }
             };
 
-            if !healthy {
-                self.recorder.record_connected(true);
-                healthy = true;
-            }
-
-            match self.run_connected(stream).await {
+            match self.run_connected(stream, &mut healthy).await {
                 ConnectedOutcome::Shutdown => return,
                 ConnectedOutcome::Failed { saw_response } => {
                     // gRFC A78: a server goes unhealthy (one `server_failure`) on
                     // a connectivity failure or when the ADS stream fails
                     // *without* seeing a response message. A stream that failed
                     // after receiving a response is not counted; just reconnect.
-                    if !saw_response {
+                    if saw_response {
+                        self.backoff.reset();
+                    } else {
                         self.record_unhealthy(&mut healthy);
                     }
                     match self.backoff.next_backoff() {
@@ -775,7 +769,11 @@ where
     /// (command channel closed), or [`ConnectedOutcome::Failed`] if the stream
     /// failed and the worker should reconnect (carrying whether a response was
     /// seen, per gRFC A78).
-    async fn run_connected<S: TransportStream>(&mut self, mut stream: S) -> ConnectedOutcome {
+    async fn run_connected<S: TransportStream>(
+        &mut self,
+        mut stream: S,
+        &mut healthy: bool,
+    ) -> ConnectedOutcome {
         // Whether at least one response was received on this stream. Per gRFC
         // A78 a stream that fails *after* receiving a response is not counted as
         // a server failure.
@@ -793,7 +791,13 @@ where
                 result = stream.recv(), if pending.is_none() => {
                     match result {
                         Ok(Some(bytes)) => {
-                            saw_response = true;
+                            if !saw_response {
+                                if !healthy {
+                                    worker.recorder.record_connected(true);
+                                    healthy = true;
+                                }
+                                saw_response = true;
+                            }
                             match self.handle_response(&mut stream, bytes).await {
                                 Ok(dispatch) => pending = dispatch,
                                 Err(_) => return ConnectedOutcome::Failed { saw_response },


### PR DESCRIPTION
Per gRFC A78, establishing an ADS stream is not sufficient to declare a connection working.