### PR TITLE
grpc: resolve simple clippy warnings

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -14,6 +14,11 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 rust-version = { workspace = true }
 edition = "2024"
 
+[lints.clippy]
+elidable_lifetime_names = "warn"
+semicolon_if_nothing_returned = "warn"
+unnecessary_semicolon = "warn"
+
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
     "bytes::*",

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = { workspace = true }
 edition = "2024"
 
 [lints.clippy]
-elidable_lifetime_names = "warn"
-semicolon_if_nothing_returned = "warn"
-unnecessary_semicolon = "warn"
+elidable_lifetime_names = "deny"
+semicolon_if_nothing_returned = "deny"
+unnecessary_semicolon = "deny"
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -326,7 +326,7 @@ impl ActiveChannel {
             while let Some(w) = wqrx.recv().await {
                 match w {
                     WorkQueueItem::ScheduleResolver => {
-                        resolver.work(&mut resolver_channel_controller)
+                        resolver.work(&mut resolver_channel_controller);
                     }
                     WorkQueueItem::ResolveNow => resolver.resolve_now(),
                     WorkQueueItem::ScheduleLbPolicy(data) => {

--- a/grpc/src/client/interceptor.rs
+++ b/grpc/src/client/interceptor.rs
@@ -917,7 +917,7 @@ mod test {
             Self { data }
         }
     }
-    impl<'a> SendMessage for ByteSendMsg<'a> {
+    impl SendMessage for ByteSendMsg<'_> {
         fn encode(&self) -> Result<Box<dyn Buf + Send + Sync>, String> {
             Ok(Box::new(self.data.clone()))
         }

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -167,7 +167,7 @@ where
         if let Some(state) = channel_controller.picker_update {
             self.children[child_idx].state = state;
             self.updated = true;
-        };
+        }
     }
 
     /// Returns true if any child has updated its picker since the last call to
@@ -271,7 +271,7 @@ where
                     policy,
                     work_scheduler,
                 });
-            };
+            }
         }
         // Anything left in old_children will just be Dropped and cleaned up.
     }
@@ -568,7 +568,7 @@ mod test {
             endpoints.push(Endpoint {
                 addresses,
                 ..Default::default()
-            })
+            });
         }
         endpoints
     }
@@ -619,7 +619,7 @@ mod test {
                     subchannels.push(sc);
                 }
                 other => panic!("unexpected event {:?}", other),
-            };
+            }
         }
         subchannels
     }

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -457,7 +457,7 @@ impl<T: LbPolicy + ?Sized> LbPolicy for Box<T> {
     }
 
     fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
-        (**self).exit_idle(channel_controller)
+        (**self).exit_idle(channel_controller);
     }
 }
 

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -98,7 +98,7 @@ impl LbPolicyBuilder for PickFirstBuilder {
 }
 
 pub(crate) fn reg() {
-    super::GLOBAL_LB_REGISTRY.add_builder(PickFirstBuilder {})
+    super::GLOBAL_LB_REGISTRY.add_builder(PickFirstBuilder {});
 }
 
 pub struct PickFirstPolicy {
@@ -928,7 +928,7 @@ mod test {
         let res = state.picker.pick(&RequestHeaders::default());
         match res {
             PickResult::Pick(pick) => {
-                assert_eq!(pick.subchannel.address().address.to_string(), "addr1")
+                assert_eq!(pick.subchannel.address().address.to_string(), "addr1");
             }
             other => panic!("unexpected pick result {:?}", other),
         }

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -289,7 +289,7 @@ mod test {
             endpoints.push(Endpoint {
                 addresses,
                 ..Default::default()
-            })
+            });
         }
         endpoints
     }
