### PR TITLE
tonic: build OK trailers without allocating a Status

### DIFF
--- a/tonic/src/codec/encode.rs
+++ b/tonic/src/codec/encode.rs
@@ -336,12 +336,10 @@ impl EncodeState {
                 }
 
                 self.is_end_stream = true;
-                let status = if let Some(status) = self.error.take() {
-                    status
-                } else {
-                    Status::ok("")
-                };
-                Some(status.to_header_map())
+                Some(match self.error.take() {
+                    Some(status) => status.to_header_map(),
+                    None => Ok(Status::ok_header_map()),
+                })
             }
         }
     }

--- a/tonic/src/status.rs
+++ b/tonic/src/status.rs
@@ -566,6 +566,14 @@ impl Status {
         Ok(header_map)
     }
 
+    /// Success trailers carry only the `grpc-status` header, so build the map without
+    /// constructing and serializing a `Status`.
+    pub(crate) fn ok_header_map() -> HeaderMap {
+        let mut map = HeaderMap::with_capacity(1);
+        map.insert(Self::GRPC_STATUS, Code::Ok.to_header_value());
+        map
+    }
+
     /// Add headers from this `Status` into `header_map`.
     pub fn add_header(&self, header_map: &mut HeaderMap) -> Result<(), Self> {
         header_map.extend(self.0.metadata.clone().into_sanitized_headers());
@@ -803,6 +811,15 @@ pub(crate) fn infer_grpc_status(
     trailers: Option<&HeaderMap>,
     status_code: http::StatusCode,
 ) -> Result<(), Option<Status>> {
+    if let Some(trailers) = trailers
+        && let Some(raw) = trailers.get(Status::GRPC_STATUS)
+        && !trailers.contains_key(Status::GRPC_MESSAGE)
+        && Code::from_bytes(raw.as_ref()) == Code::Ok
+    {
+        // grpc-status alone decides the code here. A grpc-message can fail to decode,
+        // and from_header_map then reports Unknown, so any grpc-message skips this path.
+        return Ok(());
+    }
     if let Some(trailers) = trailers
         && let Some(status) = Status::from_header_map(trailers)
     {
@@ -1108,6 +1125,29 @@ mod tests {
         let status = Status::from_header_map(&header_map).unwrap();
 
         assert_eq!(status.details(), DETAILS);
+    }
+
+    #[test]
+    fn infer_grpc_status_fast_path() {
+        let ok_map = Status::ok_header_map();
+        assert_eq!(ok_map.len(), 1);
+        assert_eq!(ok_map.get(Status::GRPC_STATUS).unwrap(), "0");
+        assert!(infer_grpc_status(Some(&ok_map), http::StatusCode::OK).is_ok());
+
+        // A grpc-message that is not valid percent-encoded UTF-8 downgrades the code in
+        // from_header_map, so grpc-status:0 with such a message stays an error.
+        let mut bad_map = HeaderMap::new();
+        bad_map.insert(Status::GRPC_STATUS, HeaderValue::from_static("0"));
+        bad_map.insert(
+            Status::GRPC_MESSAGE,
+            HeaderValue::from_bytes(b"%FF").unwrap(),
+        );
+        let status = match infer_grpc_status(Some(&bad_map), http::StatusCode::OK) {
+            Ok(()) => panic!("malformed grpc-message must be an error"),
+            Err(Some(status)) => status,
+            Err(None) => panic!("expected a status for present grpc-status header"),
+        };
+        assert_eq!(status.code(), Code::Unknown);
     }
 }
 


### PR DESCRIPTION
## Motivation

Updates #2832

On the success path, the server built trailers by constructing `Status::ok("")` and serializing it with `to_header_map`.

The client read the code through `infer_grpc_status` and `from_header_map`, which clones the trailer map and boxes a `Status` to return one code.

The wire format and error semantics stay the same. This change removes that round trip on the success path.

## Solution

Adds `Status::ok_header_map` in `tonic/src/status.rs`. It is a `HeaderMap` with capacity 1 that holds only `grpc-status: 0`. Changes `EncodeState::trailers` in `tonic/src/codec/encode.rs` to return that map when no error is present. The error case still uses `status.to_header_map()`.

Adds a fast path in `infer_grpc_status`. When trailers hold `grpc-status`, hold no `grpc-message`, and the raw status decodes to `Code::Ok`, it returns `Ok(())` without building a `Status`. All other inputs use the existing `from_header_map` path.

A present `grpc-message` always takes the existing path. `grpc-status: 0` with a malformed message such as `%FF` still returns `Code::Unknown` as an error.

Unit test `infer_grpc_status_fast_path` covers the fast path and the malformed-message case.

## Benchmark Result
| payload bytes | baseline estimate (us) | candidate estimate (us) | ratio | allocs per RPC | bytes per RPC |
| --- | --- | --- | --- | --- | --- |
| 16 | 2.8974 | 2.5555 | 1.134 | 23 to 19 | 37256 to 36564 |
| 1024 | 3.2867 | 2.6959 | 1.219 | 23 to 19 | 37256 to 36564 |
| 65536 | 13.818 | 12.707 | 1.087 | 29 to 25 | 561584 to 560892 |