### PR TITLE
feat(tonic-xds): support custom control-plane connectors

### DIFF
--- a/tonic-xds/Cargo.toml
+++ b/tonic-xds/Cargo.toml
@@ -69,6 +69,7 @@ tonic = { version = "0.14", features = [ "server", "channel", "tls-ring" ] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 async-stream = "0.3"
+hyper-util = { version = "0.1", features = ["tokio"] }
 tempfile = "3.27.0"
 rcgen = "0.14"
 google-cloud-auth = { version = "1.9", default-features = false }

--- a/tonic-xds/src/client/channel.rs
+++ b/tonic-xds/src/client/channel.rs
@@ -213,6 +213,7 @@ const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_grpc_service::<XdsChannelGrpc>();
     assert_send_sync::<XdsChannelGrpc>();
+    assert_send_sync::<XdsChannelBuilder>();
 };
 
 /// Builder for creating an [`XdsChannel`] or [`XdsChannelGrpc`].
@@ -222,6 +223,7 @@ pub struct XdsChannelBuilder {
     recorder: Option<Arc<dyn MetricsRecorder>>,
     pre_route: Option<Arc<dyn PreRouteInterceptor>>,
     retry_classifier_factory: Option<Arc<dyn RetryClassifierFactory>>,
+    cp_transport: Option<TonicTransportBuilder>,
     #[cfg(feature = "_tls-any")]
     cert_providers: HashMap<String, Arc<dyn CertificateProvider>>,
 }
@@ -256,6 +258,7 @@ impl Debug for XdsChannelBuilder {
             "cert_providers",
             &self.cert_providers.keys().collect::<Vec<_>>(),
         );
+        s.field("cp_transport", &self.cp_transport);
         s.finish()
     }
 }
@@ -269,6 +272,7 @@ impl XdsChannelBuilder {
             recorder: None,
             pre_route: None,
             retry_classifier_factory: None,
+            cp_transport: None,
             #[cfg(feature = "_tls-any")]
             cert_providers: HashMap::new(),
         }
@@ -333,6 +337,25 @@ impl XdsChannelBuilder {
         self
     }
 
+    /// Uses a custom connector for the xDS management server.
+    ///
+    /// Backend connections are unaffected. The connector owns security, so
+    /// bootstrap TLS and
+    /// [`requires_secure_transport`](xds_client::TonicCallCredentials::requires_secure_transport)
+    /// are not applied. Use an `http://` URI with `insecure` bootstrap
+    /// credentials even when the connector uses TLS.
+    #[must_use]
+    pub fn with_control_plane_connector<C>(mut self, connector: C) -> Self
+    where
+        C: tower::Service<http::Uri> + Clone + Send + Sync + 'static,
+        C::Response: xds_client::AdsIo + 'static,
+        C::Future: Send + 'static,
+        BoxError: From<C::Error>,
+    {
+        self.cp_transport = Some(TonicTransportBuilder::new().with_connector(connector));
+        self
+    }
+
     /// Emits the gRFC A78 xDS client metrics through an OpenTelemetry `Meter`.
     ///
     /// Convenience wrapper over
@@ -364,25 +387,16 @@ impl XdsChannelBuilder {
         let listener_name = self.config.target_uri.target.clone();
 
         let server_uri = bootstrap.server_uri().to_owned();
+        let bootstrap_use_tls = bootstrap.use_tls();
 
-        #[allow(unused_mut)]
-        let mut transport_builder = TonicTransportBuilder::new();
-        #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc"))]
-        if bootstrap.use_tls() {
-            transport_builder = transport_builder
-                .with_tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots());
-        }
         #[cfg(not(any(feature = "tls-ring", feature = "tls-aws-lc")))]
