### PR TITLE
feat(tonic-xds): make outlier detection transport-agnostic

### DIFF
--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -1215,14 +1215,15 @@ mod tests {
         for _ in 0..100 {
             let _ = lb.call("hello").await;
         }
-        registry.run_housekeeping();
-        let _ = poll_ready_now(&mut lb);
 
-        assert_eq!(
-            lb.ejected.len(),
-            0,
-            "Ignore must record nothing, so no ejection can occur",
-        );
+        // Ignore records neither success nor failure, so the counters stay at
+        // zero. A "not ejected" check can't prove this: a classifier that
+        // recorded a success on each failing call would also never eject.
+        // `add_channel` is get-or-create, so this reads the state the load
+        // balancer has been recording into.
+        for port in 8080..=8084 {
+            assert_eq!(registry.add_channel(addr(port)).counters(), (0, 0));
+        }
     }
 
     #[tokio::test]

--- a/tonic-xds/src/client/loadbalance/loadbalancer.rs
+++ b/tonic-xds/src/client/loadbalance/loadbalancer.rs
@@ -68,6 +68,9 @@ use crate::client::loadbalance::channel_state::{
 };
 use crate::client::loadbalance::errors::LbError;
 use crate::client::loadbalance::keyed_futures::KeyedFutures;
+use crate::client::loadbalance::outcome::{
+    CallOutcome, HealthOutcome, OutcomeClassifier, OutcomeSource,
+};
 use crate::client::loadbalance::outlier_detection::{OutlierDetector, OutlierStatsRegistry};
 use crate::client::loadbalance::pickers::ChannelPicker;
 use crate::xds::resource::outlier_detection::OutlierDetectionConfig;
@@ -127,6 +130,11 @@ pub(crate) struct LoadBalancer<D, C: Connector, Req> {
     /// and nothing reads from `eject_rx`.
     outlier: OutlierDetector,
     picker: Arc<dyn ChannelPicker<ReadyChannel<C::Service>, Req> + Send + Sync>,
+    /// Transport-specific mapping of each call's result to an outlier-detection
+    /// health verdict. gRPC uses `GrpcOutcomeClassifier`; HTTP and other
+    /// transports inject their own so their status codes are interpreted
+    /// correctly.
+    outcome_classifier: Arc<dyn OutcomeClassifier>,
 }
 
 impl<D, C, Req> LoadBalancer<D, C, Req>
@@ -148,6 +156,7 @@ where
         connector: Arc<C>,
         picker: Arc<dyn ChannelPicker<ReadyChannel<C::Service>, Req> + Send + Sync>,
         config: Arc<ArcSwap<OutlierDetectionConfig>>,
+        outcome_classifier: Arc<dyn OutcomeClassifier>,
     ) -> Self {
         let (registry, eject_rx) = OutlierStatsRegistry::new(config);
         let outlier = OutlierDetector::new(registry, eject_rx);
@@ -160,6 +169,7 @@ where
             ejected: KeyedFutures::new(),
             outlier,
             picker,
+            outcome_classifier,
         }
     }
 
@@ -340,7 +350,7 @@ where
     D::Error: Into<tower::BoxError>,
     C: Connector + Send + Sync + 'static,
     C::Service: Service<Req> + Clone + Send + 'static,
-    <C::Service as Service<Req>>::Response: Send + 'static,
+    <C::Service as Service<Req>>::Response: Send + 'static + OutcomeSource,
     <C::Service as Service<Req>>::Error: Into<tower::BoxError>,
     <C::Service as Service<Req>>::Future: Send + 'static,
     Req: Send + 'static,
@@ -388,12 +398,23 @@ where
         // Cheap clone (all Arc-shared internals) so the async block
         // can take ownership without holding the picker borrow.
         let mut svc = picked.clone();
