### PR TITLE
Add `Endpoint::eager_connect_errors` to surface lazy-channel connection failures immediately

### DIFF
--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -470,6 +470,15 @@ impl Endpoint {
     /// initial connection error immediately; it only matters for lazily-connecting channels
     /// (see [`Endpoint::connect_lazy`] and [`Endpoint::connect_with_connector_lazy`]).
     ///
+    /// For endpoints used with
+    /// [`Channel::balance_channel`](crate::transport::Channel::balance_channel) or
+    /// [`Channel::balance_list`](crate::transport::Channel::balance_list), enabling this
+    /// lets the load balancer identify a broken backend immediately and skip it rather
+    /// than routing a call to it. Such a backend is removed from the balancer as soon
+    /// as its connection attempt fails; it automatically rejoins the balancer shortly
+    /// after (on a short, fixed backoff) rather than being lost until the caller
+    /// explicitly re-adds it.
+    ///
     /// Defaults to `false`.
     pub fn eager_connect_errors(self, enabled: bool) -> Self {
         Endpoint {

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -71,6 +71,7 @@ pub struct Endpoint {
     pub(crate) tcp_keepalive_interval: Option<Duration>,
     pub(crate) tcp_keepalive_retries: Option<u32>,
     pub(crate) tcp_nodelay: bool,
+    pub(crate) eager_connect_errors: bool,
     pub(crate) http2_keep_alive_interval: Option<Duration>,
     pub(crate) http2_keep_alive_timeout: Option<Duration>,
     pub(crate) http2_keep_alive_while_idle: Option<bool>,
@@ -121,6 +122,7 @@ impl Endpoint {
             tcp_keepalive_interval: None,
             tcp_keepalive_retries: None,
             tcp_nodelay: true,
+            eager_connect_errors: false,
             http2_keep_alive_interval: None,
             http2_keep_alive_timeout: None,
             http2_keep_alive_while_idle: None,
@@ -152,6 +154,7 @@ impl Endpoint {
             tcp_keepalive_interval: None,
             tcp_keepalive_retries: None,
             tcp_nodelay: true,
+            eager_connect_errors: false,
             http2_keep_alive_interval: None,
             http2_keep_alive_timeout: None,
             http2_keep_alive_while_idle: None,
@@ -453,6 +456,24 @@ impl Endpoint {
     pub fn tcp_nodelay(self, enabled: bool) -> Self {
         Endpoint {
             tcp_nodelay: enabled,
+            ..self
+        }
+    }
+
+    /// Sets whether connection errors should be surfaced immediately, rather than only
+    /// once an actual call is made.
+    ///
+    /// When enabled, a failed connection attempt is reported right away instead of being
+    /// deferred and retried transparently on the next call.
+    ///
+    /// This has no effect on channels that connect eagerly which already surface their
+    /// initial connection error immediately; it only matters for lazily-connecting channels
+    /// (see [`Endpoint::connect_lazy`] and [`Endpoint::connect_with_connector_lazy`]).
+    ///
+    /// Defaults to `false`.
+    pub fn eager_connect_errors(self, enabled: bool) -> Self {
+        Endpoint {
+            eager_connect_errors: enabled,
             ..self
         }
     }

--- a/tonic/src/transport/channel/mod.rs
+++ b/tonic/src/transport/channel/mod.rs
@@ -165,7 +165,7 @@ impl Channel {
         E: Executor<Pin<Box<dyn Future<Output = ()> + Send>>> + Send + Sync + 'static,
     {
         let (tx, rx) = channel(capacity);
-        let list = DynamicServiceStream::new(rx);
+        let list = DynamicServiceStream::new(rx, tx.clone());
         (Self::balance(list, DEFAULT_BUFFER_SIZE, executor), tx)
     }
 

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -102,7 +102,12 @@ impl Connection {
         let make_service =
             MakeSendRequestService::new(connector, endpoint.executor.clone(), settings);
 
-        let conn = Reconnect::new(make_service, endpoint.uri().clone(), is_lazy);
+        let conn = Reconnect::new(
+            make_service,
+            endpoint.uri().clone(),
+            is_lazy,
+            endpoint.eager_connect_errors,
+        );
 
         Self {
             inner: BoxService::new(stack.layer(conn)),

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -22,7 +22,7 @@
  *
  */
 
-use super::{AddOrigin, Reconnect, SharedExec, UserAgent};
+use super::{AddOrigin, Change, Reconnect, SharedExec, UserAgent};
 use crate::{
     body::Body,
     transport::{Endpoint, channel::BoxFuture, service::GrpcTimeout},
@@ -34,7 +34,9 @@ use hyper_util::rt::TokioTimer;
 use std::{
     fmt,
     task::{Context, Poll},
+    time::Duration,
 };
+use tokio::sync::mpsc;
 use tower::load::Load;
 use tower::{
     ServiceBuilder, ServiceExt,
@@ -44,12 +46,16 @@ use tower::{
 };
 use tower_service::Service;
 
+/// How long to wait before re-inserting a balanced endpoint that was evicted after a
+/// failed connection attempt. See [`ReinsertOnError`].
+const REINSERT_BACKOFF: Duration = Duration::from_secs(1);
+
 pub(crate) struct Connection {
     inner: BoxService<Request<Body>, Response<Body>, crate::BoxError>,
 }
 
 impl Connection {
-    fn new<C>(connector: C, endpoint: Endpoint, is_lazy: bool) -> Self
+    fn new<C>(connector: C, endpoint: Endpoint, is_lazy: bool, fail_early: bool) -> Self
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::BoxError> + Send,
@@ -102,12 +108,7 @@ impl Connection {
         let make_service =
             MakeSendRequestService::new(connector, endpoint.executor.clone(), settings);
 
-        let conn = Reconnect::new(
-            make_service,
-            endpoint.uri().clone(),
-            is_lazy,
-            endpoint.eager_connect_errors,
-        );
+        let conn = Reconnect::new(make_service, endpoint.uri().clone(), is_lazy, fail_early);
 
         Self {
             inner: BoxService::new(stack.layer(conn)),
@@ -124,7 +125,10 @@ impl Connection {
         C::Future: Unpin + Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
-        Self::new(connector, endpoint, false).ready_oneshot().await
+        let fail_early = endpoint.eager_connect_errors;
+        Self::new(connector, endpoint, false, fail_early)
+            .ready_oneshot()
+            .await
     }
 
     pub(crate) fn lazy<C>(connector: C, endpoint: Endpoint) -> Self
@@ -134,7 +138,100 @@ impl Connection {
         C::Future: Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
-        Self::new(connector, endpoint, true)
+        let fail_early = endpoint.eager_connect_errors;
+        Self::new(connector, endpoint, true, fail_early)
+    }
+
+    /// Like [`Connection::lazy`], but for connections managed by a discovery-driven
+    /// [`tower::balance::p2c::Balance`].
+    ///
+    /// `Balance` polls its services through a `tower::ready_cache::ReadyCache`, which
+    /// permanently evicts any service whose `poll_ready` returns `Err` and never
+    /// retries it on its own. Since [`Endpoint::eager_connect_errors`] intentionally
+    /// causes connect failures to surface from `poll_ready` (so `Balance` can skip a
+    /// broken endpoint instead of routing a call to it), a connection built here is
+    /// wrapped in [`ReinsertOnError`] so that an eviction like that is followed by an
+    /// automatic re-insert of the same key after a short backoff, instead of the
+    /// endpoint being lost until the caller notices and re-inserts it manually.
+    pub(crate) fn lazy_for_discovery<C, K>(
+        connector: C,
+        endpoint: Endpoint,
+        key: K,
+        reinsert: mpsc::Sender<Change<K, Endpoint>>,
+    ) -> Self
+    where
+        C: Service<Uri> + Send + 'static,
+        C::Error: Into<crate::BoxError> + Send,
+        C::Future: Send,
+        C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+        K: Clone + Send + 'static,
+    {
+        let fail_early = endpoint.eager_connect_errors;
+        let executor = endpoint.executor.clone();
+        let retry_endpoint = endpoint.clone();
+        let inner = Self::new(connector, endpoint, true, fail_early);
+
+        Self {
+            inner: BoxService::new(ReinsertOnError {
+                inner,
+                key,
+                endpoint: retry_endpoint,
+                executor,
+                reinsert,
+            }),
+        }
+    }
+}
+
+/// Wraps a discovery-managed [`Connection`] so that a `poll_ready` error (which causes
+/// `tower`'s `Balance`/`ReadyCache` to evict it permanently, see [`Connection::lazy_for_discovery`])
+/// is followed by scheduling a fresh [`Change::Insert`] for the same key after
+/// [`REINSERT_BACKOFF`], so the endpoint can rejoin the balancer on its own.
+struct ReinsertOnError<K> {
+    inner: Connection,
+    key: K,
+    endpoint: Endpoint,
+    executor: SharedExec,
+    reinsert: mpsc::Sender<Change<K, Endpoint>>,
+}
+
+impl<K> ReinsertOnError<K>
+where
+    K: Clone + Send + 'static,
+{
+    fn schedule_reinsert(&self) {
+        let key = self.key.clone();
+        let endpoint = self.endpoint.clone();
+        let reinsert = self.reinsert.clone();
+
+        Executor::<BoxFuture<'static, ()>>::execute(
+            &self.executor,
+            Box::pin(async move {
+                tokio::time::sleep(REINSERT_BACKOFF).await;
+                let _ = reinsert.send(Change::Insert(key, endpoint)).await;
+            }) as _,
+        );
+    }
+}
+
+impl<K> Service<Request<Body>> for ReinsertOnError<K>
+where
+    K: Clone + Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = crate::BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let poll = Service::poll_ready(&mut self.inner, cx);
+        if let Poll::Ready(Err(_)) = &poll {
+            self.schedule_reinsert();
+        }
+        poll
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        self.inner.call(req)
     }
 }
 

--- a/tonic/src/transport/channel/service/discover.rs
+++ b/tonic/src/transport/channel/service/discover.rs
@@ -29,7 +29,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::Stream;
 use tower::discover::Change as TowerChange;
 
@@ -44,15 +44,22 @@ pub enum Change<K, V> {
 
 pub(crate) struct DynamicServiceStream<K: Hash + Eq + Clone> {
     changes: Receiver<Change<K, Endpoint>>,
+    /// A sender back into the same channel `changes` reads from, handed to each
+    /// discovered [`Connection`] so it can re-insert itself after being evicted by
+    /// `Balance` for a connect failure. See [`Connection::lazy_for_discovery`].
+    reinsert: Sender<Change<K, Endpoint>>,
 }
 
 impl<K: Hash + Eq + Clone> DynamicServiceStream<K> {
-    pub(crate) fn new(changes: Receiver<Change<K, Endpoint>>) -> Self {
-        Self { changes }
+    pub(crate) fn new(
+        changes: Receiver<Change<K, Endpoint>>,
+        reinsert: Sender<Change<K, Endpoint>>,
+    ) -> Self {
+        Self { changes, reinsert }
     }
 }
 
-impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
+impl<K: Hash + Eq + Clone + Send + 'static> Stream for DynamicServiceStream<K> {
     type Item = Result<TowerChange<K, Connection>, crate::BoxError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -60,7 +67,12 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
             Poll::Pending | Poll::Ready(None) => Poll::Pending,
             Poll::Ready(Some(change)) => match change {
                 Change::Insert(k, endpoint) => {
-                    let connection = Connection::lazy(endpoint.http_connector(), endpoint);
+                    let connection = Connection::lazy_for_discovery(
+                        endpoint.http_connector(),
+                        endpoint,
+                        k.clone(),
+                        self.reinsert.clone(),
+                    );
                     Poll::Ready(Some(Ok(TowerChange::Insert(k, connection))))
                 }
                 Change::Remove(k) => Poll::Ready(Some(Ok(TowerChange::Remove(k)))),

--- a/tonic/src/transport/channel/service/reconnect.rs
+++ b/tonic/src/transport/channel/service/reconnect.rs
@@ -44,6 +44,7 @@ where
     error: Option<crate::BoxError>,
     has_been_connected: bool,
     is_lazy: bool,
+    fail_early: bool,
 }
 
 #[derive(Debug)]
@@ -58,7 +59,7 @@ where
     M: Service<Target>,
     M::Error: Into<crate::BoxError>,
 {
-    pub(crate) fn new(mk_service: M, target: Target, is_lazy: bool) -> Self {
+    pub(crate) fn new(mk_service: M, target: Target, is_lazy: bool, fail_early: bool) -> Self {
         Reconnect {
             mk_service,
             state: State::Idle,
@@ -66,6 +67,7 @@ where
             error: None,
             has_been_connected: false,
             is_lazy,
+            fail_early,
         }
     }
 }
@@ -121,7 +123,9 @@ where
 
                             state = State::Idle;
 
-                            if !(self.has_been_connected || self.is_lazy) {
+                            if self.fail_early {
+                                return Poll::Ready(Err(e.into()));
+                            } else if !(self.has_been_connected || self.is_lazy) {
                                 return Poll::Ready(Err(e.into()));
                             } else {
                                 let error = e.into();

--- a/tonic/src/transport/channel/service/reconnect.rs
+++ b/tonic/src/transport/channel/service/reconnect.rs
@@ -70,6 +70,10 @@ where
             fail_early,
         }
     }
+
+    fn return_connection_errors_on_poll(&self) -> bool {
+        self.fail_early || !(self.has_been_connected || self.is_lazy)
+    }
 }
 
 impl<M, Target, S, Request> Service<Request> for Reconnect<M, Target>
@@ -123,9 +127,7 @@ where
 
                             state = State::Idle;
 
-                            if self.fail_early {
-                                return Poll::Ready(Err(e.into()));
-                            } else if !(self.has_been_connected || self.is_lazy) {
+                            if self.return_connection_errors_on_poll() {
                                 return Poll::Ready(Err(e.into()));
                             } else {
                                 let error = e.into();


### PR DESCRIPTION
Fixes #2839.

Adds `Endpoint::eager_connect_errors(bool)`. When enabled, a lazily-connecting channel (`Endpoint::connect_lazy` / `connect_with_connector_lazy`) reports a failed connection attempt to the caller right away, instead of waiting till a call is made. This allows load balancers like tower's p2c to identify healthy endpoints before making an actual call.  

A new `fail_early` field/parameter on the internal `Reconnect` service, set from `endpoint.eager_connect_errors` at construction time in `Connection::new`.