-        if bootstrap.use_tls() {
+        if self.cp_transport.is_none() && bootstrap_use_tls {
             return Err(BuildError::Bootstrap(BootstrapError::Validation(
                 "TLS requested by bootstrap but no TLS feature enabled \
-                 (enable tls-ring or tls-aws-lc)"
+                 (enable tls-ring or tls-aws-lc, or supply the connection \
+                 yourself with XdsChannelBuilder::with_control_plane_connector)"
                     .into(),
             )));
-        }
-
-        if let Some(creds) = self.config.call_creds.clone() {
-            transport_builder = transport_builder.with_call_credentials(creds);
         }
 
         #[cfg(feature = "_tls-any")]
@@ -394,8 +408,12 @@ impl XdsChannelBuilder {
         let node = Node::try_from(bootstrap.node)?;
         let client_config =
             ClientConfig::new(node, &server_uri).with_target(self.config.target_uri.to_string());
-        let mut client_builder =
-            XdsClient::builder(client_config, transport_builder, ProstCodec, TokioRuntime);
+        let mut client_builder = XdsClient::builder(
+            client_config,
+            self.control_plane_transport(bootstrap_use_tls),
+            ProstCodec,
+            TokioRuntime,
+        );
         if let Some(recorder) = self.recorder.clone() {
             client_builder = client_builder.with_metrics_recorder(recorder);
         }
@@ -412,6 +430,24 @@ impl XdsChannelBuilder {
             #[cfg(feature = "_tls-any")]
             cert_provider_registry,
         })
+    }
+
+    fn control_plane_transport(&self, bootstrap_use_tls: bool) -> TonicTransportBuilder {
+        #[allow(unused_mut)]
+        let mut transport_builder = self.cp_transport.clone().unwrap_or_default();
+
+        #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc"))]
+        if bootstrap_use_tls && self.cp_transport.is_none() {
+            transport_builder = transport_builder
+                .with_tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots());
+        }
+        #[cfg(not(any(feature = "tls-ring", feature = "tls-aws-lc")))]
+        let _ = bootstrap_use_tls;
+
+        if let Some(creds) = self.config.call_creds.clone() {
+            transport_builder = transport_builder.with_call_credentials(creds);
+        }
+        transport_builder
     }
 
     /// Wires the shared routing / retry / load-balancing stack from a pre-built

