### PR TITLE
grpc: fix broken rustdoc links in the server module

### DIFF
--- a/grpc/src/server/mod.rs
+++ b/grpc/src/server/mod.rs
@@ -37,7 +37,6 @@
 //!
 //! # Additional Types
 //!
-//! - **[`Call`]:** Represents an incoming RPC accepted by a [`Listener`].
 //! - **[`SendStream`] / [`RecvStream`]:** Represent the sending and receiving
 //!   sides of a server-side RPC.
 //! - **[`RequestHeaders`]:** Represents gRPC headers sent by the client to
@@ -196,7 +195,7 @@ impl GracefulCoordinator {
 }
 
 impl Server {
-    /// Creates a new [`ServerBuilder`] with an [`Identity`] (no-op) interceptor.
+    /// Creates a new [`ServerBuilder`] with a no-op interceptor.
     pub fn builder() -> ServerBuilder<Identity> {
         ServerBuilder::new()
     }


### PR DESCRIPTION
Fix reference to private interceptor and remove now deleted call. 

We may need to revisit making `Identity` and `Interceptor` public at some point, since we expose a private symbol `Identity` via `ServerBuilder` public. Ideally, this may require making interceptors pub instead of pub crate 
