### PR TITLE
tonic: add in-process unary round-trip benchmark

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -99,6 +99,7 @@ tokio-util = "0.7"
 
 [dev-dependencies]
 bencher = "0.1.5"
+criterion = "0.8"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 static_assertions = "1.0"
@@ -141,3 +142,7 @@ allowed_external_types = [
 [[bench]]
 harness = false
 name = "decode"
+
+[[bench]]
+name = "unary"
+harness = false

--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -146,3 +146,7 @@ name = "decode"
 [[bench]]
 name = "unary"
 harness = false
+
+[[bench]]
+harness = false
+name = "unary_allocs"

--- a/tonic/benches/unary.rs
+++ b/tonic/benches/unary.rs
@@ -21,188 +21,26 @@
  * IN THE SOFTWARE.
  *
  */
-#![expect(missing_docs, reason = "benchmark crate has no public API")]
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::convert::Infallible;
-use std::future::{Future, Ready, ready};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::task::{Context, Poll};
+//! Wall-clock cost of an in-process unary round trip.
+//!
+//! This target runs on the system allocator so nothing instruments the timed
+//! region. Allocations per RPC are measured by the separate `unary_allocs`
+//! target, which installs a counting allocator in its own process.
 
-use bytes::{Buf, BufMut, Bytes};
+mod unary_support;
+
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use http::uri::PathAndQuery;
-use tonic::body::Body;
-use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
-use tower_service::Service;
 
-const SIZES: [usize; 3] = [16, 1024, 65536];
-
-static COUNT: AtomicUsize = AtomicUsize::new(0);
-static BYTES: AtomicUsize = AtomicUsize::new(0);
-
-struct Counting;
-
-#[global_allocator]
-static ALLOCATOR: Counting = Counting;
-
-// Keep allocation counts separate from deallocation counts so each RPC delta is
-// independent of when its response is dropped.
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        COUNT.fetch_add(1, Ordering::Relaxed);
-        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
-        unsafe { System.alloc(layout) }
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        COUNT.fetch_add(1, Ordering::Relaxed);
-        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
-        unsafe { System.alloc_zeroed(layout) }
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        COUNT.fetch_add(1, Ordering::Relaxed);
-        BYTES.fetch_add(new_size, Ordering::Relaxed);
-        unsafe { System.realloc(ptr, layout, new_size) }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct BytesCodec;
-
-impl Codec for BytesCodec {
-    type Encode = Bytes;
-    type Decode = Bytes;
-    type Encoder = Self;
-    type Decoder = Self;
-
-    fn encoder(&mut self) -> Self::Encoder {
-        Self
-    }
-
-    fn decoder(&mut self) -> Self::Decoder {
-        Self
-    }
-}
-
-impl Encoder for BytesCodec {
-    type Item = Bytes;
-    type Error = tonic::Status;
-
-    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
-        dst.reserve(item.len());
-        dst.put(item);
-        Ok(())
-    }
-}
-
-impl Decoder for BytesCodec {
-    type Item = Bytes;
-    type Error = tonic::Status;
-
-    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
-        Ok(Some(src.copy_to_bytes(src.remaining())))
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct Echo;
-
-impl Service<tonic::Request<Bytes>> for Echo {
-    type Response = tonic::Response<Bytes>;
-    type Error = tonic::Status;
-    type Future = Ready<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, request: tonic::Request<Bytes>) -> Self::Future {
-        ready(Ok(tonic::Response::new(request.into_inner())))
-    }
-}
-
-struct Loopback;
-
-impl Service<http::Request<Body>> for Loopback {
-    type Response = http::Response<Body>;
-    type Error = Infallible;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
-        Box::pin(async move {
-            Ok(tonic::server::Grpc::new(BytesCodec)
-                .unary(Echo, request)
-                .await)
-        })
-    }
-}
-
-async fn one_rpc(client: &mut tonic::client::Grpc<Loopback>, payload: &Bytes) -> Bytes {
-    client
-        .unary(
-            tonic::Request::new(payload.clone()),
-            PathAndQuery::from_static("/bench.Echo/Unary"),
-            BytesCodec,
-        )
-        .await
-        .unwrap()
-        .into_inner()
-}
-
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-}
-
-fn report_allocations() {
-    for size in SIZES {
-        let payload = Bytes::from(vec![0xAB; size]);
-        let mut client = tonic::client::Grpc::new(Loopback);
-        let runtime = runtime();
-
-        for _ in 0..200 {
-            let _ = runtime.block_on(one_rpc(&mut client, &payload));
-        }
-
-        let count = COUNT.load(Ordering::Relaxed);
-        let bytes = BYTES.load(Ordering::Relaxed);
-
-        for _ in 0..1000 {
-            let _ = runtime.block_on(one_rpc(&mut client, &payload));
-        }
-
-        let d_count = COUNT.load(Ordering::Relaxed) - count;
-        let d_bytes = BYTES.load(Ordering::Relaxed) - bytes;
-        eprintln!(
-            "unary/{size}: {} allocs/rpc, {} bytes/rpc",
-            d_count / 1000,
-            d_bytes / 1000
-        );
-    }
-}
+use unary_support::{SIZES, client, one_rpc, payload, runtime};
 
 fn bench_unary(c: &mut Criterion) {
-    report_allocations();
-
     let mut group = c.benchmark_group("unary");
     for size in SIZES {
         group.throughput(Throughput::Bytes(size as u64));
 
-        let payload = Bytes::from(vec![0xAB; size]);
-        let mut client = tonic::client::Grpc::new(Loopback);
+        let payload = payload(size);
+        let mut client = client();
         let runtime = runtime();
         let response = runtime.block_on(one_rpc(&mut client, &payload));
         assert_eq!(response, payload);

--- a/tonic/benches/unary.rs
+++ b/tonic/benches/unary.rs
@@ -1,0 +1,218 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+#![expect(missing_docs, reason = "benchmark crate has no public API")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::convert::Infallible;
+use std::future::{Future, Ready, ready};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use bytes::{Buf, BufMut, Bytes};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use http::uri::PathAndQuery;
+use tonic::body::Body;
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tower_service::Service;
+
+const SIZES: [usize; 3] = [16, 1024, 65536];
+
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+// Keep allocation counts separate from deallocation counts so each RPC delta is
+// independent of when its response is dropped.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(new_size, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BytesCodec;
+
+impl Codec for BytesCodec {
+    type Encode = Bytes;
+    type Decode = Bytes;
+    type Encoder = Self;
+    type Decoder = Self;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        Self
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        Self
+    }
+}
+
+impl Encoder for BytesCodec {
+    type Item = Bytes;
+    type Error = tonic::Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        dst.reserve(item.len());
+        dst.put(item);
+        Ok(())
+    }
+}
+
+impl Decoder for BytesCodec {
+    type Item = Bytes;
+    type Error = tonic::Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(Some(src.copy_to_bytes(src.remaining())))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Echo;
+
+impl Service<tonic::Request<Bytes>> for Echo {
+    type Response = tonic::Response<Bytes>;
+    type Error = tonic::Status;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: tonic::Request<Bytes>) -> Self::Future {
+        ready(Ok(tonic::Response::new(request.into_inner())))
+    }
+}
+
+struct Loopback;
+
+impl Service<http::Request<Body>> for Loopback {
+    type Response = http::Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
+        Box::pin(async move {
+            Ok(tonic::server::Grpc::new(BytesCodec)
+                .unary(Echo, request)
+                .await)
+        })
+    }
+}
+
+async fn one_rpc(client: &mut tonic::client::Grpc<Loopback>, payload: &Bytes) -> Bytes {
+    client
+        .unary(
+            tonic::Request::new(payload.clone()),
+            PathAndQuery::from_static("/bench.Echo/Unary"),
+            BytesCodec,
+        )
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn report_allocations() {
+    for size in SIZES {
+        let payload = Bytes::from(vec![0xAB; size]);
+        let mut client = tonic::client::Grpc::new(Loopback);
+        let runtime = runtime();
+
+        for _ in 0..200 {
+            let _ = runtime.block_on(one_rpc(&mut client, &payload));
+        }
+
+        let count = COUNT.load(Ordering::Relaxed);
+        let bytes = BYTES.load(Ordering::Relaxed);
+
+        for _ in 0..1000 {
+            let _ = runtime.block_on(one_rpc(&mut client, &payload));
+        }
+
+        let d_count = COUNT.load(Ordering::Relaxed) - count;
+        let d_bytes = BYTES.load(Ordering::Relaxed) - bytes;
+        eprintln!(
+            "unary/{size}: {} allocs/rpc, {} bytes/rpc",
+            d_count / 1000,
+            d_bytes / 1000
+        );
+    }
+}
+
+fn bench_unary(c: &mut Criterion) {
+    report_allocations();
+
+    let mut group = c.benchmark_group("unary");
+    for size in SIZES {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        let payload = Bytes::from(vec![0xAB; size]);
+        let mut client = tonic::client::Grpc::new(Loopback);
+        let runtime = runtime();
+        let response = runtime.block_on(one_rpc(&mut client, &payload));
+        assert_eq!(response, payload);
+
+        group.bench_with_input(size.to_string(), &payload, |b, payload| {
+            b.iter(|| runtime.block_on(one_rpc(&mut client, payload)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_unary);
+criterion_main!(benches);

--- a/tonic/benches/unary_allocs.rs
+++ b/tonic/benches/unary_allocs.rs
@@ -1,0 +1,130 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+//! Allocations per in-process unary RPC.
+//!
+//! A counting global allocator cannot share a process with a timed benchmark:
+//! it adds two atomic read-modify-writes to every allocation. So this census
+//! lives in its own `harness = false` target and reports no timings. Wall-clock
+//! cost is measured by the separate `unary` target.
+
+mod unary_support;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use unary_support::{SIZES, client, one_rpc, payload, runtime};
+
+/// RPCs run before the counters are read, so steady-state buffer growth is not
+/// charged to the measured window.
+const WARMUP_RPCS: usize = 200;
+
+/// RPCs spanned by the measured window.
+const MEASURED_RPCS: usize = 1000;
+
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+// Allocation counts stay separate from deallocation counts, so each RPC delta
+// is independent of when its response is dropped.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(new_size, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+/// Totals for one payload size. Per-RPC figures are integer quotients, so the
+/// totals are reported alongside them to keep a fractional count visible.
+struct Census {
+    size: usize,
+    allocs: usize,
+    bytes: usize,
+}
+
+fn census(size: usize) -> Census {
+    let payload = payload(size);
+    let mut client = client();
+    let runtime = runtime();
+
+    let response = runtime.block_on(one_rpc(&mut client, &payload));
+    assert_eq!(
+        response, payload,
+        "census must measure a working round trip"
+    );
+
+    for _ in 0..WARMUP_RPCS {
+        let _ = runtime.block_on(one_rpc(&mut client, &payload));
+    }
+
+    let allocs_before = COUNT.load(Ordering::Relaxed);
+    let bytes_before = BYTES.load(Ordering::Relaxed);
+
+    for _ in 0..MEASURED_RPCS {
+        let _ = runtime.block_on(one_rpc(&mut client, &payload));
+    }
+
+    Census {
+        size,
+        allocs: COUNT.load(Ordering::Relaxed) - allocs_before,
+        bytes: BYTES.load(Ordering::Relaxed) - bytes_before,
+    }
+}
+
+fn main() {
+    for size in SIZES {
+        let Census {
+            size,
+            allocs,
+            bytes,
+        } = census(size);
+        println!(
+            "unary/{size}: {allocs_per_rpc} allocs/rpc, {bytes_per_rpc} bytes/rpc \
+             ({allocs} allocs and {bytes} bytes over {MEASURED_RPCS} rpcs)",
+            allocs_per_rpc = allocs / MEASURED_RPCS,
+            bytes_per_rpc = bytes / MEASURED_RPCS,
+        );
+    }
+}

--- a/tonic/benches/unary_support/mod.rs
+++ b/tonic/benches/unary_support/mod.rs
@@ -1,0 +1,148 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+//! Shared in-process harness for the two unary benches.
+//!
+//! `unary` measures wall-clock time and runs on the system allocator.
+//! `unary_allocs` installs a counting global allocator and reports allocations
+//! per RPC. The two must not share a process: a counting allocator adds two
+//! atomic read-modify-writes to every allocation, which taxes a timed region
+//! and makes the timing untrustworthy.
+
+use std::convert::Infallible;
+use std::future::{Future, Ready, ready};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, BufMut, Bytes};
+use http::uri::PathAndQuery;
+use tonic::body::Body;
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tower_service::Service;
+
+/// 16 bytes sits below the 8 KiB initial codec buffer, 65536 above it. 1024
+/// stays below both that buffer and the 32 KiB yield threshold.
+pub(crate) const SIZES: [usize; 3] = [16, 1024, 65536];
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BytesCodec;
+
+impl Codec for BytesCodec {
+    type Encode = Bytes;
+    type Decode = Bytes;
+    type Encoder = Self;
+    type Decoder = Self;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        Self
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        Self
+    }
+}
+
+impl Encoder for BytesCodec {
+    type Item = Bytes;
+    type Error = tonic::Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        dst.reserve(item.len());
+        dst.put(item);
+        Ok(())
+    }
+}
+
+impl Decoder for BytesCodec {
+    type Item = Bytes;
+    type Error = tonic::Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(Some(src.copy_to_bytes(src.remaining())))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Echo;
+
+impl Service<tonic::Request<Bytes>> for Echo {
+    type Response = tonic::Response<Bytes>;
+    type Error = tonic::Status;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: tonic::Request<Bytes>) -> Self::Future {
+        ready(Ok(tonic::Response::new(request.into_inner())))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Loopback;
+
+impl Service<http::Request<Body>> for Loopback {
+    type Response = http::Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
+        Box::pin(async move {
+            Ok(tonic::server::Grpc::new(BytesCodec)
+                .unary(Echo, request)
+                .await)
+        })
+    }
+}
+
+pub(crate) fn payload(size: usize) -> Bytes {
+    Bytes::from(vec![0xAB; size])
+}
+
+pub(crate) fn client() -> tonic::client::Grpc<Loopback> {
+    tonic::client::Grpc::new(Loopback)
+}
+
+pub(crate) fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+pub(crate) async fn one_rpc(client: &mut tonic::client::Grpc<Loopback>, payload: &Bytes) -> Bytes {
+    client
+        .unary(
+            tonic::Request::new(payload.clone()),
+            PathAndQuery::from_static("/bench.Echo/Unary"),
+            BytesCodec,
+        )
+        .await
+        .unwrap()
+        .into_inner()
+}


### PR DESCRIPTION
## Motivation

Refs #2832

Issue #2832 reports a fixed per-RPC cost in `Grpc::unary`. The existing decode benchmark measures decoding only. `grpc-benchmark` measures a full network path through hyper, h2, and sockets. This PR adds an in-process unary benchmark for the codec, status, and trailer path.

## Solution

The PR adds Criterion 0.8 and two bench targets with `harness = false`:

- `tonic/benches/unary.rs` measures time with the normal system allocator.
- `tonic/benches/unary_allocs.rs` counts allocations in a separate binary and calls no Criterion timing API.

Both targets use the shared fixture in `tonic/benches/unary_support/mod.rs`. It connects `tonic::client::Grpc` directly to `tonic::server::Grpc` through `Loopback`, a `BytesCodec`, and an `Echo` handler. Each RPC returns the same `Bytes` payload without hyper, h2, sockets, or a network. Both targets check payload equality outside measurement.

The Criterion group covers payloads of 16, 1024, and 65536 bytes with `Throughput::Bytes`. The census uses 200 warm-up RPCs and 1000 measured RPCs per size. Only the census binary links the counting allocator. Allocation counters therefore do not affect the timed loop.

Default features suffice. Both targets also build with all features enabled. This does not establish support for every feature combination.

These are clean Criterion time estimates, not a before/after speed claim. They replace the earlier estimates from a binary that counted allocations during timing.

| payload bytes | Criterion time estimate (us) |
| --- | --- |
| 16 | 2.7683 |
| 1024 | 2.9046 |
| 65536 | 11.892 |

Allocation counts come only from the separate census. Two runs produced identical results:

| payload bytes | allocs per RPC | allocated bytes per RPC |
| --- | --- | --- |
| 16 | 23 | 37256 |
| 1024 | 23 | 37256 |
| 65536 | 29 | 561584 |

The timing run used Rust 1.98.1 and CPU 4. The governor was `powersave`. CPU frequency was uncontrolled. Criterion used its defaults: 100 samples, 3 s warm-up, and 5 s measurement.

Commands:

```bash
taskset -c 4 cargo bench -p tonic --bench unary
taskset -c 4 cargo bench -p tonic --bench unary_allocs
```
