### PR TITLE
grpc-google: fix cargo toml for publishing

### DIFF
--- a/grpc-google/Cargo.toml
+++ b/grpc-google/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "grpc-google"
-version = "0.0.0-alpha"
+version = "0.10.0"
 edition = "2024"
 authors = ["gRPC authors"]
 license = "MIT"
 rust-version = { workspace = true }
-publish = false
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["grpc::*"]
@@ -14,9 +13,9 @@ allowed_external_types = ["grpc::*"]
 
 [dependencies]
 google-cloud-auth = { version = "1.9", default-features = false }
-grpc = { path = "../grpc", default-features = false }
+grpc = { version = "0.10.0", path = "../grpc", default-features = false }
 tonic = { version = "0.14.6", path = "../tonic", default-features = false }
-trait-variant = "0.1"
+trait-variant = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/grpc-google/Cargo.toml
+++ b/grpc-google/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 authors = ["gRPC authors"]
 license = "MIT"
 rust-version = { workspace = true }
+publish = false
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = ["grpc::*"]

--- a/grpc-google/src/lib.rs
+++ b/grpc-google/src/lib.rs
@@ -45,7 +45,7 @@ const DEFAULT_CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/clou
 
 /// An abstraction for fetching authentication tokens.
 #[trait_variant::make(Send)]
-pub trait TokenProvider: Sync + Debug + 'static {
+trait TokenProvider: Sync + Debug + 'static {
     /// Returns an authentication token.
     async fn get_token(&self) -> Result<String, String>;
 }


### PR DESCRIPTION
This change also unexports the `TokenProvider` trait, which was only used to mock credential-fetching logic in tests.