### PR TITLE
grpc/service_config: make LB config parsing produce non-optional value

### DIFF
--- a/grpc/src/client/service_config/mod.rs
+++ b/grpc/src/client/service_config/mod.rs
@@ -57,7 +57,7 @@ impl ServiceConfig {
     // Chooses load balancing configuration per gRPC specification rules.
     pub(crate) fn lb_config(&self) -> (Arc<DynLbPolicyBuilder>, Option<DynLbConfig>) {
         // Choose LbConfig if present.
-        if let Some(selected) = self.inner.load_balancing_config.as_ref() {
+        if let Some(selected) = self.inner.load_balancing_config.lb_config.as_ref() {
             return (selected.builder.clone(), selected.config.clone());
         }
 
@@ -235,7 +235,7 @@ mod test {
             sc.inner.load_balancing_policy,
             Some("round_robin".to_string())
         );
-        assert!(sc.inner.load_balancing_config.is_none());
+        assert!(sc.inner.load_balancing_config.lb_config.is_none());
     }
 
     #[test]

--- a/grpc/src/client/service_config/serde_bindings.rs
+++ b/grpc/src/client/service_config/serde_bindings.rs
@@ -26,6 +26,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::Deserialize;
+use serde::Deserializer;
+use serde_json::Value;
 
 use super::duration::GrpcDuration;
 use crate::client::load_balancing::DynLbConfig;
@@ -37,11 +39,31 @@ use crate::client::load_balancing::ParsedJsonLbConfig;
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceConfigSerde {
     pub(crate) load_balancing_policy: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_load_balancing_config")]
     pub(crate) load_balancing_config: Option<LbConfigSerde>,
     pub(crate) method_config: Option<Vec<MethodConfigSerde>>,
     pub(crate) retry_throttling: Option<RetryThrottlingPolicySerde>,
     pub(crate) health_check_config: Option<HealthCheckConfigSerde>,
     pub(crate) connection_scaling: Option<ConnectionScalingSerde>,
+}
+
+/// treats an empty list as `None` to allow falling back to the deprecated
+/// `load_balancing_policy` value if present.
+fn deserialize_load_balancing_config<'de, D>(
+    deserializer: D,
+) -> Result<Option<LbConfigSerde>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<Value>::deserialize(deserializer)?;
+
+    match opt {
+        None => Ok(None),
+        Some(Value::Array(arr)) if arr.is_empty() => Ok(None),
+        Some(value) => LbConfigSerde::deserialize(value)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -402,11 +424,12 @@ mod test {
         }));
         assert!(res.is_err());
 