+        let classifier = Arc::clone(&self.outcome_classifier);
         LbFuture::Pending(Box::pin(async move {
             tower::ServiceExt::ready(&mut svc)
                 .await
                 .map_err(|e| LbError::LbChannelPollReadyError(e.into()))?;
             let result = svc.call(req).await;
-            svc.record_outcome(result.is_ok());
+            // The transport-specific classifier decides what this outcome means
+            // for outlier detection; `Ignore` records nothing (e.g. HTTP 4xx).
+            let outcome = match &result {
+                Ok(response) => response.call_outcome(),
+                Err(_) => CallOutcome::Error,
+            };
+            match classifier.classify(outcome) {
+                HealthOutcome::Success => svc.record_outcome(true),
+                HealthOutcome::Failure => svc.record_outcome(false),
+                HealthOutcome::Ignore => {}
+            }
             result.map_err(|e| LbError::LbChannelCallError(e.into()))
         }))
     }
@@ -410,6 +431,35 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use tokio::sync::mpsc;
     use tower::load::Load;
+
+    use crate::client::loadbalance::outcome::GrpcOutcomeClassifier;
+    use std::sync::LazyLock;
+
+    /// The `&'static str` mock responses carry no HTTP metadata, so they satisfy
+    /// the load balancer's `OutcomeSource` bound as a 200 with no headers — a
+    /// success under `GrpcOutcomeClassifier`, matching the pre-classifier
+    /// `record_outcome(result.is_ok())` behavior.
+    static EMPTY_HEADERS: LazyLock<http::HeaderMap> = LazyLock::new(http::HeaderMap::new);
+
+    impl OutcomeSource for &'static str {
+        fn call_outcome(&self) -> CallOutcome<'_> {
+            CallOutcome::Response {
+                status: http::StatusCode::OK,
+                headers: &EMPTY_HEADERS,
+            }
+        }
+    }
+
+    /// Classifier returning a fixed verdict, so tests can assert the LB records
+    /// exactly what the classifier says regardless of the transport result.
+    #[derive(Debug)]
+    struct FixedClassifier(HealthOutcome);
+
+    impl OutcomeClassifier for FixedClassifier {
+        fn classify(&self, _outcome: CallOutcome<'_>) -> HealthOutcome {
+            self.0
+        }
+    }
 
     // -- Mock service --
 
@@ -547,7 +597,13 @@ mod tests {
         let picker: Arc<dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync> =
             Arc::new(P2cPicker);
         let config = Arc::new(ArcSwap::from_pointee(OutlierDetectionConfig::default()));
-        let lb = LoadBalancer::new(discover, connector.clone(), picker, config);
+        let lb = LoadBalancer::new(
+            discover,
+            connector.clone(),
+            picker,
+            config,
+            Arc::new(GrpcOutcomeClassifier),
+        );
         (lb, connector)
     }
 
@@ -599,7 +655,13 @@ mod tests {
         let picker: Arc<dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync> =
             Arc::new(RecordingPicker { seen: seen.clone() });
         let config = Arc::new(ArcSwap::from_pointee(OutlierDetectionConfig::default()));
-        let lb = LoadBalancer::new(discover, connector, picker, config);
+        let lb = LoadBalancer::new(
+            discover,
+            connector,
+            picker,
+            config,
+            Arc::new(GrpcOutcomeClassifier),
+        );
         (lb, seen)
     }
 
@@ -1011,11 +1073,21 @@ mod tests {
         discover: MockDiscover,
         config: OutlierDetectionConfig,
     ) -> (Lb, Arc<MockConnector>, Arc<OutlierStatsRegistry>) {
+        make_lb_with_classifier(discover, config, Arc::new(GrpcOutcomeClassifier))
+    }
+
+    /// Like [`make_lb_with_outlier`], but with a caller-supplied outcome
+    /// classifier so tests can exercise the transport-agnostic seam.
+    fn make_lb_with_classifier(
+        discover: MockDiscover,
+        config: OutlierDetectionConfig,
+        classifier: Arc<dyn OutcomeClassifier>,
+    ) -> (Lb, Arc<MockConnector>, Arc<OutlierStatsRegistry>) {
         let connector = Arc::new(MockConnector::new());
         let picker: Arc<dyn ChannelPicker<ReadyChannel<MockService>, &'static str> + Send + Sync> =
             Arc::new(P2cPicker);
         let config = Arc::new(ArcSwap::from_pointee(config));
-        let lb = LoadBalancer::new(discover, connector.clone(), picker, config);
+        let lb = LoadBalancer::new(discover, connector.clone(), picker, config, classifier);
         let registry = lb.outlier.registry().clone();
         (lb, connector, registry)
     }
