### PR TITLE
grpc/load_balancing: move LB config selection into registry

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -79,7 +79,7 @@ rustls-pki-types = { version = "1.8", optional = true, default-features = false 
 rustls-platform-verifier = { version = "0.7", optional = true, default-features = false }
 rustls-webpki = { version = "0.103", optional = true, default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde_json = { version = "1.0.140", features = ["raw_value"] }
 socket2 = { version = "0.6", optional = true }
 tokio = { version = "1.37.0", features = ["sync", "macros"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false }

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -24,7 +24,6 @@
 
 use core::panic;
 use std::any::Any;
-use std::error::Error;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::sync::Arc;
@@ -77,7 +76,7 @@ pub trait LbPolicyBuilder: Send + Sync + Debug + 'static {
     /// default implementation returns Ok(None).
     fn parse_config(
         &self,
-        _config: &ParsedJsonLbConfig,
+        _config: &LbConfigPayload<'_>,
     ) -> Result<Option<<Self::LbPolicy as LbPolicy>::LbConfig>, String> {
         Ok(None)
     }
@@ -178,43 +177,37 @@ pub trait WorkScheduler: Send + Sync + Debug {
     fn schedule_work(&self, data: Option<WorkData>);
 }
 
-/// Abstract representation of the configuration for any LB policy, stored as
-/// JSON.  Hides internal storage details and includes a method to deserialize
-/// the JSON into a concrete policy struct.
-#[derive(Debug)]
-pub struct ParsedJsonLbConfig {
-    value: serde_json::Value,
+/// Borrowed JSON payload containing the configuration for an LB policy.
+///
+/// Hides internal serialization libraries and guarantees zero-allocation access.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct LbConfigPayload<'a>(&'a str);
+
+impl<'a> LbConfigPayload<'a> {
+    pub const EMPTY: Self = Self("{}");
+
+    #[inline]
+    pub const fn new(raw_json: &'a str) -> Self {
+        Self(raw_json)
+    }
+
+    #[inline]
+    pub const fn empty() -> Self {
+        Self::EMPTY
+    }
+
+    #[inline]
+    pub const fn as_str(&self) -> &'a str {
+        self.0
+    }
 }
 
-impl ParsedJsonLbConfig {
-    /// Creates a new ParsedJsonLbConfig from the provided JSON string.
-    pub fn new(json: &str) -> Result<Self, String> {
-        match serde_json::from_str(json) {
-            Ok(value) => Ok(ParsedJsonLbConfig { value }),
-            Err(e) => Err(format!("failed to parse LB config JSON: {e}")),
-        }
-    }
-
-    pub fn from_value(value: serde_json::Value) -> Self {
-        Self { value }
-    }
-
-    /// Converts the JSON configuration into a concrete type that represents the
-    /// configuration of an LB policy.
-    ///
-    /// This will typically be used by the LB policy builder to parse the
-    /// configuration into a type that can be used by the LB policy.
-    pub fn convert_to<T: serde::de::DeserializeOwned>(
-        &self,
-    ) -> Result<T, Box<dyn Error + Send + Sync>> {
-        let res: T = match serde_json::from_value(self.value.clone()) {
-            Ok(v) => v,
-            Err(e) => {
-                return Err(format!("{e}").into());
-            }
-        };
-        Ok(res)
-    }
+/// A successfully resolved load balancing policy builder and its parsed configuration.
+#[derive(Clone, Debug)]
+pub struct ParsedLbConfig {
+    pub builder: Arc<DynLbPolicyBuilder>,
+    pub config: Option<DynLbConfig>,
 }
 
 /// Controls channel behaviors.
@@ -474,7 +467,7 @@ impl<B: LbPolicyBuilder + ?Sized> LbPolicyBuilder for Arc<B> {
 
     fn parse_config(
         &self,
-        config: &ParsedJsonLbConfig,
+        config: &LbConfigPayload<'_>,
     ) -> Result<Option<<B::LbPolicy as LbPolicy>::LbConfig>, String> {
         (**self).parse_config(config)
     }

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -35,11 +35,11 @@ use crate::client::ConnectivityState;
 use crate::client::RequestHeaders;
 use crate::client::load_balancing::ChannelController;
 use crate::client::load_balancing::FailingPicker;
+use crate::client::load_balancing::LbConfigPayload;
 use crate::client::load_balancing::LbPolicy;
 use crate::client::load_balancing::LbPolicyBuilder;
 use crate::client::load_balancing::LbPolicyOptions;
 use crate::client::load_balancing::LbState;
-use crate::client::load_balancing::ParsedJsonLbConfig;
 use crate::client::load_balancing::Pick;
 use crate::client::load_balancing::PickResult;
 use crate::client::load_balancing::Picker;
@@ -91,8 +91,12 @@ impl LbPolicyBuilder for PickFirstBuilder {
         POLICY_NAME
     }
 
-    fn parse_config(&self, config: &ParsedJsonLbConfig) -> Result<Option<PickFirstConfig>, String> {
-        let config: PickFirstConfig = config.convert_to().map_err(|e| e.to_string())?;
+    fn parse_config(
+        &self,
+        config: &LbConfigPayload<'_>,
+    ) -> Result<Option<PickFirstConfig>, String> {
+        let config: PickFirstConfig = serde_json::from_str(config.as_str())
+            .map_err(|e| format!("Invalid pick_first config: {e}"))?;
         Ok(Some(config))
     }
 }

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -32,10 +32,11 @@ use crate::client::load_balancing::ChannelController;
 use crate::client::load_balancing::DynLbConfig;
 use crate::client::load_balancing::DynLbPolicy;
 use crate::client::load_balancing::DynLbPolicyBuilder;
+use crate::client::load_balancing::LbConfigPayload;
 use crate::client::load_balancing::LbPolicy;
 use crate::client::load_balancing::LbPolicyBuilder;
 use crate::client::load_balancing::LbPolicyOptions;
-use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::ParsedLbConfig;
 use crate::client::load_balancing::WorkData;
 use crate::client::load_balancing::subchannel::Subchannel;
 use crate::client::load_balancing::subchannel::SubchannelState;
@@ -73,6 +74,157 @@ impl LbPolicyRegistry {
     pub fn get_policy(&self, name: &str) -> Option<Arc<DynLbPolicyBuilder>> {
         self.m.lock().unwrap().get(name).cloned()
     }
+
+    /// Evaluates an ordered candidate list against the registry.
+    ///
+    /// Halts candidate evaluation immediately on the first supported policy
+    /// if configuration parsing fails (gRFC A24).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use grpc::client::load_balancing::GLOBAL_LB_REGISTRY;
+    ///
+    /// let candidates_json = r#"[
+    ///     {"xds": {}},
+    ///     {"round_robin": {}}
+    /// ]"#;
+    ///
+    /// // A parent policy (e.g. grpclb) can filter candidates to only allow specific children.
+    /// let selected = GLOBAL_LB_REGISTRY
+    ///     .select_candidate_with_filter(
+    ///         candidates_json,
+    ///         Some(|name: &str| name == "round_robin" || name == "pick_first"),
+    ///     )
+    ///     .unwrap();
+    ///
+    /// assert!(selected.is_some());
+    /// assert_eq!(selected.unwrap().builder.name(), "round_robin");
+    /// ```
+    pub fn select_candidate_with_filter<F>(
+        &self,
+        candidate_list_json: &str,
+        filter: Option<F>,
+    ) -> Result<Option<ParsedLbConfig>, String>
+    where
+        F: Fn(&str) -> bool,
+    {
+        let trimmed = candidate_list_json.trim();
+        if trimmed.is_empty() || trimmed == "null" {
+            return Ok(None);
+        }
+
+        let raw_candidates: Vec<&serde_json::value::RawValue> = serde_json::from_str(trimmed)
+            .map_err(|e| format!("failed to parse load balancing candidates JSON: {e}"))?;
+
+        if raw_candidates.is_empty() {
+            return Ok(None);
+        }
+
+        let mut unregistered = Vec::new();
+        let mut filtered_out = Vec::new();
+
+        for raw_cand in raw_candidates {
+            let candidate: CandidateEntry<'_> = serde_json::from_str(raw_cand.get())
+                .map_err(|e| format!("failed to parse candidate entry: {e}"))?;
+
+            if let Some(ref f) = filter
+                && !f(candidate.policy_name)
+            {
+                filtered_out.push(candidate.policy_name);
+                continue;
+            }
+
+            if let Some(builder) = self.get_policy(candidate.policy_name) {
+                let payload = LbConfigPayload::new(candidate.raw_config);
+                let parsed_config = builder.parse_config(&payload).map_err(|e| {
+                    format!(
+                        "failed to parse config for policy '{}': {e}",
+                        candidate.policy_name
+                    )
+                })?;
+                return Ok(Some(ParsedLbConfig {
+                    builder,
+                    config: parsed_config,
+                }));
+            }
+
+            unregistered.push(candidate.policy_name);
+        }
+
+        let err_msg = match (filtered_out.is_empty(), unregistered.is_empty()) {
+            (false, true) => format!(
+                "None of the candidate policies were permitted by filter: [{}].",
+                filtered_out.join(", ")
+            ),
+            (true, false) => format!(
+                "None of the candidate policies are registered: [{}].",
+                unregistered.join(", ")
+            ),
+            (false, false) => format!(
+                "No supported load balancing policy selected (unregistered: [{}], filtered out: [{}]).",
+                unregistered.join(", "),
+                filtered_out.join(", ")
+            ),
+            (true, true) => "No supported load balancing policy found in config.".to_string(),
+        };
+
+        Err(err_msg)
+    }
+
+    /// Evaluates an ordered candidate list against the registry without a filter.
+    pub fn select_candidate(
+        &self,
+        candidate_list_json: &str,
+    ) -> Result<Option<ParsedLbConfig>, String> {
+        self.select_candidate_with_filter::<fn(&str) -> bool>(candidate_list_json, None)
+    }
+}
+
+/// Internal visitor to deserialize a candidate object and strictly enforce the
+/// gRFC A24 oneOf rule with zero AST allocation.
+#[derive(Debug)]
+struct CandidateEntry<'de> {
+    policy_name: &'de str,
+    raw_config: &'de str,
+}
+
+impl<'de> serde::Deserialize<'de> for CandidateEntry<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = CandidateEntry<'de>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a single-property object representing an LB policy candidate")
+            }
+
+            fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let policy_name: &'de str = access.next_key()?.ok_or_else(|| {
+                    serde::de::Error::custom(
+                        "Each load balancing config entry must contain exactly one policy name.",
+                    )
+                })?;
+                let raw_val: &'de serde_json::value::RawValue = access.next_value()?;
+                if access.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "Each load balancing config entry must contain exactly one policy name.",
+                    ));
+                }
+                Ok(CandidateEntry {
+                    policy_name,
+                    raw_config: raw_val.get(),
+                })
+            }
+        }
+        deserializer.deserialize_map(Visitor)
+    }
 }
 
 impl Default for LbPolicyRegistry {
@@ -104,8 +256,8 @@ impl<T: LbPolicyBuilder> LbPolicyBuilder for DynAdapter<T> {
         self.0.name()
     }
 
-    fn parse_config(&self, config: &ParsedJsonLbConfig) -> Result<Option<DynLbConfig>, String> {
-        // Call the real parse config and then wrap its result in a DynLbConfig if it is Ok(Some)
+    fn parse_config(&self, config: &LbConfigPayload<'_>) -> Result<Option<DynLbConfig>, String> {
+        // Call the real parse config and then wrap its result in a DynLbConfig if it is Ok(Some).
         let cfg = self.0.parse_config(config)?;
         Ok(cfg.map(|c| Arc::new(c) as DynLbConfig))
     }
@@ -150,5 +302,122 @@ impl<T: LbPolicy> LbPolicy for DynAdapter<T> {
 impl<T> DynAdapter<T> {
     fn new_arc(policy: T) -> Arc<Self> {
         Arc::new(DynAdapter(policy))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_skips_registered_policy_and_ignores_trailing_malformed_entries() {
+        let json = r#"[
+            { "pick_first": { "shuffleAddressList": true } },
+            { "round_robin": {} },
+            { "invalid": 123, "second_key": true }
+        ]"#;
+
+        // Filter rejects pick_first despite it being registered in GLOBAL_LB_REGISTRY.
+        let selected = GLOBAL_LB_REGISTRY
+            .select_candidate_with_filter(json, Some(|name: &str| name == "round_robin"))
+            .expect("selection should succeed")
+            .expect("should find a supported candidate");
+
+        assert_eq!(
+            selected.builder.name(),
+            "round_robin",
+            "selected builder name does not match expected round_robin."
+        );
+    }
+
+    #[test]
+    fn filter_rejecting_all_registered_candidates_returns_error() {
+        let json = r#"[
+            { "pick_first": { "shuffleAddressList": true } },
+            { "round_robin": {} }
+        ]"#;
+
+        // Filter rejects all policies.
+        let result = GLOBAL_LB_REGISTRY.select_candidate_with_filter(json, Some(|_: &str| false));
+
+        assert!(
+            result.is_err(),
+            "expected error when all candidates are rejected by filter."
+        );
+        let err = result.err().unwrap();
+        assert_eq!(
+            err,
+            "None of the candidate policies were permitted by filter: [pick_first, round_robin].",
+            "error message should detail which policies were filtered out."
+        );
+    }
+
+    #[test]
+    fn unregistered_candidates_returns_error() {
+        let json = r#"[
+            { "unregistered_1": {} },
+            { "unregistered_2": {} }
+        ]"#;
+
+        let result = GLOBAL_LB_REGISTRY.select_candidate(json);
+
+        assert!(
+            result.is_err(),
+            "expected error when candidates are not registered."
+        );
+        let err = result.err().unwrap();
+        assert_eq!(
+            err, "None of the candidate policies are registered: [unregistered_1, unregistered_2].",
+            "error message should detail which policies were unregistered."
+        );
+    }
+
+    #[test]
+    fn mixed_unregistered_and_filtered_candidates_returns_error() {
+        let json = r#"[
+            { "unregistered_1": {} },
+            { "round_robin": {} }
+        ]"#;
+
+        let result = GLOBAL_LB_REGISTRY
+            .select_candidate_with_filter(json, Some(|name: &str| name == "unregistered_1"));
+
+        assert!(
+            result.is_err(),
+            "expected error when candidates are either unregistered or filtered out."
+        );
+        let err = result.err().unwrap();
+        assert_eq!(
+            err,
+            "No supported load balancing policy selected (unregistered: [unregistered_1], filtered out: [round_robin]).",
+            "error message should distinguish between unregistered and filtered policies."
+        );
+    }
+
+    #[test]
+    fn empty_and_null_candidate_lists_return_none() {
+        let empty_res = GLOBAL_LB_REGISTRY
+            .select_candidate_with_filter::<fn(&str) -> bool>("[]", None)
+            .expect("empty array should succeed");
+        assert!(
+            empty_res.is_none(),
+            "empty candidate list should return None."
+        );
+
+        let null_res = GLOBAL_LB_REGISTRY
+            .select_candidate_with_filter::<fn(&str) -> bool>("null", None)
+            .expect("null should succeed");
+        assert!(
+            null_res.is_none(),
+            "null candidate list should return None."
+        );
+
+        let whitespace_res = GLOBAL_LB_REGISTRY
+            .select_candidate_with_filter::<fn(&str) -> bool>("   ", None)
+            .expect("whitespace should succeed");
+        assert!(
+            whitespace_res.is_none(),
+            "whitespace candidate list should return None."
+        );
     }
 }

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -35,11 +35,11 @@ use crate::client::RequestHeaders;
 use crate::client::load_balancing::ChannelController;
 use crate::client::load_balancing::DynLbConfig;
 use crate::client::load_balancing::DynLbPolicy;