@@ -517,7 +517,7 @@ mod test {
         match rx_events.recv().unwrap() {
             TestEvent::RequestResolution => {}
             other => panic!("unexpected event {:?}", other),
-        };
+        }
     }
 
     fn verify_no_activity(rx_events: &mut mpsc::Receiver<TestEvent>) {
@@ -650,7 +650,7 @@ mod test {
             match picker.pick(&req) {
                 PickResult::Pick(pick) => {
                     println!("picked subchannel is {}", pick.subchannel);
-                    picked.push(pick.subchannel.clone())
+                    picked.push(pick.subchannel.clone());
                 }
                 other => panic!("unexpected pick result {}", other),
             }
@@ -718,7 +718,7 @@ mod test {
             match picker.pick(&req) {
                 PickResult::Pick(pick) => {
                     println!("picked subchannel is {}", pick.subchannel);
-                    picked.push(pick.subchannel.clone())
+                    picked.push(pick.subchannel.clone());
                 }
                 other => panic!("unexpected pick result {}", other),
             }
@@ -744,7 +744,7 @@ mod test {
             match new_picker.pick(&req) {
                 PickResult::Pick(pick) => {
                     println!("picked subchannel is {}", pick.subchannel);
-                    picked.push(pick.subchannel.clone())
+                    picked.push(pick.subchannel.clone());
                 }
                 other => panic!("unexpected pick result {}", other),
             }

--- a/grpc/src/client/load_balancing/subchannel.rs
+++ b/grpc/src/client/load_balancing/subchannel.rs
@@ -238,7 +238,7 @@ pub trait ForwardingSubchannel: DynHash + DynPartialEq + Any + Send + Sync {
     }
 
     fn connect(&self) {
-        self.delegate().connect()
+        self.delegate().connect();
     }
 }
 
@@ -252,7 +252,7 @@ impl<T: ForwardingSubchannel> Subchannel for T {
     }
 
     fn connect(&self) {
-        self.connect()
+        self.connect();
     }
 }
 impl<T: ForwardingSubchannel> private::Sealed for T {}

--- a/grpc/src/client/load_balancing/subchannel_sharing.rs
+++ b/grpc/src/client/load_balancing/subchannel_sharing.rs
@@ -126,7 +126,7 @@ impl<T: LbPolicy> LbPolicy for SubchannelSharing<T> {
 
         for ext in ext_subchannels {
             self.delegate
-                .subchannel_update(ext, state, &mut channel_controller)
+                .subchannel_update(ext, state, &mut channel_controller);
         }
     }
 
@@ -208,7 +208,7 @@ struct SharingChannelController<'a> {
     delegate: &'a mut dyn ChannelController,
 }
 
-impl<'a> ChannelController for SharingChannelController<'a> {
+impl ChannelController for SharingChannelController<'_> {
     fn new_subchannel(&mut self, address: &Address) -> (Arc<dyn Subchannel>, SubchannelState) {
         let mut inner = self.balancer_inner.lock().unwrap();
 

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -311,5 +311,5 @@ impl LbPolicyBuilder for StubPolicyBuilder {
 }
 
 pub(crate) fn reg_stub_policy(name: &'static str, funcs: StubPolicyFuncs) {
-    super::GLOBAL_LB_REGISTRY.add_dyn_builder(Arc::new(StubPolicyBuilder { name, funcs }))
+    super::GLOBAL_LB_REGISTRY.add_dyn_builder(Arc::new(StubPolicyBuilder { name, funcs }));
 }

--- a/grpc/src/client/metadata_utils.rs
+++ b/grpc/src/client/metadata_utils.rs
@@ -62,10 +62,10 @@ impl<I: InvokeOnce> Intercept<I> for AttachHeadersInterceptor {
         for kv in self.md.iter() {
             match kv {
                 crate::metadata::KeyAndValueRef::Ascii(key, value) => {
-                    incoming_meta.append(key, value.clone())
+                    incoming_meta.append(key, value.clone());
                 }
                 crate::metadata::KeyAndValueRef::Binary(key, value) => {
-                    incoming_meta.append_bin(key, value.clone())
+                    incoming_meta.append_bin(key, value.clone());
                 }
             }
         }

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -262,7 +262,7 @@ impl<T: SendStream> DynSendStream for T {
     }
 }
 
-impl<'a> SendStream for Box<dyn DynSendStream + 'a> {
+impl SendStream for Box<dyn DynSendStream + '_> {
     async fn send(&mut self, msg: &dyn SendMessage, options: SendOptions) -> Result<(), ()> {
         (**self).dyn_send(msg, options).await
     }
@@ -361,7 +361,7 @@ impl<T: RecvStream> DynRecvStream for T {
     }
 }
 
-impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
+impl RecvStream for Box<dyn DynRecvStream + '_> {
     async fn recv(&mut self, msg: &mut dyn RecvMessage) -> ResponseStreamItem {
         (**self).dyn_recv(msg).await
     }

--- a/grpc/src/client/name_resolution/backoff.rs
+++ b/grpc/src/client/name_resolution/backoff.rs
@@ -78,7 +78,7 @@ impl BackoffConfig {
             Err("jitter must be greater than or equal to 0")?;
         }
         if self.jitter > 1.0 {
-            Err("jitter must be less than or equal to 1")?
+            Err("jitter must be less than or equal to 1")?;
         }
         Ok(())
     }

--- a/grpc/src/client/name_resolution/proxy_resolver.rs
+++ b/grpc/src/client/name_resolution/proxy_resolver.rs
@@ -216,7 +216,7 @@ struct InterceptingController<'a> {
     proxy_options: &'a Arc<ProxyOptions>,
 }
 
-impl<'a> ChannelController for InterceptingController<'a> {
+impl ChannelController for InterceptingController<'_> {
     fn update(&mut self, mut update: ResolverUpdate) -> Result<(), String> {
         if let Ok(endpoints) = &mut update.endpoints {
             for endpoint in endpoints {

--- a/grpc/src/client/name_resolution/test_utils.rs
+++ b/grpc/src/client/name_resolution/test_utils.rs
@@ -70,7 +70,7 @@ impl TestChannelController {
     }
 
     pub(crate) fn set_update_result(&mut self, update_result: Result<(), String>) {
-        self.update_result = update_result
+        self.update_result = update_result;
     }
 }
 

--- a/grpc/src/client/test_util.rs
+++ b/grpc/src/client/test_util.rs
@@ -116,7 +116,7 @@ impl<'a> ByteSendMsg<'a> {
         Self { data }
     }
 }
-impl<'a> SendMessage for ByteSendMsg<'a> {
+impl SendMessage for ByteSendMsg<'_> {
     fn encode(&self) -> Result<Box<dyn Buf + Send + Sync>, String> {
         Ok(Box::new(self.data.clone()))
     }

--- a/grpc/src/client/transport/registry.rs
+++ b/grpc/src/client/transport/registry.rs
@@ -42,7 +42,7 @@ impl Debug for TransportRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let m = self.inner.lock().unwrap();
         for key in m.keys() {
-            write!(f, "k: {key:?}")?
+            write!(f, "k: {key:?}")?;
         }
         Ok(())
     }

--- a/grpc/src/client/transport/tonic/test.rs
+++ b/grpc/src/client/transport/tonic/test.rs
@@ -1207,7 +1207,7 @@ async fn tonic_transport_recv_drop_sends_rst_stream() {
             None => {
                 panic!("Expected RST_STREAM, got clean close (EOS)");
             }
-        };
+        }
     });
 
     let builder = GLOBAL_TRANSPORT_REGISTRY
