### PR TITLE
fix(transport): backoff reconnect in load balancer to fix failover (#2839)

### DIFF
--- a/tests/integration_tests/tests/load_balance_failover.rs
+++ b/tests/integration_tests/tests/load_balance_failover.rs
@@ -1,0 +1,164 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+use integration_tests::pb::{test_client::TestClient, test_server, Input, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tonic::{
+    transport::{server::TcpIncoming, Channel, Endpoint, Server},
+    Request, Response, Status,
+};
+
+struct Svc(Arc<AtomicUsize>);
+
+#[tonic::async_trait]
+impl test_server::Test for Svc {
+    async fn unary_call(&self, _: Request<Input>) -> Result<Response<Output>, Status> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(Output {}))
+    }
+}
+
+#[tokio::test]
+async fn balance_list_failover_when_one_endpoint_fails_to_connect() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpIncoming::from(listener).with_nodelay(Some(true));
+
+    let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let count = Arc::new(AtomicUsize::new(0));
+    let svc = test_server::TestServer::new(Svc(count.clone()));
+
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(incoming, async { drop(rx.await) })
+            .await
+            .unwrap();
+    });
+
+    // Endpoint 1: Alive
+    let ep_a = Endpoint::from_shared(format!("http://{addr}")).unwrap();
+    // Endpoint 2: Dead server with 50ms connect timeout and 50ms reconnect delay
+    let ep_b = Endpoint::from_static("http://127.0.0.1:1")
+        .connect_timeout(Duration::from_millis(50))
+        .reconnect_delay(Duration::from_millis(50));
+
+    let channel = Channel::balance_list(vec![ep_a, ep_b].into_iter());
+    let mut client = TestClient::new(channel);
+
+    // Wait for ep_b initial connect to fail
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Send requests: all should route to healthy ep_a!
+    for i in 0..20 {
+        let res = client.unary_call(Request::new(Input {})).await;
+        assert!(res.is_ok(), "Request {} failed: {:?}", i, res.err());
+    }
+
+    assert_eq!(count.load(Ordering::SeqCst), 20);
+    jh.abort();
+}
+
+#[tokio::test]
+async fn balance_list_reconnects_when_down_endpoint_starts_up() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing_subscriber::filter::LevelFilter::TRACE)
+        .try_init();
+
+    // Server A: Running initially
+    let listener_a = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr_a = listener_a.local_addr().unwrap();
+    let incoming_a = TcpIncoming::from(listener_a).with_nodelay(Some(true));
+    let count_a = Arc::new(AtomicUsize::new(0));
+
+    let jh_a = tokio::spawn(async move {
+        Server::builder()
+            .add_service(test_server::TestServer::new(Svc(count_a)))
+            .serve_with_incoming(incoming_a)
+            .await
+            .unwrap();
+    });
+
+    // Server B: Port allocated, but not started yet
+    let listener_b = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr_b = listener_b.local_addr().unwrap();
+    drop(listener_b); // close listener so connect fails initially
+
+    let ep_a = Endpoint::from_shared(format!("http://{addr_a}")).unwrap();
+    let ep_b = Endpoint::from_shared(format!("http://{addr_b}"))
+        .unwrap()
+        .connect_timeout(Duration::from_millis(50))
+        .reconnect_delay(Duration::from_millis(50));
+
+    let channel = Channel::balance_list(vec![ep_a, ep_b].into_iter());
+    let mut client = TestClient::new(channel);
+
+    // Initial calls: ep_b is down, all go to ep_a
+    for i in 0..10 {
+        let res = client.unary_call(Request::new(Input {})).await;
+        assert!(res.is_ok(), "Initial request {} failed: {:?}", i, res.err());
+    }
+
+    // Now start Server B on the same port!
+    let listener_b = TcpListener::bind(addr_b).await.unwrap();
+    let incoming_b = TcpIncoming::from(listener_b).with_nodelay(Some(true));
+    let count_b = Arc::new(AtomicUsize::new(0));
+    let count_b_clone = count_b.clone();
+
+    let jh_b = tokio::spawn(async move {
+        Server::builder()
+            .add_service(test_server::TestServer::new(Svc(count_b_clone)))
+            .serve_with_incoming(incoming_b)
+            .await
+            .unwrap();
+    });
+
+    // Wait for ep_b's backoff to fire and connect to Server B
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Send more requests: now both Server A and Server B should receive requests
+    for i in 0..30 {
+        let res = client.unary_call(Request::new(Input {})).await;
+        assert!(
+            res.is_ok(),
+            "Subsequent request {} failed: {:?}",
+            i,
+            res.err()
+        );
+    }
+
+    // Verify Server B received traffic once it started up!
+    let b_requests = count_b.load(Ordering::SeqCst);
+    println!("Requests served by Server B after coming up: {b_requests}");
+    assert!(
+        b_requests > 0,
+        "Server B should have received requests after starting up!"
+    );
+
+    jh_a.abort();
+    jh_b.abort();
+}