@@ -1078,6 +1150,79 @@ mod tests {
         assert!(!lb.ready.contains_key(&addr(8084)));
         // The registry's `ejected_count` should reflect the same.
         assert!(registry.len() == 5);
+    }
+
+    #[tokio::test]
+    async fn outcome_classifier_failure_ejects_despite_transport_success() {
+        // Every transport call succeeds ("ok"), but a Failure-returning
+        // classifier makes outlier detection treat each as a failure — proving
+        // the ejection signal now comes from the classifier, not `is_ok()`.
+        let (tx, discover) = new_discover();
+        let (mut lb, connector, registry) = make_lb_with_classifier(
+            discover,
+            fp_config(
+                /*threshold*/ 50, /*request_volume*/ 5, /*minimum_hosts*/ 3,
+            ),
+            Arc::new(FixedClassifier(HealthOutcome::Failure)),
+        );
+
+        for port in 8080..=8084 {
+            tx.send(Ok(Change::Insert(addr(port), IdleChannel::new(addr(port)))))
+                .await
+                .unwrap();
+        }
+        drive_to_ready(&mut lb, &connector).await;
+
+        for _ in 0..100 {
+            lb.call("hello").await.unwrap();
+        }
+        registry.run_housekeeping();
+        let _ = poll_ready_now(&mut lb);
+
+        assert!(
+            lb.ejected.len() >= 1,
+            "a success classified as Failure should drive ejection",
+        );
+    }
+
+    #[tokio::test]
+    async fn outcome_classifier_ignore_records_nothing() {
+        // Every transport call fails, but an Ignore-returning classifier records
+        // neither success nor failure, so no endpoint is ever ejected.
+        let (tx, discover) = new_discover();
+        let (mut lb, connector, registry) = make_lb_with_classifier(
+            discover,
+            fp_config(
+                /*threshold*/ 50, /*request_volume*/ 5, /*minimum_hosts*/ 3,
+            ),
+            Arc::new(FixedClassifier(HealthOutcome::Ignore)),
+        );
+
+        for port in 8080..=8084 {
+            tx.send(Ok(Change::Insert(addr(port), IdleChannel::new(addr(port)))))
+                .await
+                .unwrap();
+        }
+        drive_to_ready(&mut lb, &connector).await;
+        // Every endpoint fails at the transport level.
+        for port in 8080..=8084 {
+            connector
+                .service(&addr(port))
+                .fail_call
+                .store(true, Ordering::Relaxed);
+        }
+
+        for _ in 0..100 {
+            let _ = lb.call("hello").await;
+        }
+        registry.run_housekeeping();
+        let _ = poll_ready_now(&mut lb);
+
+        assert_eq!(
+            lb.ejected.len(),
+            0,
+            "Ignore must record nothing, so no ejection can occur",
+        );
     }
 
     #[tokio::test]

--- a/tonic-xds/src/client/loadbalance/mod.rs
+++ b/tonic-xds/src/client/loadbalance/mod.rs
@@ -27,5 +27,6 @@ pub(crate) mod channel_state;
 pub(crate) mod errors;
 pub(crate) mod keyed_futures;
 pub(crate) mod loadbalancer;
+pub(crate) mod outcome;
 pub(crate) mod outlier_detection;
 pub(crate) mod pickers;