--- a/tonic-xds/src/client/xds_e2e.rs
+++ b/tonic-xds/src/client/xds_e2e.rs
@@ -39,6 +39,7 @@ mod test {
     use xds_test_util::config;
 
     use crate::BootstrapConfig;
+    use crate::ChannelCredentialType;
     use crate::XdsChannelBuilder;
     use crate::XdsChannelConfig;
     use crate::XdsChannelGrpc;
@@ -62,14 +63,19 @@ mod test {
     /// Builds a real xDS channel whose bootstrap points at `cp_addr` and whose
     /// target resolves the listener `listener_name`.
     fn build_channel(cp_addr: SocketAddr, listener_name: &str) -> XdsChannelGrpc {
-        let bootstrap_json = format!(
-            r#"{{"xds_servers":[{{"server_uri":"http://{cp_addr}","channel_creds":[{{"type":"insecure"}}]}}],"node":{{"id":"test"}}}}"#
-        );
-        let bootstrap = BootstrapConfig::from_json(&bootstrap_json).expect("parse bootstrap");
-        let target = XdsUri::parse(&format!("xds:///{listener_name}")).expect("parse target");
-        XdsChannelBuilder::new(XdsChannelConfig::new(target).with_bootstrap(bootstrap))
+        let bootstrap = BootstrapConfig::builder(format!("http://{cp_addr}"))
+            .channel_creds([ChannelCredentialType::Insecure])
+            .node_id("test")
+            .build()
+            .expect("build bootstrap");
+        channel_builder(bootstrap, listener_name)
             .build_grpc_channel()
             .expect("build xds channel")
+    }
+
+    fn channel_builder(bootstrap: BootstrapConfig, listener_name: &str) -> XdsChannelBuilder {
+        let target = XdsUri::parse(&format!("xds:///{listener_name}")).expect("parse target");
+        XdsChannelBuilder::new(XdsChannelConfig::new(target).with_bootstrap(bootstrap))
     }
 
     /// Sends `say_hello` in a loop until a reply starting with `want_prefix` is
@@ -316,6 +322,81 @@ mod test {
         }
 
         for backend in backends {
+            let _ = backend.shutdown.send(());
+        }
+    }
+
+    mod user_transport {
+        use super::*;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        fn configure_route(
+            control_plane: &RunningControlPlane,
+            name: &str,
+            backend_addr: SocketAddr,
+        ) {
+            let cluster = format!("{name}-cluster");
+            control_plane.get_service().set_xds_config(
+                &config::AdsTypeUrl::Lds,
+                HashMap::from([(
+                    name.to_string(),
+                    config::build_inline_listener(name, &cluster),
+                )]),
+            );
+            control_plane.get_service().set_xds_config(
+                &config::AdsTypeUrl::Cds,
+                HashMap::from([(cluster.clone(), config::build_cluster(&cluster))]),
+            );
+            control_plane.get_service().set_xds_config(
+                &config::AdsTypeUrl::Eds,
+                HashMap::from([(
+                    cluster.clone(),
+                    config::build_cla(
+                        &cluster,
+                        &[(backend_addr.ip().to_string(), backend_addr.port())],
+                    ),
+                )]),
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn custom_control_plane_connector_owns_transport() {
+            const LISTENER: &str = "my-service";
+
+            let backend = spawn_greeter_server("backend", None, None)
+                .await
+                .expect("spawn greeter backend");
+            let (control_plane, cp_addr) = start_control_plane().await;
+            configure_route(&control_plane, LISTENER, backend.addr);
+
+            let calls = Arc::new(AtomicUsize::new(0));
+            let connector_calls = calls.clone();
+            let connector = tower::service_fn(move |_uri: http::Uri| {
+                connector_calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    let stream = tokio::net::TcpStream::connect(cp_addr).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            });
+
+            let bootstrap = BootstrapConfig::builder(format!("http://{cp_addr}"))
+                .channel_creds([ChannelCredentialType::Insecure])
+                .node_id("test")
+                .build()
+                .expect("build bootstrap");
+            let channel = channel_builder(bootstrap, LISTENER)
+                .with_control_plane_connector(connector)
+                .build_grpc_channel()
+                .expect("build xds channel");
+
+            let mut client = GreeterClient::new(channel);
+            assert_eq!(
+                say_hello_until_prefix(&mut client, "backend:").await,
+                "backend: world"
+            );
+            assert!(calls.load(Ordering::SeqCst) > 0, "connector was not used");
+
             let _ = backend.shutdown.send(());
         }
     }

--- a/xds-client/Cargo.toml
+++ b/xds-client/Cargo.toml
@@ -22,6 +22,8 @@ rand = "0.10"
 tonic = { version = "0.14", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 http = { version = "1", optional = true }
+tower-service = { version = "0.3", optional = true }
+hyper = { version = "1", optional = true }
 
 # Optional dependencies for prost codec
 envoy-types = { version = "0.7", optional = true }
@@ -35,6 +37,8 @@ transport-tonic = [
     "tonic/codegen",
     "dep:tokio-stream",
     "dep:http",
+    "dep:tower-service",
+    "dep:hyper",
 ]
 tonic-tls-ring = ["transport-tonic", "tonic/tls-ring"]
 tonic-tls-aws-lc = ["transport-tonic", "tonic/tls-aws-lc"]
@@ -50,6 +54,8 @@ tokio = { version = "1", features = [
 ] }
 tonic = { version = "0.14" }
 async-stream = "0.3"
+hyper-util = { version = "0.1", features = ["tokio"] }
+tower = { version = "0.5", features = ["util"] }
 envoy-types = "0.7"
 prost = "0.14"
 
@@ -65,4 +71,10 @@ allowed_external_types = [
     # Re-exported in the public API behind the transport-tonic / codegen-prost features.
     "tonic::*",
     "prost::*",
+    # Bounds on a user-supplied ADS connector, imposed by tonic's own
+    # `Endpoint::connect_with_connector` signature.
+    "tower_service::Service",
+    "http::uri::Uri",
+    "hyper::rt::io::Read",
+    "hyper::rt::io::Write",
 ]

--- a/xds-client/src/lib.rs
+++ b/xds-client/src/lib.rs
@@ -103,7 +103,7 @@ pub use runtime::tokio::TokioRuntime;
 
 // Tonic transport
 #[cfg(feature = "transport-tonic")]
-pub use transport::tonic::{TonicCallCredentials, TonicTransport, TonicTransportBuilder};
+pub use transport::tonic::{AdsIo, TonicCallCredentials, TonicTransport, TonicTransportBuilder};
 
 // Prost codec
 #[cfg(feature = "codegen-prost")]

--- a/xds-client/src/transport/tonic.rs
+++ b/xds-client/src/transport/tonic.rs
@@ -30,9 +30,12 @@
 
 use crate::client::config::ServerConfig;
 use crate::error::{Error, Result};
+
 use crate::transport::{Transport, TransportBuilder, TransportStream};
 use bytes::{Buf, BufMut, Bytes};
 use http::uri::PathAndQuery;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -185,6 +188,48 @@ impl TonicTransport {
     }
 }
 
+/// I/O returned by a custom ADS connector.
+pub trait AdsIo: hyper::rt::Read + hyper::rt::Write + Send + Unpin {}
+impl<T: hyper::rt::Read + hyper::rt::Write + Send + Unpin> AdsIo for T {}
+
+type ErasedConnect =
+    Arc<dyn Fn(Endpoint) -> Pin<Box<dyn Future<Output = Result<Channel>> + Send>> + Send + Sync>;
+
+fn connect_with<C>(
+    connector: &C,
+    endpoint: Endpoint,
+) -> Pin<Box<dyn Future<Output = Result<Channel>> + Send>>
+where
+    C: tower_service::Service<tonic::transport::Uri> + Clone + Send + Sync + 'static,
+    C::Response: AdsIo + 'static,
+    C::Future: Send + 'static,
+    Box<dyn std::error::Error + Send + Sync>: From<C::Error>,
+{
+    let connector = connector.clone();
+    Box::pin(async move {
+        endpoint
+            .connect_with_connector(connector)
+            .await
+            .map_err(|e| Error::Connection(e.to_string()))
+    })
+}
+
+#[derive(Clone, Default)]
+enum Connect {
+    #[default]
+    Default,
+    Custom(ErasedConnect),
+}
+
+impl std::fmt::Debug for Connect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => f.write_str("Default"),
+            Self::Custom(_) => f.write_str("Custom(<user connector>)"),
+        }
+    }
+}
+
 /// Builder for creating [`TonicTransport`] instances.
 ///
 /// This implements [`TransportBuilder`] and can be used with