--- a/tonic/src/transport/channel/endpoint.rs
+++ b/tonic/src/transport/channel/endpoint.rs
@@ -77,6 +77,7 @@ pub struct Endpoint {
     pub(crate) http2_header_table_size: Option<u32>,
     pub(crate) http2_max_header_list_size: Option<u32>,
     pub(crate) connect_timeout: Option<Duration>,
+    pub(crate) reconnect_delay: Option<Duration>,
     pub(crate) http2_adaptive_window: Option<bool>,
     pub(crate) local_address: Option<IpAddr>,
     pub(crate) executor: SharedExec,
@@ -127,6 +128,7 @@ impl Endpoint {
             http2_header_table_size: None,
             http2_max_header_list_size: None,
             connect_timeout: None,
+            reconnect_delay: None,
             http2_adaptive_window: None,
             executor: SharedExec::tokio(),
             local_address: None,
@@ -158,6 +160,7 @@ impl Endpoint {
             http2_header_table_size: None,
             http2_max_header_list_size: None,
             connect_timeout: None,
+            reconnect_delay: None,
             http2_adaptive_window: None,
             executor: SharedExec::tokio(),
             local_address: None,
@@ -288,6 +291,20 @@ impl Endpoint {
     pub fn connect_timeout(self, dur: Duration) -> Self {
         Endpoint {
             connect_timeout: Some(dur),
+            ..self
+        }
+    }
+
+    /// Set the reconnect delay for load-balanced channels when a connection fails.
+    ///
+    /// When an endpoint in a load-balanced channel (`Channel::balance_list`, `Channel::balance_channel`)
+    /// fails to connect or loses connection, it will wait for this duration before attempting
+    /// to reconnect, avoiding tight reconnect loops while allowing healthy endpoints to serve requests.
+    ///
+    /// Defaults to 100 milliseconds.
+    pub fn reconnect_delay(self, dur: Duration) -> Self {
+        Endpoint {
+            reconnect_delay: Some(dur),
             ..self
         }
     }

--- a/tonic/src/transport/channel/service/connection.rs
+++ b/tonic/src/transport/channel/service/connection.rs
@@ -22,7 +22,7 @@
  *
  */
 
-use super::{AddOrigin, Reconnect, SharedExec, UserAgent};
+use super::{AddOrigin, Reconnect, SharedExec, UserAgent, reconnect::ReconnectMode};
 use crate::{
     body::Body,
     transport::{Endpoint, channel::BoxFuture, service::GrpcTimeout},
@@ -49,7 +49,7 @@ pub(crate) struct Connection {
 }
 
 impl Connection {
-    fn new<C>(connector: C, endpoint: Endpoint, is_lazy: bool) -> Self
+    fn new<C>(connector: C, endpoint: Endpoint, mode: ReconnectMode) -> Self
     where
         C: Service<Uri> + Send + 'static,
         C::Error: Into<crate::BoxError> + Send,
@@ -102,7 +102,12 @@ impl Connection {
         let make_service =
             MakeSendRequestService::new(connector, endpoint.executor.clone(), settings);
 
-        let conn = Reconnect::new(make_service, endpoint.uri().clone(), is_lazy);
+        let conn = Reconnect::new(
+            make_service,
+            endpoint.uri().clone(),
+            mode,
+            endpoint.reconnect_delay,
+        );
 
         Self {
             inner: BoxService::new(stack.layer(conn)),
@@ -119,7 +124,9 @@ impl Connection {
         C::Future: Unpin + Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
-        Self::new(connector, endpoint, false).ready_oneshot().await
+        Self::new(connector, endpoint, ReconnectMode::Eager)
+            .ready_oneshot()
+            .await
     }
 
     pub(crate) fn lazy<C>(connector: C, endpoint: Endpoint) -> Self
@@ -129,7 +136,17 @@ impl Connection {
         C::Future: Send,
         C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
     {
-        Self::new(connector, endpoint, true)
+        Self::new(connector, endpoint, ReconnectMode::Lazy)
+    }
+
+    pub(crate) fn balanced<C>(connector: C, endpoint: Endpoint) -> Self
+    where
+        C: Service<Uri> + Send + 'static,
+        C::Error: Into<crate::BoxError> + Send,
+        C::Future: Send,
+        C::Response: rt::Read + rt::Write + Unpin + Send + 'static,
+    {
+        Self::new(connector, endpoint, ReconnectMode::Balanced)
     }
 }
 

--- a/tonic/src/transport/channel/service/discover.rs
+++ b/tonic/src/transport/channel/service/discover.rs
@@ -60,7 +60,7 @@ impl<K: Hash + Eq + Clone> Stream for DynamicServiceStream<K> {
             Poll::Pending | Poll::Ready(None) => Poll::Pending,
             Poll::Ready(Some(change)) => match change {
                 Change::Insert(k, endpoint) => {
-                    let connection = Connection::lazy(endpoint.http_connector(), endpoint);
+                    let connection = Connection::balanced(endpoint.http_connector(), endpoint);
                     Poll::Ready(Some(Ok(TowerChange::Insert(k, connection))))
                 }
                 Change::Remove(k) => Poll::Ready(Some(Ok(TowerChange::Remove(k)))),

--- a/tonic/src/transport/channel/service/reconnect.rs
+++ b/tonic/src/transport/channel/service/reconnect.rs
@@ -24,6 +24,7 @@
 
 use pin_project::pin_project;
 use std::fmt;
+use std::time::Duration;
 use std::{
     future::Future,
     pin::Pin,
@@ -32,6 +33,15 @@ use std::{
 use tower::make::MakeService;
 use tower_service::Service;
 use tracing::trace;
+
+pub(crate) const DEFAULT_RECONNECT_DELAY: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReconnectMode {
+    Eager,
+    Lazy,
+    Balanced,
+}
 
 pub(crate) struct Reconnect<M, Target>
 where
@@ -43,7 +53,8 @@ where
     target: Target,
     error: Option<crate::BoxError>,
     has_been_connected: bool,
-    is_lazy: bool,
+    mode: ReconnectMode,
+    reconnect_delay: Duration,
 }
 
 #[derive(Debug)]
@@ -51,6 +62,7 @@ enum State<F, S> {
     Idle,
     Connecting(F),
     Connected(S),
+    Backoff(Pin<Box<tokio::time::Sleep>>),
 }
 
 impl<M, Target> Reconnect<M, Target>
@@ -58,14 +70,20 @@ where
     M: Service<Target>,
     M::Error: Into<crate::BoxError>,
 {
-    pub(crate) fn new(mk_service: M, target: Target, is_lazy: bool) -> Self {
+    pub(crate) fn new(
+        mk_service: M,
+        target: Target,
+        mode: ReconnectMode,
+        reconnect_delay: Option<Duration>,
+    ) -> Self {
         Reconnect {
             mk_service,
             state: State::Idle,
             target,
             error: None,
             has_been_connected: false,
-            is_lazy,
+            mode,
+            reconnect_delay: reconnect_delay.unwrap_or(DEFAULT_RECONNECT_DELAY),
         }
     }
 }
@@ -119,15 +137,25 @@ where
                         Poll::Ready(Err(e)) => {
                             trace!("poll_ready; error");
 
-                            state = State::Idle;
-
-                            if !(self.has_been_connected || self.is_lazy) {
-                                return Poll::Ready(Err(e.into()));
-                            } else {
-                                let error = e.into();
-                                tracing::debug!("reconnect::poll_ready: {:?}", error);
-                                self.error = Some(error);
-                                break;
+                            match self.mode {
+                                ReconnectMode::Eager => {
+                                    self.state = State::Idle;
+                                    return Poll::Ready(Err(e.into()));
+                                }
+                                ReconnectMode::Lazy => {
+                                    state = State::Idle;
+                                    let error = e.into();
+                                    tracing::debug!("reconnect::poll_ready: {:?}", error);
+                                    self.error = Some(error);
+                                    break;
+                                }
+                                ReconnectMode::Balanced => {
+                                    trace!("poll_ready; balanced backoff");
+                                    self.state = State::Backoff(Box::pin(tokio::time::sleep(
+                                        self.reconnect_delay,
+                                    )));
+                                    continue;
+                                }
                             }
                         }
                     }
@@ -148,7 +176,31 @@ where
                         }
                         Poll::Ready(Err(_)) => {
                             trace!("poll_ready; error");
-                            state = State::Idle;
+                            match self.mode {
+                                ReconnectMode::Balanced => {
+                                    self.state = State::Backoff(Box::pin(tokio::time::sleep(
+                                        self.reconnect_delay,
+                                    )));
+                                    continue;
+                                }
+                                _ => {
+                                    state = State::Idle;
+                                }
+                            }
+                        }
+                    }
+                }
+                State::Backoff(ref mut sleep) => {
+                    trace!("poll_ready; backoff");
+                    match Pin::new(sleep).poll(cx) {
+                        Poll::Pending => {
+                            trace!("poll_ready; backoff pending");
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(()) => {
+                            trace!("poll_ready; backoff elapsed");
+                            self.state = State::Idle;
+                            continue;
                         }
                     }
                 }
@@ -240,5 +292,130 @@ where
                 Poll::Ready(Err(e))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tower::service_fn;
+
+    #[derive(Clone)]
+    struct FailingMakeService {
+        attempts: Arc<AtomicUsize>,
+        fail_times: usize,
+    }
+
+    impl Service<()> for FailingMakeService {
+        type Response = tower::util::BoxService<(), (), crate::BoxError>;
+        type Error = crate::BoxError;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: ()) -> Self::Future {
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt < self.fail_times {
+                std::future::ready(Err("connection failed".into()))
+            } else {
+                std::future::ready(Ok(tower::util::BoxService::new(service_fn(|()| async {
+                    Ok(())
+                }))))
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_mode_eager() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let mk_svc = FailingMakeService {
+            attempts: attempts.clone(),
+            fail_times: 1,
+        };
+
+        let mut reconnect = Reconnect::new(mk_svc, (), ReconnectMode::Eager, None);
+
+        let poll = std::future::poll_fn(|cx| reconnect.poll_ready(cx)).await;
+        assert!(
+            poll.is_err(),
+            "Eager mode should return Err on connect failure"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_mode_lazy() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let mk_svc = FailingMakeService {
+            attempts: attempts.clone(),
+            fail_times: 1,
+        };
+
+        let mut reconnect = Reconnect::new(mk_svc, (), ReconnectMode::Lazy, None);
+
+        let poll = std::future::poll_fn(|cx| reconnect.poll_ready(cx)).await;
+        assert!(
+            poll.is_ok(),
+            "Lazy mode should return Ready(Ok) on connect failure"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        let res = reconnect.call(()).await;
+        assert!(res.is_err(), "Lazy mode should return error from call");
+
+        // Subsequent poll should reconnect and succeed
+        let poll2 = std::future::poll_fn(|cx| reconnect.poll_ready(cx)).await;
+        assert!(poll2.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_mode_balanced_backs_off() {
+        tokio::time::pause();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let mk_svc = FailingMakeService {
+            attempts: attempts.clone(),
+            fail_times: 2,
+        };
+
+        let delay = Duration::from_millis(100);
+        let mut reconnect = Reconnect::new(mk_svc, (), ReconnectMode::Balanced, Some(delay));
+
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        let p1 = reconnect.poll_ready(&mut cx);
+        assert!(
+            p1.is_pending(),
+            "Balanced mode must return Pending on connect failure"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        // Advance time partially (50ms): should still be pending
+        tokio::time::advance(Duration::from_millis(50)).await;
+        let p2 = reconnect.poll_ready(&mut cx);
+        assert!(p2.is_pending());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        // Advance past delay: next poll attempts and fails again
+        tokio::time::advance(Duration::from_millis(60)).await;
+        let p3 = reconnect.poll_ready(&mut cx);
+        assert!(p3.is_pending());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        // Advance past second delay: next poll attempts and succeeds
+        tokio::time::advance(Duration::from_millis(110)).await;
+        let p4 = reconnect.poll_ready(&mut cx);
+        assert!(
+            matches!(p4, Poll::Ready(Ok(()))),
+            "Balanced mode should return Ready(Ok) once connection succeeds"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }


### PR DESCRIPTION
## Motivation

Closes #2839

When using load-balanced channels (`Channel::balance_list` or `Channel::balance_channel`), if one endpoint fails to connect or is temporarily down, requests routed to that channel intermittently fail with:
```
Status { code: Unavailable, message: "tcp connect error", ... }
```
even when healthy endpoints are available.

### Root Cause Analysis
1. In PR #458 and PR #536, `tonic` updated `Reconnect::poll_ready` to return `Poll::Ready(Ok(()))` on connection failures if lazy connecting is enabled or if the channel has connected previously. This was done so that `tower::buffer::Buffer`'s worker task does not exit and poison the channel when a standalone channel experiences a temporary connection drop.
2. However, `Channel::balance_list` uses Tower's `p2c::Balance` (`tower::ready_cache::ReadyCache`).
3. Because `Reconnect::poll_ready` returned `Poll::Ready(Ok(()))` even on connection failure, Tower considered the dead endpoint as **healthy and ready**.
4. P2C (Power of Two Choices) then picked the dead endpoint and called `call(req)`, which immediately failed and consumed the user's retry budget instead of failing over to healthy endpoints.
5. Furthermore, if `poll_ready` were to return `Poll::Ready(Err(e))`, Tower's `ReadyCache` permanently evicts and drops the service from the load balancer, which would prevent static `balance_list` endpoints from ever recovering when the server comes back online.

## Solution

1. **Distinguish Connection Modes via `ReconnectMode`**:
   - `ReconnectMode::Eager`: Used by `Connection::connect` (`ready_oneshot`). Eagerly returns `Poll::Ready(Err(e))` on connection error.
   - `ReconnectMode::Lazy`: Preserves lazy channel behavior for standalone channels. Defers the error to `call()` so `tower::buffer::Buffer` worker does not crash.
   - `ReconnectMode::Balanced`: Used by load-balanced channels (`DynamicServiceStream` in `discover.rs`). When a connection fails or drops:
     - Enters a backoff state (`State::Backoff`) using `tokio::time::sleep`.
     - Returns `Poll::Pending` while backing off.
     - Tower keeps the endpoint in its `pending` set (NOT in `ready`), ensuring Tower's P2C algorithm routes 100% of requests to live endpoints.
     - Once the backoff timer expires, Tokio's timer wakes `cx.waker()`, allowing the endpoint to attempt reconnection and seamlessly rejoin the `ready` pool without busy-looping.
2. **Configurable Reconnect Delay**:
   - Added `Endpoint::reconnect_delay(mut self, dur: Duration) -> Self` (defaults to 100ms).
3. **Comprehensive Tests**:
   - Unit tests covering `Eager`, `Lazy`, and `Balanced` modes in `tonic/src/transport/channel/service/reconnect.rs`.
   - Integration test `balance_list_failover_when_one_endpoint_fails_to_connect` in `tests/integration_tests/tests/load_balance_failover.rs`: Asserts that when one endpoint is down, all requests route to the healthy endpoint without any failure.
   - Integration test `balance_list_reconnects_when_down_endpoint_starts_up`: Asserts that an endpoint that starts up after client creation automatically reconnects and receives traffic from the load balancer.
   - Verified that existing lazy connection tests (`connect_lazy_reconnects_after_first_failure`, etc.) continue to pass with 0 regressions.