--- a/tonic-xds/src/client/loadbalance/outcome.rs
+++ b/tonic-xds/src/client/loadbalance/outcome.rs
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2025 gRPC authors.
+ * Copyright 2026 gRPC authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/tonic-xds/src/client/loadbalance/outcome.rs
+++ b/tonic-xds/src/client/loadbalance/outcome.rs
@@ -1,0 +1,174 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+//! Transport-agnostic outcome classification for outlier detection.
+//!
+//! The load balancer records a per-call success/failure signal into outlier
+//! detection. What counts as a failure is transport-specific, so the decision
+//! is delegated to a pluggable [`OutcomeClassifier`] — mirroring the retry
+//! layer's [`RetryClassifier`](crate::RetryClassifier). The built-in
+//! [`GrpcOutcomeClassifier`] interprets gRPC status; a non-gRPC transport (e.g.
+//! plain HTTP) supplies its own to interpret HTTP status codes without touching
+//! the outlier-detection engine.
+
+/// Borrowed view of one endpoint call's result, handed to
+/// [`OutcomeClassifier::classify`]. It carries no error payload — outlier
+/// detection only needs to know that a call errored, not why — so it works with
+/// the load balancer's generic endpoint error type.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum CallOutcome<'a> {
+    /// The endpoint produced a response; inspect `status`/`headers` (e.g. gRPC's
+    /// trailers-only `grpc-status`) to decide.
+    Response {
+        /// The response status.
+        status: http::StatusCode,
+        /// The response headers.
+        headers: &'a http::HeaderMap,
+    },
+    /// The endpoint failed before producing a usable response (e.g. a
+    /// connection-level error).
+    Error,
+}
+
+/// The health verdict for a single call, recorded by outlier detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthOutcome {
+    /// Count the call as a success.
+    Success,
+    /// Count the call as a failure.
+    Failure,
+    /// Do not record the call — it reflects neither upstream health nor fault
+    /// (e.g. HTTP `4xx` client errors).
+    Ignore,
+}
+
+/// Maps a transport [`CallOutcome`] to a [`HealthOutcome`] for outlier
+/// detection.
+///
+/// This is the transport seam for OD accounting: the built-in
+/// [`GrpcOutcomeClassifier`] interprets gRPC status, while a non-gRPC transport
+/// (e.g. plain HTTP) supplies its own to interpret HTTP status codes (`5xx` =
+/// failure, `4xx` = ignore, ...) without touching the outlier-detection engine.
+pub trait OutcomeClassifier: Send + Sync + 'static {
+    /// Classify a single endpoint call outcome.
+    fn classify(&self, outcome: CallOutcome<'_>) -> HealthOutcome;
+}
+
+/// gRPC outcome classifier. A transport error or a non-2xx HTTP status is a
+/// failure; on a 2xx response the `grpc-status` header decides — absent or `0`
+/// is a success, and any other value (including an unparseable one) is a failure
+/// (tonic emits trailers-only errors as HTTP 200 with `grpc-status` in the
+/// leading headers).
+#[derive(Debug, Default, Clone)]
+pub struct GrpcOutcomeClassifier;
+
+impl OutcomeClassifier for GrpcOutcomeClassifier {
+    fn classify(&self, outcome: CallOutcome<'_>) -> HealthOutcome {
+        match outcome {
+            CallOutcome::Error => HealthOutcome::Failure,
+            CallOutcome::Response { status, headers } => {
+                if !status.is_success() {
+                    return HealthOutcome::Failure;
+                }
+                let ok = headers
+                    .get("grpc-status")
+                    .is_none_or(|v| v.to_str().ok().and_then(|s| s.parse::<u32>().ok()) == Some(0));
+                if ok {
+                    HealthOutcome::Success
+                } else {
+                    HealthOutcome::Failure
+                }
+            }
+        }
+    }
+}
+
+/// Extracts a [`CallOutcome`] from an endpoint response so the load balancer can
+/// classify outcomes while staying generic over the response body. Implemented
+/// for [`http::Response`]; the whole xDS data plane is HTTP-typed.
+pub(crate) trait OutcomeSource {
+    /// Borrow this response as a [`CallOutcome`].
+    fn call_outcome(&self) -> CallOutcome<'_>;
+}
+
+impl<B> OutcomeSource for http::Response<B> {
+    fn call_outcome(&self) -> CallOutcome<'_> {
+        CallOutcome::Response {
+            status: self.status(),
+            headers: self.headers(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response(status: u16, grpc_status: Option<&str>) -> http::Response<()> {
+        let mut builder = http::Response::builder().status(status);
+        if let Some(code) = grpc_status {
+            builder = builder.header("grpc-status", code);
+        }
+        builder.body(()).unwrap()
+    }
+
+    fn classify(status: u16, grpc_status: Option<&str>) -> HealthOutcome {
+        GrpcOutcomeClassifier.classify(response(status, grpc_status).call_outcome())
+    }
+
+    #[test]
+    fn grpc_transport_error_is_failure() {
+        assert_eq!(
+            GrpcOutcomeClassifier.classify(CallOutcome::Error),
+            HealthOutcome::Failure
+        );
+    }
+
+    #[test]
+    fn grpc_ok_without_status_is_success() {
+        assert_eq!(classify(200, None), HealthOutcome::Success);
+    }
+
+    #[test]
+    fn grpc_trailers_only_zero_is_success() {
+        assert_eq!(classify(200, Some("0")), HealthOutcome::Success);
+    }
+
+    #[test]
+    fn grpc_trailers_only_nonzero_is_failure() {
+        // 13 = INTERNAL.
+        assert_eq!(classify(200, Some("13")), HealthOutcome::Failure);
+    }
+
+    #[test]
+    fn grpc_unparseable_status_is_failure() {
+        assert_eq!(classify(200, Some("not-a-number")), HealthOutcome::Failure);
+    }
+
+    #[test]
+    fn grpc_non_2xx_is_failure() {
+        assert_eq!(classify(503, None), HealthOutcome::Failure);
+    }
+}

--- a/tonic-xds/src/client/loadbalance/outcome.rs
+++ b/tonic-xds/src/client/loadbalance/outcome.rs
@@ -77,10 +77,11 @@ pub trait OutcomeClassifier: Send + Sync + 'static {
 }
 
 /// gRPC outcome classifier. A transport error or a non-2xx HTTP status is a
-/// failure; on a 2xx response the `grpc-status` header decides — absent or `0`
-/// is a success, and any other value (including an unparseable one) is a failure
-/// (tonic emits trailers-only errors as HTTP 200 with `grpc-status` in the
-/// leading headers).
+/// failure; on a 2xx response the `grpc-status` in the leading headers decides.
+/// Decoding is deferred to [`tonic::Status::from_header_map`] so the verdict
+/// matches how the RPC actually resolves — e.g. `grpc-status: 00` is not a valid
+/// `0` and tonic maps it to `Unknown`, a failure. An absent `grpc-status`
+/// (anything that isn't trailers-only) is treated as a success.
 #[derive(Debug, Default, Clone)]
 pub struct GrpcOutcomeClassifier;
 
@@ -92,13 +93,10 @@ impl OutcomeClassifier for GrpcOutcomeClassifier {
                 if !status.is_success() {
                     return HealthOutcome::Failure;
                 }
-                let ok = headers
-                    .get("grpc-status")
-                    .is_none_or(|v| v.to_str().ok().and_then(|s| s.parse::<u32>().ok()) == Some(0));
-                if ok {
-                    HealthOutcome::Success
-                } else {
-                    HealthOutcome::Failure
+                match tonic::Status::from_header_map(headers) {
+                    None => HealthOutcome::Success,
+                    Some(s) if s.code() == tonic::Code::Ok => HealthOutcome::Success,
+                    Some(_) => HealthOutcome::Failure,
                 }
             }
         }
@@ -165,6 +163,13 @@ mod tests {
     #[test]
     fn grpc_unparseable_status_is_failure() {
         assert_eq!(classify(200, Some("not-a-number")), HealthOutcome::Failure);
+    }
+
+    #[test]
+    fn grpc_leading_zero_status_is_failure() {
+        // "00" is not a valid grpc-status `0`; tonic decodes it to Unknown, so
+        // the RPC fails and OD must not count it as a success.
+        assert_eq!(classify(200, Some("00")), HealthOutcome::Failure);
     }
 
     #[test]

--- a/tonic-xds/src/client/loadbalance/outcome.rs
+++ b/tonic-xds/src/client/loadbalance/outcome.rs
@@ -31,14 +31,17 @@
 //! [`GrpcOutcomeClassifier`] interprets gRPC status; a non-gRPC transport (e.g.
 //! plain HTTP) supplies its own to interpret HTTP status codes without touching
 //! the outlier-detection engine.
+//!
+//! The seam is crate-internal for now: nothing outside the crate can inject a
+//! classifier yet. The public builder hook (and the final `#[non_exhaustive]`
+//! shaping of these types) lands with the outlier-detection `Discover` wiring.
 
 /// Borrowed view of one endpoint call's result, handed to
 /// [`OutcomeClassifier::classify`]. It carries no error payload — outlier
 /// detection only needs to know that a call errored, not why — so it works with
 /// the load balancer's generic endpoint error type.
-#[non_exhaustive]
 #[derive(Debug)]
-pub enum CallOutcome<'a> {
+pub(crate) enum CallOutcome<'a> {
     /// The endpoint produced a response; inspect `status`/`headers` (e.g. gRPC's
     /// trailers-only `grpc-status`) to decide.
     Response {
@@ -54,7 +57,7 @@ pub enum CallOutcome<'a> {
 
 /// The health verdict for a single call, recorded by outlier detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HealthOutcome {
+pub(crate) enum HealthOutcome {
     /// Count the call as a success.
     Success,
     /// Count the call as a failure.
@@ -71,7 +74,7 @@ pub enum HealthOutcome {
 /// [`GrpcOutcomeClassifier`] interprets gRPC status, while a non-gRPC transport
 /// (e.g. plain HTTP) supplies its own to interpret HTTP status codes (`5xx` =
 /// failure, `4xx` = ignore, ...) without touching the outlier-detection engine.
-pub trait OutcomeClassifier: Send + Sync + 'static {
+pub(crate) trait OutcomeClassifier: Send + Sync + 'static {
     /// Classify a single endpoint call outcome.
     fn classify(&self, outcome: CallOutcome<'_>) -> HealthOutcome;
 }
@@ -83,7 +86,7 @@ pub trait OutcomeClassifier: Send + Sync + 'static {
 /// `0` and tonic maps it to `Unknown`, a failure. An absent `grpc-status`
 /// (anything that isn't trailers-only) is treated as a success.
 #[derive(Debug, Default, Clone)]
-pub struct GrpcOutcomeClassifier;
+pub(crate) struct GrpcOutcomeClassifier;
 
 impl OutcomeClassifier for GrpcOutcomeClassifier {
     fn classify(&self, outcome: CallOutcome<'_>) -> HealthOutcome {

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -206,9 +206,6 @@ pub use client::channel::{
 pub use client::endpoint::{
     ClusterConfig, Connector, EndpointAddress, EndpointChannel, MakeConnector,
 };
-pub use client::loadbalance::outcome::{
-    CallOutcome, GrpcOutcomeClassifier, HealthOutcome, OutcomeClassifier,
-};
 pub use client::retry::{
     GrpcRetryClassifierFactory, RetryClassifier, RetryClassifierFactory, RetryOutcome,
     is_retryable_connection_error,

--- a/tonic-xds/src/lib.rs
+++ b/tonic-xds/src/lib.rs
@@ -206,6 +206,9 @@ pub use client::channel::{
 pub use client::endpoint::{
     ClusterConfig, Connector, EndpointAddress, EndpointChannel, MakeConnector,
 };
+pub use client::loadbalance::outcome::{
+    CallOutcome, GrpcOutcomeClassifier, HealthOutcome, OutcomeClassifier,
+};
 pub use client::retry::{
     GrpcRetryClassifierFactory, RetryClassifier, RetryClassifierFactory, RetryOutcome,
     is_retryable_connection_error,


### PR DESCRIPTION
## Motivation

Outlier detection records a per-call success/failure via `svc.record_outcome(result.is_ok())` — a transport-level signal that counts an `Ok(503)` or a gRPC trailers-only error (`200` + `grpc-status != 0`) as a success. That is wrong for a non-gRPC transport, so a plain-HTTP consumer (e.g. an xDS HTTP data plane) cannot use OD correctly. 

## Solution

Introduce a pluggable `OutcomeClassifier` seam so the transport decides what a call outcome means for OD.

Scope: this is the classification seam only. Threading the classifier through `XdsChannelBuilder` and the OD `Discover` is deferred to a follow-up, since the OD load balancer is not yet on the production channel path.

## Testing Done

- 6 `GrpcOutcomeClassifier` unit tests (transport error; 2xx without status; trailers-only `0` / non-zero / unparseable; non-2xx).
- 2 load-balancer wiring tests: a `Failure` verdict ejects an endpoint whose transport calls all succeed; an `Ignore` verdict never ejects endpoints whose transport calls all fail.
- Full `tonic-xds` lib suite green (423 tests); clippy clean (default and `--all-features`); rustdoc intra-doc links resolve.