+use crate::client::load_balancing::LbConfigPayload;
 use crate::client::load_balancing::LbPolicy;
 use crate::client::load_balancing::LbPolicyBuilder;
 use crate::client::load_balancing::LbPolicyOptions;
 use crate::client::load_balancing::LbState;
-use crate::client::load_balancing::ParsedJsonLbConfig;
 use crate::client::load_balancing::Subchannel;
 use crate::client::load_balancing::SubchannelState;
 use crate::client::load_balancing::WorkData;
@@ -299,13 +299,9 @@ impl LbPolicyBuilder for StubPolicyBuilder {
         self.name
     }
 
-    fn parse_config(&self, config: &ParsedJsonLbConfig) -> Result<Option<DynLbConfig>, String> {
-        let cfg: MockConfig = match config.convert_to() {
-            Ok(c) => c,
-            Err(e) => {
-                return Err(format!("failed to parse JSON config: {}", e));
-            }
-        };
+    fn parse_config(&self, config: &LbConfigPayload<'_>) -> Result<Option<DynLbConfig>, String> {
+        let cfg: MockConfig = serde_json::from_str(config.as_str())
+            .map_err(|e| format!("failed to parse JSON config: {e}"))?;
         Ok(Some(Arc::new(cfg)))
     }
 }

--- a/grpc/src/client/service_config/mod.rs
+++ b/grpc/src/client/service_config/mod.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use crate::client::load_balancing::DynLbConfig;
 use crate::client::load_balancing::DynLbPolicyBuilder;
 use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
