### PR TITLE
fix(codec): eliminate uninitialized memory in encode_item on unwind

### DIFF
--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -172,9 +172,7 @@ where
     let offset = buf.len();
 
     buf.reserve(HEADER_SIZE);
-    unsafe {
-        buf.advance_mut(HEADER_SIZE);
-    }
+    buf.put_slice(&[0u8; HEADER_SIZE]);
 
     if let Some(encoding) = compression_encoding {
         uncompression_buf.clear();
@@ -397,5 +395,58 @@ where
                 .map(|t| t.map(Frame::trailers))
                 .into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::catch_unwind;
+
+    struct PanickingEncoder;
+
+    impl Encoder for PanickingEncoder {
+        type Item = String;
+        type Error = Status;
+
+        fn encode(
+            &mut self,
+            _item: Self::Item,
+            _dst: &mut EncodeBuf<'_>,
+        ) -> Result<(), Self::Error> {
+            panic!("encoder deliberate panic for testing exception safety");
+        }
+    }
+
+    #[test]
+    fn encode_item_exception_safety_on_panic() {
+        let mut encoder = PanickingEncoder;
+        let mut buf = BytesMut::new();
+        let mut uncompression_buf = BytesMut::new();
+
+        let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+            encode_item(
+                &mut encoder,
+                &mut buf,
+                &mut uncompression_buf,
+                None,
+                None,
+                BufferSettings::default(),
+                "test".to_string(),
+            )
+        }));
+
+        assert!(result.is_err(), "Encoder panic should unwind correctly.");
+        // Buffer must only contain initialized bytes (5 zero bytes written by put_slice).
+        assert_eq!(
+            buf.len(),
+            HEADER_SIZE,
+            "Buffer length should reflect reserved header bytes."
+        );
+        assert_eq!(
+            &buf[..],
+            &[0u8; HEADER_SIZE],
+            "Buffer must contain only initialized zero bytes."
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/grpc/grpc-rust/issues/2720.

In `tonic/src/codec/encode.rs`, `encode_item` previously advanced the buffer's logical length by 5 bytes using `unsafe { buf.advance_mut(HEADER_SIZE); }` before invoking the user-provided `Encoder::encode`. If the encoder panicked or unwound, `buf` was left with 5 uninitialized bytes exposed to callers catching unwinds.

## Solution

* Replace `unsafe { buf.advance_mut(HEADER_SIZE); }` with safe zero-filled initialization via `buf.put_slice(&[0u8; HEADER_SIZE])`, eliminating the `unsafe` block entirely.
* Writing 5 zero bytes into the cache line that is immediately overwritten by `finish_encoding` incurs minimal performance impact (a single store instruction).
* The alternative RAII drop guard approach was deliberately avoided because it preserves `unsafe` code and could resurface the soundness vulnerability if `std::mem::forget` (or a similar leak) were ever introduced.
* Add unit test `encode_item_exception_safety_on_panic` verifying that unwinding panics leave only initialized zero bytes in the buffer.

## Test Plan

- Ran `cargo test -p tonic codec::encode`.
- Ran `cargo fmt --all --check`.
- Ran `cargo clippy`.