### PR TITLE
protoc-gen-rust-grpc: suppress unused_imports in generated client modules

### DIFF
--- a/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
+++ b/protoc-gen-rust-grpc/src/cpp_source/src/grpc_rust_generator.cc
@@ -392,6 +392,7 @@ static void GenerateClient(const Service &service, Printer &printer,
       /// Generated client implementations.
       pub mod $client_mod$ {
           #![allow(
+              unused_imports,
               dead_code,
               missing_docs,
               clippy::wildcard_imports,


### PR DESCRIPTION
## Motivation

The generated client module (`pub mod <service>_client`) imports client helper types via wildcard statements:
```rust
use grpc::client::*;
use grpc_protobuf::*;
use grpc_protobuf::client::*;
```

When a protobuf service defines only unary RPCs (or a subset of streaming RPC patterns), types brought into scope by these wildcards for unused streaming patterns are not referenced. As a result, `rustc` emits `unused_imports` compiler warnings when consumers build the generated stubs.

## Solution

Add `unused_imports` to the `#![allow(...)]` attribute list inside `pub mod $client_mod$` in `grpc_rust_generator.cc`, ensuring generated client modules compile without warnings regardless of which RPC patterns the service implements.