@@ -1254,5 +1254,5 @@ async fn tonic_transport_recv_drop_sends_rst_stream() {
 
     // Verify the send stream has ended.
     let req = WrappedEchoRequest(EchoRequest::default());
-    assert!(tx.send(&req, SendOptions::default()).await.is_err())
+    assert!(tx.send(&req, SendOptions::default()).await.is_err());
 }

--- a/grpc/src/credentials/rustls/client/mod.rs
+++ b/grpc/src/credentials/rustls/client/mod.rs
@@ -188,7 +188,7 @@ impl RustlsChannelCredentials {
         client_config.alpn_protocols = vec![ALPN_PROTO_STR_H2.to_vec()];
         client_config.resumption = rustls::client::Resumption::disabled();
         if let Some(path) = config.key_log_path {
-            client_config.key_log = Arc::new(KeyLogFile::new(&path))
+            client_config.key_log = Arc::new(KeyLogFile::new(&path));
         }
 
         Ok(RustlsChannelCredentials {

--- a/grpc/src/credentials/rustls/client/test.rs
+++ b/grpc/src/credentials/rustls/client/test.rs
@@ -569,7 +569,7 @@ async fn setup_server_multi_connection(
                         let _ = stream.shutdown().await;
                     }
                     Err(err) => {
-                        println!("TLS handshake failed: {}", err)
+                        println!("TLS handshake failed: {}", err);
                     }
                 }
             });