-use crate::client::load_balancing::ParsedJsonLbConfig;
+use crate::client::load_balancing::LbConfigPayload;
 use crate::client::load_balancing::pick_first;
 
 pub type ParseResult = Result<ServiceConfig, String>;
@@ -65,8 +65,10 @@ impl ServiceConfig {
         if let Some(ref policy) = self.inner.load_balancing_policy
             && let Some(builder) = GLOBAL_LB_REGISTRY.get_policy(policy)
         {
-            let empty_json = ParsedJsonLbConfig::from_value(serde_json::json!({}));
-            let parsed_config = builder.parse_config(&empty_json).ok().flatten();
+            let parsed_config = builder
+                .parse_config(&LbConfigPayload::empty())
+                .ok()
+                .flatten();
             return (builder, parsed_config);
         }
 
@@ -79,8 +81,10 @@ impl ServiceConfig {
         let builder = GLOBAL_LB_REGISTRY
             .get_policy(pick_first::POLICY_NAME)
             .expect("pick_first policy must be registered");
-        let default_json = ParsedJsonLbConfig::from_value(serde_json::json!({}));
-        let parsed_config = builder.parse_config(&default_json).ok().flatten();
+        let parsed_config = builder
+            .parse_config(&LbConfigPayload::empty())
+            .ok()
+            .flatten();
         (builder, parsed_config)
     }
 }