@@ -213,6 +258,8 @@ impl TonicTransport {
 /// ```
 #[derive(Debug, Clone)]
 pub struct TonicTransportBuilder {
+    connect: Connect,
+
     // Future extensions:
     // - Connection pooling settings
     // - Per-server credential overrides (via ServerConfig.extensions)
@@ -235,6 +282,7 @@ pub struct TonicTransportBuilder {
 impl Default for TonicTransportBuilder {
     fn default() -> Self {
         Self {
+            connect: Connect::Default,
             #[cfg(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc"))]
             tls_config: None,
             call_creds: None,
@@ -249,6 +297,24 @@ impl TonicTransportBuilder {
     /// Create a new transport builder with default (plaintext) settings.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Uses a custom connector for ADS connections, cloned per connection.
+    ///
+    /// The server URI is passed through unchanged. The connector owns transport
+    /// security, so
+    /// [`requires_secure_transport`](TonicCallCredentials::requires_secure_transport)
+    /// is not checked.
+    pub fn with_connector<C>(mut self, connector: C) -> Self
+    where
+        C: tower_service::Service<tonic::transport::Uri> + Clone + Send + Sync + 'static,
+        C::Response: AdsIo + 'static,
+        C::Future: Send + 'static,
+        Box<dyn std::error::Error + Send + Sync>: From<C::Error>,
+    {
+        self.connect =
+            Connect::Custom(Arc::new(move |endpoint| connect_with(&connector, endpoint)));
+        self
     }
 
     /// Set the timeout for establishing the connection to the xDS server.
@@ -314,7 +380,12 @@ impl TransportBuilder for TonicTransportBuilder {
         #[cfg(not(any(feature = "tonic-tls-ring", feature = "tonic-tls-aws-lc")))]
         let tls_configured = false;
 
-        let uri = Self::ensure_secure_server_uri(server.uri(), tls_configured);
+        let user_owns_transport = matches!(self.connect, Connect::Custom(_));
+        let uri = if user_owns_transport {
+            server.uri().to_string()
+        } else {
+            Self::ensure_secure_server_uri(server.uri(), tls_configured)
+        };
 
         // tonic handshakes for an `https` URI alone, so the scheme decides
         // whether the channel is encrypted.
@@ -325,13 +396,13 @@ impl TransportBuilder for TonicTransportBuilder {
         // Require the scheme and the TLS config to agree, so the caller gets
         // the channel they asked for. `ensure_secure_server_uri` has already
         // upgraded the scheme-less form, leaving only real conflicts here.
-        if tls_configured && !secure {
+        if !user_owns_transport && tls_configured && !secure {
             return Err(Error::Connection(format!(
                 "TLS is configured but server URI '{uri}' connects in plaintext; \
                  use an `https://` or scheme-less URI"
             )));
         }
-        if secure && !tls_configured {
+        if !user_owns_transport && secure && !tls_configured {
             return Err(Error::Connection(format!(
                 "server URI '{uri}' requires TLS but no TLS config is set"
             )));
@@ -341,6 +412,7 @@ impl TransportBuilder for TonicTransportBuilder {
         if let Some(creds) = &self.call_creds
             && creds.requires_secure_transport()
             && !secure
+            && !user_owns_transport
         {
             return Err(Error::CallCredentials(
                 "call credentials require a secure transport".into(),
@@ -367,10 +439,13 @@ impl TransportBuilder for TonicTransportBuilder {
             None => endpoint,
         };
 
-        let channel = endpoint
-            .connect()
-            .await
-            .map_err(|e| Error::Connection(e.to_string()))?;
+        let channel = match &self.connect {
+            Connect::Default => endpoint
+                .connect()
+                .await
+                .map_err(|e| Error::Connection(e.to_string()))?,
+            Connect::Custom(connect) => connect(endpoint).await?,
+        };
 
         Ok(TonicTransport {
             channel,
@@ -655,6 +730,82 @@ mod tests {
             err.to_string()
                 .contains("requires TLS but no TLS config is set")
         );
+    }
+
+    fn redirecting_connector(
+        addr: std::net::SocketAddr,
+    ) -> impl tower_service::Service<
+        tonic::transport::Uri,
+        Response = hyper_util::rt::TokioIo<tokio::net::TcpStream>,
+        Error = std::io::Error,
+        Future: Send,
+    > + Clone
+    + Send
+    + Sync
+    + 'static {
+        tower::service_fn(move |_uri: tonic::transport::Uri| async move {
+            Ok(hyper_util::rt::TokioIo::new(
+                tokio::net::TcpStream::connect(addr).await?,
+            ))
+        })
+    }
+
+    #[tokio::test]
+    async fn user_connector_carries_ads_stream_with_call_credentials() {
+        let addr = start_mock_server(Some("******")).await;
+
+        let builder = TonicTransportBuilder::new()
+            .with_call_credentials(Arc::new(MockCreds {
+                pairs: vec![("authorization".into(), "******".into())],
+                requires_secure: false,
+            }))
+            .with_connector(redirecting_connector(addr));
+        let server = ServerConfig::new("http://127.0.0.1:1".to_string());
+
+        for attempt in 0..2 {
+            let transport = builder
+                .build(&server)
+                .await
+                .unwrap_or_else(|e| panic!("build {attempt} failed: {e:?}"));
+
+            let request = DiscoveryRequest {
+                type_url: "type.googleapis.com/envoy.config.listener.v3.Listener".to_string(),
+                ..Default::default()
+            };
+            let request_bytes: Bytes = request.encode_to_vec().into();
+            let mut stream = transport.new_stream(vec![request_bytes]).await.unwrap();
+            let response = stream.recv().await.unwrap().unwrap();
+            let response = DiscoveryResponse::decode(response).unwrap();
+            assert_eq!(response.version_info, "1");
+        }
+    }
+
+    #[tokio::test]
+    async fn user_connector_takes_over_the_security_judgement() {
+        let addr = start_mock_server(None).await;
+        let strict = Arc::new(MockCreds {
+            pairs: vec![],
+            requires_secure: true,
+        });
+
+        assert!(
+            matches!(
+                TonicTransportBuilder::new()
+                    .with_call_credentials(strict.clone())
+                    .build(&ServerConfig::new("http://127.0.0.1:1"))
+                    .await
+                    .unwrap_err(),
+                Error::CallCredentials(_)
+            ),
+            "the built-in path must still refuse them"
+        );
+
+        TonicTransportBuilder::new()
+            .with_call_credentials(strict)
+            .with_connector(redirecting_connector(addr))
+            .build(&ServerConfig::new("http://127.0.0.1:1"))
+            .await
+            .expect("the credential guard must be skipped once a connector is set");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`tonic-xds` always used tonic's built-in connector for the ADS control-plane connection. This prevented applications from supplying a custom transport or managing control-plane TLS themselves.

## Solution

- Add `TonicTransportBuilder::with_connector`.
- Add `XdsChannelBuilder::with_control_plane_connector`.
- Preserve tonic channel setup, keepalives, timeouts, reconnects, and ADS call credentials.
- Leave transport security and URI handling to the custom connector.
- Keep discovered backend connections unchanged.

The connector is cloned for each ADS connection and implements the same `Service<Uri>` interface accepted by tonic's `Endpoint::connect_with_connector`.

## Testing

- Default `tonic-xds` and `xds-client` test suites
- `tonic-xds` with `tls-ring` and `tls-aws-lc`
- Clippy and rustdoc with warnings denied
- Workspace examples and no-default-features build
- `cargo-check-external-types` using the CI nightly toolchain