### PR TITLE
tonic: correct codec buffer growth documentation

### DIFF
--- a/tonic/src/codec/mod.rs
+++ b/tonic/src/codec/mod.rs
@@ -52,20 +52,13 @@ const DEFAULT_YIELD_THRESHOLD: usize = 32 * 1024;
 
 /// Settings for how tonic allocates and grows buffers.
 ///
-/// Tonic eagerly allocates the buffer_size per RPC, and grows
-/// the buffer by buffer_size increments to handle larger messages.
-/// Buffer size defaults to 8KiB.
+/// Tonic eagerly allocates `buffer_size` bytes per RPC. The default is 8 KiB.
+/// Buffers grow as needed for larger messages.
 ///
-/// Example:
-/// ```ignore
-/// Buffer start:       | 8kb |
-/// Message received:   |   24612 bytes    |
-/// Buffer grows:       | 8kb | 8kb | 8kb | 8kb |
-/// ```
-///
-/// The buffer grows to the next largest buffer_size increment of
-/// 32768 to hold 24612 bytes, which is just slightly too large for
-/// the previous buffer increment of 24576.
+/// After the decoder reads and validates a message length, it makes one
+/// reservation for that many additional bytes. The buffer can allocate more
+/// capacity than requested. The decoder's input buffer does not grow in
+/// fixed `buffer_size` increments.
 ///
 /// If you use a smaller buffer size you will waste less memory, but
 /// you will allocate more frequently. If one way or the other matters


### PR DESCRIPTION
The buffer comment describes growth in fixed `buffer_size` increments.
The decoder instead calls `reserve(len)` once after it validates the
declared message length. This requests additional capacity, not an exact
allocation size.

Remove the incorrect worked example. State the decoder input buffer's
behavior without changing the description of compression buffers.

Verification:

- fmt passes.
- rustdoc passes with -D warnings on the final text.
- build passes.
- clippy passes.
- 211 tests pass.

This documentation change does not alter runtime behavior.
