### PR TITLE
build: remove unused dependencies

### DIFF
--- a/grpc-protobuf-build/Cargo.toml
+++ b/grpc-protobuf-build/Cargo.toml
@@ -27,5 +27,3 @@ default = ["build-plugin"]
 # Alias for existing users
 build-plugin = ["protoc-gen-rust-grpc"]
 
-[build-dependencies]
-cmake = "0.1"

--- a/tonic-prost-build/Cargo.toml
+++ b/tonic-prost-build/Cargo.toml
@@ -25,10 +25,6 @@ prettyplease = { version = "0.2" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
-tempfile = "3.0"
-
-[dev-dependencies]
-tonic = { version = "0.14.6", path = "../tonic", default-features = false }
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [


### PR DESCRIPTION
This PR removes three unused dependency declarations from two manifests.

No source or test in `tonic-prost-build` uses `tempfile` or its `tonic` development dependency.

`grpc-protobuf-build` has no `build.rs` or custom build-script setting.
Its `cmake` build dependency cannot run.

Change:

- Delete tempfile from tonic-prost-build/Cargo.toml.
- Delete the unused tonic development dependency and its empty section from tonic-prost-build/Cargo.toml.
- Delete cmake and its build dependencies section from grpc-protobuf-build/Cargo.toml.

Verification:

- fmt passes.
- build passes with the expected PROTOC_GEN_RUST_GRPC_NO_BUILD skip warning from the configuration used in CI.
- clippy passes.
- 11 tests pass.
- cargo +nightly udeps --all-targets --all-features passes for both packages with no unused dependencies.

This PR changes no source code or remaining dependency versions.
