### PR TITLE
grpc: unlink private symbol in public rustdoc

### DIFF
--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -90,8 +90,8 @@ impl<T: Handle + Sized> HandleExt for T {}
 
 /// A no-op interceptor that simply delegates to the next handler.
 ///
-/// This is the default interceptor used by [`RouterBuilder`](crate::server::RouterBuilder)
-/// when no interceptor has been added.
+/// This is the default interceptor used by `RouterBuilder` when no interceptor
+/// has been added.
 #[derive(Clone, Copy)]
 pub struct Identity;
 


### PR DESCRIPTION
## Why
`RouterBuilder` is private, so it can't be linked in a public rustdoc.

https://github.com/grpc/grpc-rust/blob/900ff055dcc904468747d1ed2a22ffd41486221d/grpc/src/server/router.rs#L48-L49