### PR TITLE
Windows UDS Support

### DIFF
--- a/examples/src/uds/client_standard.rs
+++ b/examples/src/uds/client_standard.rs
@@ -22,7 +22,7 @@
  *
  */
 
-#![cfg_attr(not(unix), allow(unused_imports))]
+#![cfg_attr(not(any(unix, windows)), allow(unused_imports))]
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -30,7 +30,7 @@ pub mod hello_world {
 
 use hello_world::{HelloRequest, greeter_client::GreeterClient};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Unix socket URI follows [RFC-3986](https://datatracker.ietf.org/doc/html/rfc3986)
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn main() {
-    panic!("The `uds` example only works on unix systems!");
+    panic!("The `uds` example only works on unix or windows systems!");
 }

--- a/examples/src/uds/client_with_connector.rs
+++ b/examples/src/uds/client_with_connector.rs
@@ -22,7 +22,7 @@
  *
  */
 
-#![cfg_attr(not(unix), allow(unused_imports))]
+#![cfg_attr(not(any(unix, windows)), allow(unused_imports))]
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -30,12 +30,12 @@ pub mod hello_world {
 
 use hello_world::{HelloRequest, greeter_client::GreeterClient};
 use hyper_util::rt::TokioIo;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use tokio::net::UnixStream;
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // We will ignore this uri because uds do not use it
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn main() {
-    panic!("The `uds` example only works on unix systems!");
+    panic!("The `uds` example only works on unix or windows systems!");
 }

--- a/examples/src/uds/server.rs
+++ b/examples/src/uds/server.rs
@@ -22,14 +22,14 @@
  *
  */
 
-#![cfg_attr(not(unix), allow(unused_imports))]
+#![cfg_attr(not(any(unix, windows)), allow(unused_imports))]
 
 use std::path::Path;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use tokio::net::UnixListener;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use tokio_stream::wrappers::UnixListenerStream;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use tonic::transport::server::UdsConnectInfo;
 use tonic::{Request, Response, Status, transport::Server};
 
@@ -51,7 +51,7 @@ impl Greeter for MyGreeter {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             let conn_info = request.extensions().get::<UdsConnectInfo>().unwrap();
             println!("Got a request {request:?} with info {conn_info:?}");
@@ -64,7 +64,7 @@ impl Greeter for MyGreeter {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = "/tmp/tonic/helloworld";
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn main() {
-    panic!("The `uds` example only works on unix systems!");
+    panic!("The `uds` example only works on unix or windows systems!");
 }

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -603,7 +603,7 @@ fn setup_registeries() {
     pick_first::reg();
     round_robin::reg();
     dns::reg();
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     name_resolution::unix::reg();
     #[cfg(target_os = "linux")]
     name_resolution::unix_abstract::reg();

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -56,7 +56,7 @@ mod test_utils;
 
 pub(crate) mod proxy_resolver;
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 pub(crate) mod unix;
 #[cfg(target_os = "linux")]
 pub(crate) mod unix_abstract;

--- a/grpc/src/client/name_resolution/proxy_resolver.rs
+++ b/grpc/src/client/name_resolution/proxy_resolver.rs
@@ -519,7 +519,7 @@ mod tests {
         assert!(err.contains("invalid target host in URL"));
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[tokio::test]
     async fn unix_path_bypass() {
         crate::client::name_resolution::unix::reg();

--- a/grpc/src/client/name_resolution/unix.rs
+++ b/grpc/src/client/name_resolution/unix.rs
@@ -146,6 +146,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unix_resolver_success_windows_path() {
+        run_success("unix:C:/path/to/socket", "C:/path/to/socket").await;
+    }
+
+    #[tokio::test]
+    async fn unix_resolver_success_windows_path_with_slashes() {
+        run_success("unix:///C:/path/to/socket", "/C:/path/to/socket").await;
+    }
+
+    #[tokio::test]
     async fn unix_resolver_error_with_authority() {
         reg();
 

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -308,7 +308,7 @@ async fn grpc_invoke_tonic_unary() {
     server_handle.await.unwrap();
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 mod unix_tests {
     use std::path::Component;
     use std::path::Path;

--- a/grpc/src/rt/tokio/mod.rs
+++ b/grpc/src/rt/tokio/mod.rs
@@ -131,7 +131,7 @@ impl Runtime for TokioRuntime {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn unix_stream(
         &self,
         path: std::path::PathBuf,
@@ -158,6 +158,15 @@ impl Runtime for TokioRuntime {
         })
     }
 
+    #[cfg(not(any(unix, windows)))]
+    fn unix_stream(
+        &self,
+        _path: std::path::PathBuf,
+        _opts: super::UnixSocketOptions,
+    ) -> BoxFuture<Result<Box<dyn super::GrpcEndpoint>, String>> {
+        Box::pin(async move { Err("Unix streams are not supported on this platform".to_string()) })
+    }
+
     fn tcp_listener(
         &self,
         addr: SocketAddr,
@@ -170,7 +179,7 @@ impl Runtime for TokioRuntime {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn unix_listener(
         &self,
         path: std::path::PathBuf,
@@ -182,7 +191,7 @@ impl Runtime for TokioRuntime {
         })
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn unix_listener(
         &self,
         _path: std::path::PathBuf,
@@ -248,12 +257,12 @@ impl super::EndpointListener for TokioTcpListener {
 // TokioUnixListener — EndpointListener for Unix sockets
 // ---------------------------------------------------------------------------
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 struct TokioUnixListener {
     listener: tokio::net::UnixListener,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 #[tonic::async_trait]
 impl super::EndpointListener for TokioUnixListener {
     async fn accept(&self) -> Result<Box<dyn super::GrpcEndpoint>, String> {


### PR DESCRIPTION
## Motivation
Provide Windows Unix Domain Socket (UDS) support and test coverage.
Addresses https://github.com/grpc/grpc-rust/issues/254.

## Solution
- Updated conditional compilation annotations from `#[cfg(unix)]` to `#[cfg(any(unix, windows))]` (with `#[cfg(not(any(unix, windows)))]` fallbacks) across `grpc` runtime networking, channel registration, name resolution modules, and UDS examples.
- Added unit tests for Windows filesystem path parsing in `grpc/src/client/name_resolution/unix.rs`.
- Enabled the UDS integration test suite on Windows platforms in `grpc/src/client/transport/tonic/test.rs`.