### PR TITLE
grpc: allow external TLS implementations with __unstable

### DIFF
--- a/grpc/src/credentials/mod.rs
+++ b/grpc/src/credentials/mod.rs
@@ -248,11 +248,18 @@ pub(crate) mod common {
 
 /// Contains information about a [`ChannelCredentials`] or
 /// [`ServerCredentials`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ProtocolInfo {
     security_protocol: &'static str,
 }
 
 impl ProtocolInfo {
+    #[cfg(feature = "__unstable")]
+    pub const fn new(security_protocol: &'static str) -> Self {
+        Self { security_protocol }
+    }
+
+    #[cfg(not(feature = "__unstable"))]
     pub(crate) const fn new(security_protocol: &'static str) -> Self {
         Self { security_protocol }
     }

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -71,6 +71,8 @@ pub use status::StatusError;
 #[cfg(feature = "__unstable")]
 #[doc(hidden)]
 pub mod __unstable {
+    pub use crate::private::Internal;
+
     pub mod rt {
         pub use crate::rt::*;
     }
@@ -83,6 +85,17 @@ pub mod __unstable {
         }
         pub mod service_config {
             pub use crate::client::service_config::*;
+        }
+    }
+    pub mod credentials {
+        pub mod client {
+            pub use crate::credentials::client::*;
+        }
+        pub mod server {
+            pub use crate::credentials::server::*;
+        }
+        pub mod common {
+            pub use crate::credentials::common::*;
         }
     }
 }

--- a/grpc/src/rt/mod.rs
+++ b/grpc/src/rt/mod.rs
@@ -223,16 +223,16 @@ pub trait GrpcEndpoint: Send + Unpin + 'static {
 /// An adapter that exposes `AsyncRead` and `AsyncWrite` functionality for
 /// interfacing with `hyper` and `rustls`. This type is kept private to avoid
 /// exposing its read and write methods to external crates.
-pub(crate) struct EndpointIoStream<T> {
+pub struct EndpointIoStream<T> {
     inner: T,
 }
 
 impl<T: GrpcEndpoint> EndpointIoStream<T> {
-    pub(crate) fn new(inner: T) -> Self {
+    pub fn new(inner: T) -> Self {
         Self { inner }
     }
 
-    pub(crate) fn get_ref(&self) -> &T {
+    pub fn get_ref(&self) -> &T {
         &self.inner
     }
 }
@@ -278,7 +278,7 @@ impl<T: GrpcEndpoint> AsyncWrite for EndpointIoStream<T> {
 }
 
 /// A wrapper that implements [GrpcEndpoint] for an asynchronous I/O stream.
-pub(crate) struct StreamEndpoint<T> {
+pub struct StreamEndpoint<T> {
     inner: T,
     peer_addr: Box<str>,
     local_addr: Box<str>,
@@ -286,7 +286,7 @@ pub(crate) struct StreamEndpoint<T> {
 }
 
 impl<T> StreamEndpoint<T> {
-    pub(crate) fn new(
+    pub fn new(
         inner: T,
         local_addr: Box<str>,
         peer_addr: Box<str>,
@@ -455,7 +455,7 @@ impl Runtime for NoOpRuntime {
     }
 }
 
-pub(crate) fn default_runtime() -> GrpcRuntime {
+pub fn default_runtime() -> GrpcRuntime {
     #[cfg(feature = "_runtime-tokio")]
     {
         return GrpcRuntime::new(tokio::TokioRuntime::default());
@@ -467,6 +467,12 @@ pub(crate) fn default_runtime() -> GrpcRuntime {
 #[derive(Clone, Debug)]
 pub struct GrpcRuntime {
     inner: Arc<dyn Runtime>,
+}
+
+impl Default for GrpcRuntime {
+    fn default() -> Self {
+        default_runtime()
+    }
 }
 
 impl GrpcRuntime {


### PR DESCRIPTION
## Motivation

Grpc-rust currently supports rustls for transport security. Some environments want to use grpc-rust but standardize on other TLS libraries (such as BoringSSL).

## Solution

To provide a TLS implementation, an external crate must implement the `ChannelCredentials` (TLS client) and `ServerCredentials` (TLS server) traits. These traits depend on a number of dependent traits, as well as the `Internal` sealing token. This change exposes the required items in the `grpc::__unstable` module, subject to the `__unstable` feature flag.