--- a/grpc/src/inmemory/mod.rs
+++ b/grpc/src/inmemory/mod.rs
@@ -255,9 +255,9 @@ pub struct InMemoryServerSendStream {
 }
 
 impl ServerSendStream for InMemoryServerSendStream {
-    async fn send<'a>(
+    async fn send(
         &mut self,
-        item: ServerResponseStreamItem<'a>,
+        item: ServerResponseStreamItem<'_>,
         _options: ServerSendOptions,
     ) -> Result<(), ()> {
         let inmemory_item = match item {

--- a/grpc/src/metadata/map.rs
+++ b/grpc/src/metadata/map.rs
@@ -103,7 +103,7 @@ where
     key: Option<MetadataKey<VE>>,
 }
 
-impl<'a, VE> Debug for ValueIter<'a, VE>
+impl<VE> Debug for ValueIter<'_, VE>
 where
     VE: ValueEncoding,
 {
@@ -124,7 +124,7 @@ pub struct GetAll<'a, VE> {
     key: Option<MetadataKey<VE>>,
 }
 
-impl<'a, VE> std::fmt::Debug for GetAll<'a, VE>
+impl<VE> std::fmt::Debug for GetAll<'_, VE>
 where
     VE: ValueEncoding,
 {
@@ -889,7 +889,7 @@ impl MetadataMap {
     where
         K: AsMetadataKey<Ascii>,
     {
-        key.remove_all(self, private::Internal)
+        key.remove_all(self, private::Internal);
     }
 
     /// Removes all entries matching the given binary key.
@@ -901,7 +901,7 @@ impl MetadataMap {
     where
         K: AsMetadataKey<Binary>,
     {
-        key.remove_all(self, private::Internal)
+        key.remove_all(self, private::Internal);
     }
 
     pub(crate) fn merge(&mut self, other: MetadataMap) {
@@ -1317,7 +1317,7 @@ impl<VE: ValueEncoding> AsMetadataKey<VE> for String {
     #[doc(hidden)]
     #[inline]
     fn remove_all(self, map: &mut MetadataMap, token: private::Internal) {
-        AsMetadataKey::<VE>::remove_all(self.as_str(), map, token)
+        AsMetadataKey::<VE>::remove_all(self.as_str(), map, token);
     }
 }
 
@@ -1343,7 +1343,7 @@ impl<VE: ValueEncoding> AsMetadataKey<VE> for &String {
     #[doc(hidden)]
     #[inline]
     fn remove_all(self, map: &mut MetadataMap, token: private::Internal) {
-        AsMetadataKey::<VE>::remove_all(self.as_str(), map, token)
+        AsMetadataKey::<VE>::remove_all(self.as_str(), map, token);
     }
 }
 

--- a/grpc/src/metadata/value.rs
+++ b/grpc/src/metadata/value.rs
@@ -562,13 +562,13 @@ impl Error for ToStrError {}
 
 impl Hash for MetadataValue<Ascii> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.data.hash(state)
+        self.inner.data.hash(state);
     }
 }
 
 impl Hash for MetadataValue<Binary> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.data.hash(state)
+        self.inner.data.hash(state);
     }
 }
 

--- a/grpc/src/rt/tokio/hickory_resolver.rs
+++ b/grpc/src/rt/tokio/hickory_resolver.rs
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(
             ips_hickory, system_resolver_ips,
             "both resolvers should produce same IPs for localhost"
-        )
+        );
     }
 
     #[tokio::test]
@@ -209,7 +209,7 @@ mod tests {
         let hickory_dns = super::DnsResolver::new(opts).unwrap();
         let ips = hickory_dns.lookup_host_name("test.local").await.unwrap();
         assert_eq!(ips, vec![Ipv4Addr::new(1, 2, 3, 4)]);
-        dns.shutdown().await
+        dns.shutdown().await;
     }
 
     struct FakeDns {

--- a/grpc/src/rt/tokio/mod.rs
+++ b/grpc/src/rt/tokio/mod.rs
@@ -79,7 +79,7 @@ pub(crate) struct TokioRuntime {
 
 impl TaskHandle for JoinHandle<()> {
     fn abort(&self) {
-        self.abort()
+        self.abort();
     }
 }
 
@@ -301,7 +301,7 @@ mod tests {
         assert!(
             !ips.is_empty(),
             "Expect localhost to resolve to more than 1 IPs."
-        )
+        );
     }
 
     #[tokio::test]
@@ -309,7 +309,7 @@ mod tests {
         let default_resolver = TokioDefaultDnsResolver::new(ResolverOptions::default()).unwrap();
 
         let txt = default_resolver.lookup_txt("google.com").await;
-        assert!(txt.is_err())
+        assert!(txt.is_err());
     }
 
     #[tokio::test]
@@ -318,6 +318,6 @@ mod tests {
             server_addr: Some("8.8.8.8:53".parse().unwrap()),
         };
         let default_resolver = TokioDefaultDnsResolver::new(opts);
-        assert!(default_resolver.is_err())
+        assert!(default_resolver.is_err());
     }
 }

