### PR TITLE
fix(grpc): remove reference to private RouterBuilder in Identity doc

### DIFF
--- a/grpc/src/server/interceptor.rs
+++ b/grpc/src/server/interceptor.rs
@@ -89,9 +89,6 @@ pub trait HandleExt: Handle + Sized {
 impl<T: Handle + Sized> HandleExt for T {}
 
 /// A no-op interceptor that simply delegates to the next handler.
-///
-/// This is the default interceptor used by `RouterBuilder` when no interceptor
-/// has been added.
 #[derive(Clone, Copy)]
 pub struct Identity;
 

--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -49,6 +49,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use tokio::sync::watch;
 use tonic::async_trait;
 
 use crate::core::ConnectionInfo;
@@ -62,6 +63,9 @@ pub mod descriptor;
 pub(crate) mod interceptor;
 pub(crate) mod router;
 pub mod service;
+
+use builder::ServerBuilder;
+use interceptor::Identity;
 
 /// Settings to configure RPCs sent using the [`Handle`] trait.
 ///
@@ -153,12 +157,12 @@ pub trait Transport: Send + 'static {
 /// Each connection is watched via `watch()`. When `shutdown()` is called,
 /// all watched connections receive a `graceful_shutdown()` signal.
 struct GracefulCoordinator {
-    tx: tokio::sync::watch::Sender<()>,
+    tx: watch::Sender<()>,
 }
 
 impl GracefulCoordinator {
     fn new() -> Self {
-        let (tx, _) = tokio::sync::watch::channel(());
+        let (tx, _) = watch::channel(());
         Self { tx }
     }
 
@@ -192,9 +196,9 @@ impl GracefulCoordinator {
 }
 
 impl Server {
-    /// Creates a [`ServerBuilder`](builder::ServerBuilder) with no interceptors.
-    pub fn builder() -> builder::ServerBuilder<interceptor::Identity> {
-        builder::ServerBuilder::new()
+    /// Creates a new [`ServerBuilder`] with an [`Identity`] (no-op) interceptor.
+    pub fn builder() -> ServerBuilder<Identity> {
+        ServerBuilder::new()
     }
 
     /// Creates a new server with the given handler and runtime.


### PR DESCRIPTION

Remove reference to private RouteBuilder altogether, there's no need to couple Identity interceptor with it's usage as a default generic in ServerBuilder