--- a/grpc/src/client/service_config/serde_bindings.rs
+++ b/grpc/src/client/service_config/serde_bindings.rs
@@ -22,7 +22,6 @@
  *
  */
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::Deserialize;
@@ -31,7 +30,6 @@ use super::duration::GrpcDuration;
 use crate::client::load_balancing::DynLbConfig;
 use crate::client::load_balancing::DynLbPolicyBuilder;
 use crate::client::load_balancing::GLOBAL_LB_REGISTRY;
-use crate::client::load_balancing::ParsedJsonLbConfig;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -116,37 +114,34 @@ impl<'de> Deserialize<'de> for LbConfigSerde {
     where
         D: serde::Deserializer<'de>,
     {
-        let raw_entries =
-            Option::<Vec<HashMap<String, serde_json::Value>>>::deserialize(deserializer)?
-                .unwrap_or_default();
-
-        if raw_entries.is_empty() {
-            return Ok(LbConfigSerde(None));
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawOrValue<'a> {
+            #[serde(borrow)]
+            Raw(&'a serde_json::value::RawValue),
+            Value(serde_json::Value),
         }
 
-        for map in raw_entries {
-            let mut iter = map.into_iter();
-            let (Some((name, raw_config)), None) = (iter.next(), iter.next()) else {
-                return Err(serde::de::Error::custom(
-                    "Each load balancing config entry must contain exactly one policy name.",
-                ));
-            };
-
-            if let Some(builder) = GLOBAL_LB_REGISTRY.get_policy(&name) {
-                let parsed_json = ParsedJsonLbConfig::from_value(raw_config);
-                let parsed_config = builder
-                    .parse_config(&parsed_json)
-                    .map_err(serde::de::Error::custom)?;
-                return Ok(LbConfigSerde(Some(LbInnerConfig {
-                    builder,
-                    config: parsed_config,
-                })));
+        let raw_opt = Option::<RawOrValue<'de>>::deserialize(deserializer)?;
+        let raw_str = match raw_opt {
+            None => return Ok(LbConfigSerde(None)),
+            Some(RawOrValue::Raw(raw)) => std::borrow::Cow::Borrowed(raw.get()),
+            Some(RawOrValue::Value(val)) => {
+                if val.is_null() {
+                    return Ok(LbConfigSerde(None));
+                }
+                std::borrow::Cow::Owned(val.to_string())
             }
-        }
+        };
 
-        Err(serde::de::Error::custom(
-            "No supported load balancing policy found in config.",
-        ))
+        match GLOBAL_LB_REGISTRY.select_candidate(raw_str.as_ref()) {
+            Ok(Some(parsed)) => Ok(LbConfigSerde(Some(LbInnerConfig {
+                builder: parsed.builder,
+                config: parsed.config,
+            }))),
+            Ok(None) => Ok(LbConfigSerde(None)),
+            Err(e) => Err(serde::de::Error::custom(e)),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Child selection and configuration parsing for load balancing policies were previously embedded within private `ServiceConfigSerde` deserialization logic. This created several architectural limitations:

- **Inaccessible LB Config Selection**: No reuse of LB configuration resolution for child balancers of composite policies (e.g., xDS locality balancers, priority balancers).
- **Lack of Child Policy Filtering**: Parent policies could not enforce child eligibility constraints per gRFC A24.
- **Public API Coupling to Serde**: `LbPolicyBuilder::parse_config` accepted `&ParsedJsonLbConfig`, leaking `serde::de::DeserializeOwned`.
- **Allocation Inefficiencies**: Child list scanning eagerly deserialized `Vec<HashMap<String, Value>>` and deep-cloned JSON ASTs during configuration parsing.

## Solution

### Architectural Shift

- **LB Configuration Selection Moved to Registry**: Child policy selection is centralized in `GLOBAL_LB_REGISTRY`, making resolution reusable for both top-level channel configurations and nested child balancers.
- **Filtering and Halting Invariants (gRFC A24)**: Selection supports policy filtering predicates and immediately halts on the first registered, permitted policy, failing if that policy's configuration parsing fails.
- **Decoupled Public API**: Public load balancing traits are decoupled from external serialization crates by passing borrowed string slices (`LbConfigJson<'a>`) rather than Serde-bound structures.
- **Zero-AST `oneOf` Enforcement**: Child policy list parsing enforces single-property (`oneOf`) object entries without intermediate AST allocations.
- **Mandatory Child Resolution Helper**: Added `select_required_child` returning `Result<ParsedLbConfig, String>` for composite balancers where child policies are mandatory.

### Usage Example

**Selecting a required child policy in a composite LB policy:**
```rust
let lb = GLOBAL_LB_REGISTRY.select_required_child(raw_child_policies_json)?;
let child_policy = lb.builder.build(options);
// Apply parsed configuration: lb.config
```

**Hierarchical child selection with a policy filter:**
```rust
let parsed_lb = GLOBAL_LB_REGISTRY.select_child_with_filter(
    raw_child_policies_json,
    Some(|name: &str| name == "round_robin" || name == "pick_first"),
)?;

if let Some(lb) = parsed_lb {
    let child_policy = lb.builder.build(options);
    // Apply parsed configuration: lb.config
}
```

**Implementing an `LbPolicyBuilder`:**
```rust
impl LbPolicyBuilder for PickFirstBuilder {
    type LbPolicy = PickFirstLbPolicy;

    fn parse_config(
        &self,
        config: &LbConfigJson<'_>,
    ) -> Result<Option<PickFirstConfig>, String> {
        serde_json::from_str(config.as_str())
            .map(Some)
            .map_err(|e| format!("Invalid pick_first config: {e}"))
    }
}
```