--- a/grpc/src/server/builder.rs
+++ b/grpc/src/server/builder.rs
@@ -125,9 +125,9 @@ mod tests {
 
     struct MockSendStream;
     impl SendStream for MockSendStream {
-        async fn send<'a>(
+        async fn send(
             &mut self,
-            _item: ResponseStreamItem<'a>,
+            _item: ResponseStreamItem<'_>,
             _options: SendOptions,
         ) -> Result<(), ()> {
             Ok(())

--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -90,8 +90,8 @@ impl<T: Handle + Sized> HandleExt for T {}
 
 /// A no-op interceptor that simply delegates to the next handler.
 ///
-/// This is the default interceptor used by [`RouterBuilder`](crate::server::RouterBuilder)
-/// when no interceptor has been added.
+/// This is the default interceptor used by `RouterBuilder` when no interceptor
+/// has been added.
 #[derive(Clone, Copy)]
 pub struct Identity;
 
@@ -201,9 +201,9 @@ mod test {
 
     struct MockSendStream;
     impl SendStream for MockSendStream {
-        async fn send<'a>(
+        async fn send(
             &mut self,
-            _item: ResponseStreamItem<'a>,
+            _item: ResponseStreamItem<'_>,
             _options: SendOptions,
         ) -> Result<(), ()> {
             Ok(())

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -388,11 +388,7 @@ pub trait SendStream {
     /// This method is not intended to be cancellation safe.  If the returned
     /// future is not polled to completion, the behavior of any subsequent calls
     /// to the SendStream are undefined and data may be lost.
-    async fn send<'a>(
-        &mut self,
-        item: ResponseStreamItem<'a>,
-        options: SendOptions,
-    ) -> Result<(), ()>;
+    async fn send(&mut self, item: ResponseStreamItem<'_>, options: SendOptions) -> Result<(), ()>;
 }
 
 #[doc(hidden)]
@@ -416,22 +412,14 @@ impl<T: SendStream> DynSendStream for T {
     }
 }
 
-impl<'b> SendStream for &mut (dyn DynSendStream + 'b) {
-    async fn send<'a>(
-        &mut self,
-        item: ResponseStreamItem<'a>,
-        options: SendOptions,
-    ) -> Result<(), ()> {
+impl SendStream for &mut (dyn DynSendStream + '_) {
+    async fn send(&mut self, item: ResponseStreamItem<'_>, options: SendOptions) -> Result<(), ()> {
         (**self).dyn_send(item, options).await
     }
 }
 
-impl<'b> SendStream for Box<dyn DynSendStream + 'b> {
-    async fn send<'a>(
-        &mut self,
-        item: ResponseStreamItem<'a>,
-        options: SendOptions,
-    ) -> Result<(), ()> {
+impl SendStream for Box<dyn DynSendStream + '_> {
+    async fn send(&mut self, item: ResponseStreamItem<'_>, options: SendOptions) -> Result<(), ()> {
         (**self).dyn_send(item, options).await
     }
 }
@@ -478,7 +466,7 @@ impl<T: RecvStream> DynRecvStream for T {
     }
 }
 
-impl<'a> RecvStream for Box<dyn DynRecvStream + 'a> {
+impl RecvStream for Box<dyn DynRecvStream + '_> {
     async fn next(&mut self, msg: &mut dyn RecvMessage) -> Option<Result<(), ()>> {
         (**self).dyn_next(msg).await
     }
@@ -926,9 +914,9 @@ mod tests {
     struct NopSendStream;
 
     impl SendStream for NopSendStream {
-        async fn send<'a>(
+        async fn send(
             &mut self,
-            _item: ResponseStreamItem<'a>,
+            _item: ResponseStreamItem<'_>,
             _options: SendOptions,
         ) -> Result<(), ()> {
             Ok(())

--- a/grpc/src/server/router.rs
+++ b/grpc/src/server/router.rs
@@ -199,9 +199,9 @@ mod test {
 
     struct MockSendStream;
     impl SendStream for MockSendStream {
-        async fn send<'a>(
+        async fn send(
             &mut self,
-            _item: ResponseStreamItem<'a>,
+            _item: ResponseStreamItem<'_>,
             _options: SendOptions,
         ) -> Result<(), ()> {
             Ok(())

--- a/grpc/src/server/service.rs
+++ b/grpc/src/server/service.rs
@@ -119,9 +119,9 @@ mod tests {
 
     struct MockSendStream;
     impl SendStream for MockSendStream {
-        async fn send<'a>(
+        async fn send(
             &mut self,
-            _item: ResponseStreamItem<'a>,
+            _item: ResponseStreamItem<'_>,
             _options: SendOptions,
         ) -> Result<(), ()> {
             Ok(())


### PR DESCRIPTION
## Motivation

Clean up simple, non-invasive clippy warnings in the `grpc` crate so development and pre-commit checks don't trip on unrelated warnings.

## Solution

Resolve simple warnings across 4 categories in `grpc/src`:
- `clippy::semicolon_if_nothing_returned`: Add trailing semicolons on statements returning unit (`()`).
- `clippy::unnecessary_semicolon`: Remove redundant semicolons.
- `clippy::elidable_lifetime_names`: Elide redundant lifetime annotations on method implementations.

More complex lints (e.g. `clippy::large_enum_variant`) are deferred. 

These lints have been added to the Clippy configuration so they run in CICD now.