-        // Empty array -> Error
-        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
+        // Empty array -> collapses to None
+        let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": []
-        }));
-        assert!(res.is_err());
+        }))
+        .unwrap();
+        assert!(val.load_balancing_config.is_none());
 
         // Null or absent -> None
         let val: ServiceConfigSerde = serde_json::from_value(json!({

--- a/grpc/src/client/service_config/serde_bindings.rs
+++ b/grpc/src/client/service_config/serde_bindings.rs
@@ -37,8 +37,7 @@ use crate::client::load_balancing::ParsedJsonLbConfig;
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceConfigSerde {
     pub(crate) load_balancing_policy: Option<String>,
-    #[serde(default)]
-    pub(crate) load_balancing_config: LbConfigSerde,
+    pub(crate) load_balancing_config: Option<LbConfigSerde>,
     pub(crate) method_config: Option<Vec<MethodConfigSerde>>,
     pub(crate) retry_throttling: Option<RetryThrottlingPolicySerde>,
     pub(crate) health_check_config: Option<HealthCheckConfigSerde>,
@@ -89,26 +88,9 @@ fn default_max_connections_per_subchannel() -> SerdeU32 {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct LbInnerConfig {
+pub(crate) struct LbConfigSerde {
     pub(crate) builder: Arc<DynLbPolicyBuilder>,
     pub(crate) config: Option<DynLbConfig>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct LbConfigSerde(Option<LbInnerConfig>);
-
-impl LbConfigSerde {
-    pub(crate) fn as_ref(&self) -> Option<&LbInnerConfig> {
-        self.0.as_ref()
-    }
-
-    pub(crate) fn is_none(&self) -> bool {
-        self.0.is_none()
-    }
-
-    pub(crate) fn is_some(&self) -> bool {
-        self.0.is_some()
-    }
 }
 
 impl<'de> Deserialize<'de> for LbConfigSerde {
@@ -119,10 +101,6 @@ impl<'de> Deserialize<'de> for LbConfigSerde {
         let raw_entries =
             Option::<Vec<HashMap<String, serde_json::Value>>>::deserialize(deserializer)?
                 .unwrap_or_default();
-
-        if raw_entries.is_empty() {
-            return Ok(LbConfigSerde(None));
-        }
 
         for map in raw_entries {
             let mut iter = map.into_iter();
@@ -137,10 +115,10 @@ impl<'de> Deserialize<'de> for LbConfigSerde {
                 let parsed_config = builder
                     .parse_config(&parsed_json)
                     .map_err(serde::de::Error::custom)?;
-                return Ok(LbConfigSerde(Some(LbInnerConfig {
+                return Ok(LbConfigSerde {
                     builder,
                     config: parsed_config,
-                })));
+                });
             }
         }
 
@@ -381,24 +359,17 @@ mod test {
     fn test_load_balancing_config_serde() {
         use crate::client::load_balancing::pick_first::PickFirstConfig;
 
-        #[derive(Deserialize, Debug)]
-        #[serde(rename_all = "camelCase")]
-        struct TestConfig {
-            #[serde(default)]
-            load_balancing_config: LbConfigSerde,
-        }
-
         // Single supported policy without config (round_robin)
-        let val: TestConfig = serde_json::from_value(json!({
+        let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": [{ "round_robin": {} }]
         }))
         .unwrap();
-        let selected = val.load_balancing_config.as_ref().unwrap();
+        let selected = val.load_balancing_config.unwrap();
         assert_eq!(selected.builder.name(), "round_robin");
         assert!(selected.config.is_none());
 
         // Multiple policies; picks first supported with parsed config (pick_first)
-        let val: TestConfig = serde_json::from_value(json!({
+        let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": [
                 { "unsupported_lb_1": { "key": "val" } },
                 { "pick_first": { "shuffleAddressList": true } },
@@ -417,13 +388,13 @@ mod test {
         assert!(pf_cfg.shuffle_address_list);
 
         // Invalid config for supported policy fails deserialization
-        let res: Result<TestConfig, _> = serde_json::from_value(json!({
+        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
             "loadBalancingConfig": [{ "pick_first": { "shuffleAddressList": "not_a_bool" } }]
         }));
         assert!(res.is_err());
 
         // Non-empty array with no supported policies -> fails deserialization
-        let res: Result<TestConfig, _> = serde_json::from_value(json!({
+        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
             "loadBalancingConfig": [
                 { "unsupported_1": {} },
                 { "unsupported_2": {} }
@@ -431,25 +402,24 @@ mod test {
         }));
         assert!(res.is_err());
 
-        // Empty array -> collapses to None
-        let val: TestConfig = serde_json::from_value(json!({
+        // Empty array -> Error
+        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
             "loadBalancingConfig": []
-        }))
-        .unwrap();
-        assert!(val.load_balancing_config.is_none());
+        }));
+        assert!(res.is_err());
 
         // Null or absent -> None
-        let val: TestConfig = serde_json::from_value(json!({
+        let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": null
         }))
         .unwrap();
         assert!(val.load_balancing_config.is_none());
 
-        let val: TestConfig = serde_json::from_value(json!({})).unwrap();
+        let val: ServiceConfigSerde = serde_json::from_value(json!({})).unwrap();
         assert!(val.load_balancing_config.is_none());
 
         // Multiple policies; trailing entries after first supported are ignored
-        let val: TestConfig = serde_json::from_value(json!({
+        let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": [
                 { "pick_first": { "shuffleAddressList": true } },
                 { "unsupported": { "invalid": 123 }, "other": {} },
@@ -461,7 +431,7 @@ mod test {
         assert_eq!(selected.builder.name(), "pick_first");
 
         // Invalid entry with multiple keys in single object -> Error
-        let res: Result<TestConfig, _> = serde_json::from_value(json!({
+        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
             "loadBalancingConfig": [
                 { "round_robin": {}, "pick_first": {} }
             ]
@@ -469,7 +439,7 @@ mod test {
         assert!(res.is_err());
 
         // Invalid entry with empty object -> Error
-        let res: Result<TestConfig, _> = serde_json::from_value(json!({
+        let res: Result<ServiceConfigSerde, _> = serde_json::from_value(json!({
             "loadBalancingConfig": [{}]
         }));
         assert!(res.is_err());

--- a/grpc/src/client/service_config/serde_bindings.rs
+++ b/grpc/src/client/service_config/serde_bindings.rs
@@ -26,7 +26,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::Deserialize;
-use serde::Deserializer;
 use serde_json::Value;
 
 use super::duration::GrpcDuration;
@@ -38,31 +37,43 @@ use crate::client::load_balancing::ParsedJsonLbConfig;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceConfigSerde {
-    pub(crate) load_balancing_policy: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_load_balancing_config")]
-    pub(crate) load_balancing_config: Option<LbConfigSerde>,
-    pub(crate) method_config: Option<Vec<MethodConfigSerde>>,
-    pub(crate) retry_throttling: Option<RetryThrottlingPolicySerde>,
-    pub(crate) health_check_config: Option<HealthCheckConfigSerde>,
-    pub(crate) connection_scaling: Option<ConnectionScalingSerde>,
+    pub(super) load_balancing_policy: Option<String>,
+    pub(super) load_balancing_config: OptionalLoadBalancingConfig,
+    pub(super) method_config: Option<Vec<MethodConfigSerde>>,
+    pub(super) retry_throttling: Option<RetryThrottlingPolicySerde>,
+    pub(super) health_check_config: Option<HealthCheckConfigSerde>,
+    pub(super) connection_scaling: Option<ConnectionScalingSerde>,
 }
 
-/// treats an empty list as `None` to allow falling back to the deprecated
-/// `load_balancing_policy` value if present.
-fn deserialize_load_balancing_config<'de, D>(
-    deserializer: D,
-) -> Result<Option<LbConfigSerde>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let opt = Option::<Value>::deserialize(deserializer)?;
+/// An optional load balancing configuration parsed from a service config.
+///
+/// Wraps the deserialized [`LbConfigSerde`] for the `loadBalancingConfig` field.
+/// If the field is omitted, `null`, or an empty array (`[]`), `lb_config` will
+/// be `None`, allowing fallback to the deprecated `loadBalancingPolicy` field
+/// or the default policy.
+///
+/// When a non-empty list of policies is specified, deserialization selects the
+/// first supported policy found and parses its configuration.
+#[derive(Debug, Clone)]
+pub(super) struct OptionalLoadBalancingConfig {
+    pub(super) lb_config: Option<LbConfigSerde>,
+}
 
-    match opt {
-        None => Ok(None),
-        Some(Value::Array(arr)) if arr.is_empty() => Ok(None),
-        Some(value) => LbConfigSerde::deserialize(value)
-            .map(Some)
-            .map_err(serde::de::Error::custom),
+impl<'de> Deserialize<'de> for OptionalLoadBalancingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let opt = Option::<Value>::deserialize(deserializer)?;
+
+        let lb_config = match opt {
+            None => None,
+            Some(Value::Array(arr)) if arr.is_empty() => None,
+            Some(value) => LbConfigSerde::deserialize(value)
+                .map(Some)
+                .map_err(serde::de::Error::custom)?,
+        };
+        Ok(OptionalLoadBalancingConfig { lb_config })
     }
 }
 
@@ -386,7 +397,7 @@ mod test {
             "loadBalancingConfig": [{ "round_robin": {} }]
         }))
         .unwrap();
-        let selected = val.load_balancing_config.unwrap();
+        let selected = val.load_balancing_config.lb_config.unwrap();
         assert_eq!(selected.builder.name(), "round_robin");
         assert!(selected.config.is_none());
 
@@ -399,7 +410,7 @@ mod test {
             ]
         }))
         .unwrap();
-        let selected = val.load_balancing_config.as_ref().unwrap();
+        let selected = val.load_balancing_config.lb_config.as_ref().unwrap();
         assert_eq!(selected.builder.name(), "pick_first");
         let pf_cfg = selected
             .config
@@ -429,17 +440,17 @@ mod test {
             "loadBalancingConfig": []
         }))
         .unwrap();
-        assert!(val.load_balancing_config.is_none());
+        assert!(val.load_balancing_config.lb_config.is_none());
 
         // Null or absent -> None
         let val: ServiceConfigSerde = serde_json::from_value(json!({
             "loadBalancingConfig": null
         }))
         .unwrap();
-        assert!(val.load_balancing_config.is_none());
+        assert!(val.load_balancing_config.lb_config.is_none());
 
         let val: ServiceConfigSerde = serde_json::from_value(json!({})).unwrap();
-        assert!(val.load_balancing_config.is_none());
+        assert!(val.load_balancing_config.lb_config.is_none());
 
         // Multiple policies; trailing entries after first supported are ignored
         let val: ServiceConfigSerde = serde_json::from_value(json!({
@@ -450,7 +461,7 @@ mod test {
             ]
         }))
         .unwrap();
-        let selected = val.load_balancing_config.as_ref().unwrap();
+        let selected = val.load_balancing_config.lb_config.as_ref().unwrap();
         assert_eq!(selected.builder.name(), "pick_first");
 
         // Invalid entry with multiple keys in single object -> Error


### PR DESCRIPTION
Contributes to: https://github.com/grpc/grpc-rust/issues/2761

This change updates `LbConfigSerde` parsing to return a non-optional value, simplifying its use for load balancers that require a child configuration. Consequently, the `load_balancing_config` field in `ServiceConfigSerde` is now optional.

Since `load_balancing_config` is a `repeated` field in the Protobuf definition, and Protobuf cannot differentiate between an unset repeated field and an empty list, a helper function `deserialize_load_balancing_config` is used to parse this optional field and treat an empty list as `None`. This avoids parsing errors and enables falling back to the deprecated `load_balancing_policy` field if it is set.